### PR TITLE
Get Anthropic default model from config if available

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_anthropic.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_anthropic.py
@@ -65,8 +65,14 @@ class AnthropicAugmentedLLM(AugmentedLLM[MessageParam, Message]):
             speedPriority=0.4,
             intelligencePriority=0.3,
         )
+
+        default_model = (
+            self.context.config.anthropic.default_model
+            if self.context.config.anthropic
+            else "claude-3-5-sonnet-20241022"
+        )
         self.default_request_params = self.default_request_params or RequestParams(
-            model="claude-3-5-sonnet-20241022",
+            model=default_model,
             modelPreferences=self.model_preferences,
             maxTokens=2048,
             systemPrompt=self.instruction,

--- a/src/mcp_agent/workflows/llm/augmented_llm_anthropic.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_anthropic.py
@@ -66,11 +66,11 @@ class AnthropicAugmentedLLM(AugmentedLLM[MessageParam, Message]):
             intelligencePriority=0.3,
         )
 
-        default_model = (
-            self.context.config.anthropic.default_model
-            if self.context.config.anthropic
-            else "claude-3-5-sonnet-20241022"
-        )
+        default_model = "claude-3-7-sonnet-latest"  # Fallback default
+
+        if self.context.config.anthropic:
+            if hasattr(self.context.config.anthropic, "default_model"):
+                default_model = self.context.config.anthropic.default_model
         self.default_request_params = self.default_request_params or RequestParams(
             model=default_model,
             modelPreferences=self.model_preferences,


### PR DESCRIPTION
I had this in my `mcp_agent.config.yaml` but my logs still indicated `claude-3-5` 

```yaml
# mcp_agent.config.yaml
anthropic:
  default_model: "claude-3-7-sonnet-latest"
```