### PR TITLE
Ensure base_url is always used for OpenAI clients

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -274,7 +274,7 @@ class OpenAIAugmentedLLM(
 
         # Next we pass the text through instructor to extract structured data
         client = instructor.from_openai(
-            OpenAI(api_key=self.context.config.openai.api_key),
+            OpenAI(api_key=self.context.config.openai.api_key, base_url=self.config.openai.base_url),
             mode=instructor.Mode.TOOLS_STRICT,
         )
 


### PR DESCRIPTION
It looks like there was at least one place where this wasn't happening, not sure if there are others.