### PR TITLE
example: add marimo notebook (basic mcp agent)

### DIFF
--- a/examples/marimo_mcp_basic_agent/README.md
+++ b/examples/marimo_mcp_basic_agent/README.md
@@ -1,0 +1,16 @@
+# marimo MCP Agent example
+
+This example [marimo](https://github.com/marimo-team/marimo) notebook shows a
+"finder" Agent which has access to the 'fetch' and 'filesystem' MCP servers.
+
+You can ask it information about local files or URLs, and it will make the
+determination on what to use at what time to satisfy the request.
+
+First modify `mcp_agent.config.yaml` to include directories to which
+you'd like to give the agent access.
+
+Then run this example with:
+
+```bash
+OPENAI_API_KEY=<your-api-key> uvx marimo edit --sandbox notebook.py
+```

--- a/examples/marimo_mcp_basic_agent/mcp_agent.config.yaml
+++ b/examples/marimo_mcp_basic_agent/mcp_agent.config.yaml
@@ -1,0 +1,32 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  type: console
+  level: debug
+  batch_size: 100
+  flush_interval: 2
+  max_queue_size: 2048
+  http_endpoint:
+  http_headers:
+  http_timeout: 5
+
+mcp:
+  servers:
+    fetch:
+      command: "uvx"
+      args: ["mcp-server-fetch"]
+    filesystem:
+      command: "npx"
+      args:
+        # Add directories you'd like the agent to access, such as
+        # /Users/my-username/Desktop
+        [
+          "-y",
+          "@modelcontextprotocol/server-filesystem",
+          "/Users/akshay/tmp",
+        ]
+
+openai:
+  # Secrets (API keys, etc.) are stored in an mcp_agent.secrets.yaml file which can be gitignored
+  default_model: gpt-4o

--- a/examples/marimo_mcp_basic_agent/mcp_agent.secrets.yaml.example
+++ b/examples/marimo_mcp_basic_agent/mcp_agent.secrets.yaml.example
@@ -1,0 +1,7 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+openai:
+  api_key: openai_api_key
+
+anthropic:
+  api_key: anthropic_api_key

--- a/examples/marimo_mcp_basic_agent/notebook.py
+++ b/examples/marimo_mcp_basic_agent/notebook.py
@@ -49,7 +49,7 @@ def _(llm, mo):
 
 
     chatbot = mo.ui.chat(
-        model, prompts=["Get google.com"], show_configuration_controls=False
+        model, prompts=["What are some files in my filesystem", "Get google.com"], show_configuration_controls=False
     )
     chatbot
     return chatbot, model

--- a/examples/marimo_mcp_basic_agent/notebook.py
+++ b/examples/marimo_mcp_basic_agent/notebook.py
@@ -1,0 +1,94 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "marimo",
+#     "mcp-agent==0.0.3",
+#     "mcp==1.2.0",
+#     "openai==1.60.0",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.10.16"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        """
+        # 💬 Basic agent chatbot
+
+        **🚀 A [marimo](https://github.com/marimo-team/marimo) chatbot powered by `mcp-agent`**
+        """
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(ListToolsResult, mo, tools):
+    def format_list_tools_result(list_tools_result: ListToolsResult):
+        res = ""
+        for tool in list_tools_result.tools:
+            res += f"- **{tool.name}**: {tool.description}\n\n"
+        return res
+
+
+    tools_str = format_list_tools_result(tools)
+    mo.accordion({"View tools": mo.md(tools_str)})
+    return format_list_tools_result, tools_str
+
+
+@app.cell
+def _(llm, mo):
+    async def model(messages, config):
+        message = messages[-1]
+        response = await llm.generate_str(message.content)
+        return mo.md(response)
+
+
+    chatbot = mo.ui.chat(
+        model, prompts=["Get google.com"], show_configuration_controls=False
+    )
+    chatbot
+    return chatbot, model
+
+
+@app.cell
+async def _():
+    from mcp import ListToolsResult
+    import asyncio
+    from mcp_agent.app import MCPApp
+    from mcp_agent.agents.agent import Agent
+    from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+    app = MCPApp(name="mcp_basic_agent")
+    await app.initialize()
+    return Agent, ListToolsResult, MCPApp, OpenAIAugmentedLLM, app, asyncio
+
+
+@app.cell
+async def _(Agent, OpenAIAugmentedLLM):
+    finder_agent = Agent(
+        name="finder",
+        instruction="""You are an agent with access to the filesystem,
+        as well as the ability to fetch URLs. Your job is to identify
+        the closest match to a user's request, make the appropriate tool calls,
+        and return the URI and CONTENTS of the closest match.""",
+        server_names=["fetch", "filesystem"],
+    )
+    await finder_agent.initialize()
+    llm = await finder_agent.attach_llm(OpenAIAugmentedLLM)
+    tools = await finder_agent.list_tools()
+    return finder_agent, llm, tools
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
This PR adds a marimo notebook showcasing the basic mcp agent. The notebook includes its own dependencies, and can be run using a single command (no environment setup necessary):

```
uvx marimo edit --sandbox notebook.py
```

<img width="1187" alt="image" src="https://github.com/user-attachments/assets/6af17bbb-f307-441c-8359-fd5e04194509" />