### PR TITLE
Support models compatible with OpenAI format

### DIFF
--- a/examples/mcp_basic_ollama_agent/README.md
+++ b/examples/mcp_basic_ollama_agent/README.md
@@ -1,0 +1,14 @@
+# MCP Ollama Agent example
+
+This example shows a "finder" Agent using llama models to access the 'fetch' and 'filesystem' MCP servers.
+
+You can ask it information about local files or URLs, and it will make the determination on what to use at what time to satisfy the request.
+
+Make sure you have Ollama installed. Then pull the required models for the example:
+```bash
+ollama run llama3.2:3b
+
+ollama run llama3.1:8b
+```
+
+<img width="2160" alt="Image" src="https://github.com/user-attachments/assets/14cbfdf4-306f-486b-9ec1-6576acf0aeb7" />

--- a/examples/mcp_basic_ollama_agent/main.py
+++ b/examples/mcp_basic_ollama_agent/main.py
@@ -1,0 +1,66 @@
+import asyncio
+import os
+
+from mcp_agent.app import MCPApp
+from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm import RequestParams
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+app = MCPApp(name="mcp_basic_agent")
+
+
+async def example_usage():
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+        context = agent_app.context
+
+        logger.info("Current config:", data=context.config.model_dump())
+
+        # Add the current directory to the filesystem server's args
+        context.config.mcp.servers["filesystem"].args.extend([os.getcwd()])
+
+        finder_agent = Agent(
+            name="finder",
+            instruction="""You are an agent with access to the filesystem, 
+            as well as the ability to fetch URLs. Your job is to identify 
+            the closest match to a user's request, make the appropriate tool calls, 
+            and return the URI and CONTENTS of the closest match.""",
+            server_names=["fetch", "filesystem"],
+        )
+
+        async with finder_agent:
+            logger.info("finder: Connected to server, calling list_tools...")
+            result = await finder_agent.list_tools()
+            logger.info("Tools available:", data=result.model_dump())
+
+            llm = await finder_agent.attach_llm(OpenAIAugmentedLLM)
+            result = await llm.generate_str(
+                message="Print the contents of mcp_agent.config.yaml verbatim",
+                request_params=RequestParams(model="llama3.2:3b"),
+            )
+            logger.info(f"Result: {result}")
+
+            # Let's switch the same agent to a different LLM
+            result = await llm.generate_str(
+                message="Print the first 2 paragraphs of https://www.anthropic.com/research/building-effective-agents",
+                request_params=RequestParams(model="llama3.1:8b"),
+            )
+            logger.info(f"Result: {result}")
+
+            # Multi-turn conversations
+            result = await llm.generate_str(
+                message="Summarize those paragraphs in a 128 character tweet",
+                request_params=RequestParams(model="llama3.2:3b"),
+            )
+            logger.info(f"Result: {result}")
+
+
+if __name__ == "__main__":
+    import time
+
+    start = time.time()
+    asyncio.run(example_usage())
+    end = time.time()
+    t = end - start
+
+    print(f"Total run time: {t:.2f}s")

--- a/examples/mcp_basic_ollama_agent/mcp_agent.config.yaml
+++ b/examples/mcp_basic_ollama_agent/mcp_agent.config.yaml
@@ -1,0 +1,24 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  type: console
+  level: debug
+  batch_size: 100
+  flush_interval: 2
+  max_queue_size: 2048
+  http_endpoint:
+  http_headers:
+  http_timeout: 5
+
+mcp:
+  servers:
+    fetch:
+      command: "uvx"
+      args: ["mcp-server-fetch"]
+    filesystem:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-filesystem"]
+
+openai:
+  base_url: "http://localhost:11434/v1"

--- a/examples/mcp_basic_ollama_agent/mcp_agent.secrets.yaml.example
+++ b/examples/mcp_basic_ollama_agent/mcp_agent.secrets.yaml.example
@@ -1,0 +1,7 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+openai:
+  api_key: openai_api_key
+
+anthropic:
+  api_key: anthropic_api_key

--- a/examples/mcp_basic_ollama_agent/requirements.txt
+++ b/examples/mcp_basic_ollama_agent/requirements.txt
@@ -1,0 +1,5 @@
+# Core framework dependency
+mcp-agent @ file://../../  # Link to the local mcp-agent project root
+
+# Additional dependencies specific to this example
+openai

--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -290,6 +290,18 @@
           ],
           "default": null,
           "title": "Api Key"
+        },
+        "base_url": {
+          "title": "Base Url",
+          "default": null,
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "title": "OpenAISettings",

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -84,6 +84,8 @@ class OpenAISettings(BaseModel):
 
     api_key: str | None = None
 
+    base_url: str | None = None
+
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -89,7 +89,9 @@ class OpenAIAugmentedLLM(
         Override this method to use a different LLM.
         """
         config = self.context.config
-        openai_client = OpenAI(api_key=config.openai.api_key)
+        openai_client = OpenAI(
+            api_key=config.openai.api_key, base_url=config.openai.base_url
+        )
         messages: List[ChatCompletionMessageParam] = []
         params = self.get_request_params(request_params)
 
@@ -161,8 +163,8 @@ class OpenAIAugmentedLLM(
                 f"Iteration {i}: OpenAI ChatCompletion response:",
                 data=response,
             )
-
-            if not response.choices or len(response.choices) == 0:
+            print(response)
+            if not response or not response.choices or len(response.choices) == 0:
                 # No response from the model, we're done
                 break
 

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -163,8 +163,7 @@ class OpenAIAugmentedLLM(
                 f"Iteration {i}: OpenAI ChatCompletion response:",
                 data=response,
             )
-            print(response)
-            if not response or not response.choices or len(response.choices) == 0:
+            if not response.choices or len(response.choices) == 0:
                 # No response from the model, we're done
                 break
 


### PR DESCRIPTION
Expose openai's `base_url` in `mcp_agent.config.yaml` file so that providers using OpenAI format such as Ollama, LiteLLM, Gemini (in preview) and Deepseek etc. can be used without having to write custom classes for each of them. Included an example to demonstrate its usage. 

Closes #19