### PR TITLE
Fix duplicate tool call messages when using OpenAIAugmentedLLM 

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_anthropic.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_anthropic.py
@@ -135,6 +135,10 @@ class AnthropicAugmentedLLM(AugmentedLLM[MessageParam, Message]):
 
             response = executor_result[0]
 
+            if isinstance(response, BaseException):
+                logger.error(f"Error: {executor_result}")
+                break
+
             logger.debug(
                 f"Iteration {i}: {model} response:",
                 data=response,

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -205,11 +205,6 @@ class OpenAIAugmentedLLM(
                             continue
                         if result is not None:
                             messages.append(result)
-            elif choice.finish_reason == "stop":
-                # We have reached the end of the conversation
-                messages.append(message)
-                logger.debug(f"Iteration {i}: Stopping because finish_reason is 'stop'")
-                break
             elif choice.finish_reason == "length":
                 # We have reached the max tokens limit
                 logger.debug(
@@ -223,6 +218,11 @@ class OpenAIAugmentedLLM(
                     f"Iteration {i}: Stopping because finish_reason is 'content_filter'"
                 )
                 # TODO: saqadri - would be useful to return the reason for stopping to the caller
+                break
+            else:  # choice.finish_reason == "stop"
+                # We have reached the end of the conversation
+                messages.append(message)
+                logger.debug(f"Iteration {i}: Stopping because finish_reason is 'stop'")
                 break
 
         if params.use_history:

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -178,32 +178,34 @@ class OpenAIAugmentedLLM(
             message = choice.message
             responses.append(message)
 
-            if choice.finish_reason in ["tool_calls", "function_call"]:
-                converted_message = self.convert_message_to_message_param(
-                    choice.message, name=self.name
-                )
-                messages.append(converted_message)
+            converted_message = self.convert_message_to_message_param(
+                message, name=self.name
+            )
+            messages.append(converted_message)
 
-                if message.tool_calls:
-                    # Execute all tool calls in parallel.
-                    tool_tasks = [
-                        self.execute_tool_call(tool_call)
-                        for tool_call in choice.message.tool_calls
-                    ]
-                    # Wait for all tool calls to complete.
-                    tool_results = await self.executor.execute(*tool_tasks)
-                    logger.debug(
-                        f"Iteration {i}: Tool call results: {str(tool_results) if tool_results else 'None'}"
-                    )
-                    # Add non-None results to messages.
-                    for result in tool_results:
-                        if isinstance(result, BaseException):
-                            logger.error(
-                                f"Warning: Unexpected error during tool execution: {result}. Continuing..."
-                            )
-                            continue
-                        if result is not None:
-                            messages.append(result)
+            if (
+                choice.finish_reason in ["tool_calls", "function_call"]
+                and message.tool_calls
+            ):
+                # Execute all tool calls in parallel.
+                tool_tasks = [
+                    self.execute_tool_call(tool_call)
+                    for tool_call in message.tool_calls
+                ]
+                # Wait for all tool calls to complete.
+                tool_results = await self.executor.execute(*tool_tasks)
+                logger.debug(
+                    f"Iteration {i}: Tool call results: {str(tool_results) if tool_results else 'None'}"
+                )
+                # Add non-None results to messages.
+                for result in tool_results:
+                    if isinstance(result, BaseException):
+                        logger.error(
+                            f"Warning: Unexpected error during tool execution: {result}. Continuing..."
+                        )
+                        continue
+                    if result is not None:
+                        messages.append(result)
             elif choice.finish_reason == "length":
                 # We have reached the max tokens limit
                 logger.debug(
@@ -218,9 +220,7 @@ class OpenAIAugmentedLLM(
                 )
                 # TODO: saqadri - would be useful to return the reason for stopping to the caller
                 break
-            else:  # choice.finish_reason == "stop"
-                # We have reached the end of the conversation
-                messages.append(message)
+            elif choice.finish_reason == "stop":
                 logger.debug(f"Iteration {i}: Stopping because finish_reason is 'stop'")
                 break
 

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -170,11 +170,39 @@ class OpenAIAugmentedLLM(
             # TODO: saqadri - handle multiple choices for more complex interactions.
             # Keeping it simple for now because multiple choices will also complicate memory management
             choice = response.choices[0]
-            messages.append(choice.message)
-            responses.append(choice.message)
+            message = choice.message
+            responses.append(message)
 
-            if choice.finish_reason == "stop":
+            if choice.finish_reason in ["tool_calls", "function_call"]:
+                if message.content:
+                    converted_message = self.convert_message_to_message_param(
+                        choice.message, name=self.name
+                    )
+                    messages.append(converted_message)
+
+                if message.tool_calls:
+                    # Execute all tool calls in parallel.
+                    tool_tasks = [
+                        self.execute_tool_call(tool_call)
+                        for tool_call in choice.message.tool_calls
+                    ]
+                    # Wait for all tool calls to complete.
+                    tool_results = await self.executor.execute(*tool_tasks)
+                    logger.debug(
+                        f"Iteration {i}: Tool call results: {str(tool_results) if tool_results else 'None'}"
+                    )
+                    # Add non-None results to messages.
+                    for result in tool_results:
+                        if isinstance(result, BaseException):
+                            logger.error(
+                                f"Warning: Unexpected error during tool execution: {result}. Continuing..."
+                            )
+                            continue
+                        if result is not None:
+                            messages.append(result)
+            elif choice.finish_reason == "stop":
                 # We have reached the end of the conversation
+                messages.append(message)
                 logger.debug(f"Iteration {i}: Stopping because finish_reason is 'stop'")
                 break
             elif choice.finish_reason == "length":
@@ -191,37 +219,7 @@ class OpenAIAugmentedLLM(
                 )
                 # TODO: saqadri - would be useful to return the reason for stopping to the caller
                 break
-            else:  #  choice.finish_reason in ["tool_calls", "function_call"]
-                message = choice.message
 
-                if message.content:
-                    messages.append(
-                        self.convert_message_to_message_param(message, name=self.name)
-                    )
-
-                if message.tool_calls:
-                    # Execute all tool calls in parallel
-                    tool_tasks = [
-                        self.execute_tool_call(tool_call)
-                        for tool_call in message.tool_calls
-                    ]
-
-                    # Wait for all tool calls to complete
-                    tool_results = await self.executor.execute(*tool_tasks)
-                    logger.debug(
-                        f"Iteration {i}: Tool call results: {str(tool_results) if tool_results else 'None'}"
-                    )
-
-                    # Add non-None results to messages
-                    for result in tool_results:
-                        if isinstance(result, BaseException):
-                            # Handle any unexpected exceptions during parallel execution
-                            logger.error(
-                                f"Warning: Unexpected error during tool execution: {result}. Continuing..."
-                            )
-                            continue
-                        if result is not None:
-                            messages.append(result)
         if params.use_history:
             self.history.set(messages)
 

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -179,11 +179,10 @@ class OpenAIAugmentedLLM(
             responses.append(message)
 
             if choice.finish_reason in ["tool_calls", "function_call"]:
-                if message.content:
-                    converted_message = self.convert_message_to_message_param(
-                        choice.message, name=self.name
-                    )
-                    messages.append(converted_message)
+                converted_message = self.convert_message_to_message_param(
+                    choice.message, name=self.name
+                )
+                messages.append(converted_message)
 
                 if message.tool_calls:
                     # Execute all tool calls in parallel.

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -163,6 +163,11 @@ class OpenAIAugmentedLLM(
                 f"Iteration {i}: OpenAI ChatCompletion response:",
                 data=response,
             )
+
+            if isinstance(response, BaseException):
+                logger.error(f"Error: {response}")
+                break
+
             if not response.choices or len(response.choices) == 0:
                 # No response from the model, we're done
                 break


### PR DESCRIPTION
When a tool call message has content, `OpenAIAugmentedLLM` will append the message twice. This fix ensures that messages are only added once. Also log and handle exceptions from model for both `OpenAIAugmentedLLM` and `AnthropicAugmentedLLM`.