### PR TITLE
Multi transport logging 

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,14 @@ if __name__ == "__main__":
 ```yaml
 execution_engine: asyncio
 logger:
-  type: console
+  transports: [console]  # You can use [file, console] for both
   level: debug
+  path: "logs/mcp-agent.jsonl"  # Used for file transport
+  # For dynamic log filenames:
+  # path_settings:
+  #   path_pattern: "logs/mcp-agent-{unique_id}.jsonl"
+  #   unique_id: "timestamp"  # Or "session_id"
+  #   timestamp_format: "%Y%m%d_%H%M%S"
 
 mcp:
   servers:

--- a/examples/mcp_basic_agent/mcp_agent.config.yaml
+++ b/examples/mcp_basic_agent/mcp_agent.config.yaml
@@ -2,8 +2,13 @@ $schema: ../../schema/mcp-agent.config.schema.json
 
 execution_engine: asyncio
 logger:
-  type: console
+  transports: [console, file]
   level: debug
+  show_progress: true
+  path_settings:
+    path_pattern: "logs/mcp-agent-{unique_id}.jsonl"
+    unique_id: "timestamp" # Options: "timestamp" or "session_id"
+    timestamp_format: "%Y%m%d_%H%M%S"
 
 mcp:
   servers:

--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -1,5 +1,31 @@
 {
   "$defs": {
+    "LogPathSettings": {
+      "description": "Settings for configuring log file paths with dynamic elements like timestamps or session IDs.",
+      "properties": {
+        "path_pattern": {
+          "default": "logs/mcp-agent-{unique_id}.jsonl",
+          "title": "Path Pattern",
+          "type": "string",
+          "description": "Path pattern for log files with a {unique_id} placeholder"
+        },
+        "unique_id": {
+          "default": "timestamp",
+          "enum": ["timestamp", "session_id"],
+          "title": "Unique Id",
+          "type": "string",
+          "description": "Type of unique identifier to use in the log filename"
+        },
+        "timestamp_format": {
+          "default": "%Y%m%d_%H%M%S",
+          "title": "Timestamp Format",
+          "type": "string",
+          "description": "Format string for timestamps when unique_id is set to timestamp"
+        }
+      },
+      "title": "LogPathSettings",
+      "type": "object"
+    },
     "AnthropicSettings": {
       "additionalProperties": true,
       "description": "Settings for using Anthropic models in the MCP Agent application.",
@@ -88,30 +114,18 @@
           "type": "string",
           "description": "Path to log file, if logger 'type' is 'file'."
         },
-        "path_pattern": {
+        "path_settings": {
           "anyOf": [
             {
-              "type": "string"
+              "$ref": "#/$defs/LogPathSettings"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "title": "Path Pattern",
-          "description": "Path pattern for file transport with timestamp placeholder. {timestamp} will be replaced with current time in format specified by timestamp_format."
-        },
-        "timestamp_format": {
-          "default": "%Y%m%d_%H%M%S",
-          "title": "Timestamp Format",
-          "type": "string",
-          "description": "Format string for timestamp in path_pattern"
-        },
-        "use_run_id": {
-          "default": false,
-          "title": "Use Run Id",
-          "type": "boolean",
-          "description": "Whether to use a unique run ID in the filename instead of timestamp"
+          "title": "Path Settings",
+          "description": "Advanced settings for log file paths with dynamic elements like timestamps or session IDs"
         },
         "batch_size": {
           "default": 100,
@@ -660,13 +674,11 @@
       ],
       "default": {
         "type": "console",
-        "transports": [],
+        "transports": ["console"],
         "level": "info",
         "progress_display": true,
         "path": "mcp-agent.jsonl",
-        "path_pattern": null,
-        "timestamp_format": "%Y%m%d_%H%M%S",
-        "use_run_id": false,
+        "path_settings": null,
         "batch_size": 100,
         "flush_interval": 2.0,
         "max_queue_size": 2048,

--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -54,6 +54,16 @@
           "title": "Type",
           "type": "string"
         },
+        "transports": {
+          "default": ["console"],
+          "items": {
+            "enum": ["none", "console", "file", "http"],
+            "type": "string"
+          },
+          "title": "Transports",
+          "type": "array",
+          "description": "List of transports to use (can enable multiple simultaneously)"
+        },
         "level": {
           "default": "info",
           "enum": [
@@ -77,6 +87,31 @@
           "title": "Path",
           "type": "string",
           "description": "Path to log file, if logger 'type' is 'file'."
+        },
+        "path_pattern": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path Pattern",
+          "description": "Path pattern for file transport with timestamp placeholder. {timestamp} will be replaced with current time in format specified by timestamp_format."
+        },
+        "timestamp_format": {
+          "default": "%Y%m%d_%H%M%S",
+          "title": "Timestamp Format",
+          "type": "string",
+          "description": "Format string for timestamp in path_pattern"
+        },
+        "use_run_id": {
+          "default": false,
+          "title": "Use Run Id",
+          "type": "boolean",
+          "description": "Whether to use a unique run ID in the filename instead of timestamp"
         },
         "batch_size": {
           "default": 100,
@@ -625,9 +660,13 @@
       ],
       "default": {
         "type": "console",
+        "transports": [],
         "level": "info",
         "progress_display": true,
         "path": "mcp-agent.jsonl",
+        "path_pattern": null,
+        "timestamp_format": "%Y%m%d_%H%M%S",
+        "use_run_id": false,
         "batch_size": 100,
         "flush_interval": 2.0,
         "max_queue_size": 2048,

--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -71,12 +71,7 @@
       "properties": {
         "type": {
           "default": "console",
-          "enum": [
-            "none",
-            "console",
-            "file",
-            "http"
-          ],
+          "enum": ["none", "console", "file", "http"],
           "title": "Type",
           "type": "string"
         },
@@ -92,12 +87,7 @@
         },
         "level": {
           "default": "info",
-          "enum": [
-            "debug",
-            "info",
-            "warning",
-            "error"
-          ],
+          "enum": ["debug", "info", "warning", "error"],
           "title": "Level",
           "type": "string",
           "description": "Minimum logging level"
@@ -220,9 +210,7 @@
           "description": "Optional URI alias for presentation to the server"
         }
       },
-      "required": [
-        "uri"
-      ],
+      "required": ["uri"],
       "title": "MCPRootSettings",
       "type": "object"
     },
@@ -277,10 +265,7 @@
         },
         "transport": {
           "default": "stdio",
-          "enum": [
-            "stdio",
-            "sse"
-          ],
+          "enum": ["stdio", "sse"],
           "title": "Transport",
           "type": "string",
           "description": "The transport mechanism."
@@ -422,11 +407,7 @@
         },
         "reasoning_effort": {
           "default": "medium",
-          "enum": [
-            "low",
-            "medium",
-            "high"
-          ],
+          "enum": ["low", "medium", "high"],
           "title": "Reasoning Effort",
           "type": "string"
         },
@@ -541,10 +522,7 @@
           "title": "Api Key"
         }
       },
-      "required": [
-        "host",
-        "task_queue"
-      ],
+      "required": ["host", "task_queue"],
       "title": "TemporalSettings",
       "type": "object"
     },
@@ -587,10 +565,7 @@
     },
     "execution_engine": {
       "default": "asyncio",
-      "enum": [
-        "asyncio",
-        "temporal"
-      ],
+      "enum": ["asyncio", "temporal"],
       "title": "Execution Engine",
       "type": "string",
       "description": "Execution engine for the MCP Agent application"
@@ -674,7 +649,7 @@
       ],
       "default": {
         "type": "console",
-        "transports": ["console"],
+        "transports": [],
         "level": "info",
         "progress_display": true,
         "path": "mcp-agent.jsonl",

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -188,10 +188,12 @@ class LoggerSettings(BaseModel):
     """Path to log file, if logger 'type' is 'file'."""
 
     # Support for auto-generated filenames with timestamp patterns
-    path_pattern: str = "logs/mcp-agent-{timestamp}.jsonl"
+    path_pattern: str | None = None
     """
     Path pattern for file transport with timestamp placeholder.
     {timestamp} will be replaced with current time in format specified by timestamp_format.
+    If not specified, the standard 'path' setting will be used instead.
+    Example: "logs/mcp-agent-{timestamp}.jsonl"
     """
 
     timestamp_format: str = "%Y%m%d_%H%M%S"

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -172,7 +172,11 @@ class LoggerSettings(BaseModel):
     Logger settings for the MCP Agent application.
     """
 
+    # Original transport configuration (kept for backward compatibility)
     type: Literal["none", "console", "file", "http"] = "console"
+
+    transports: List[Literal["none", "console", "file", "http"]] = ["console"]
+    """List of transports to use (can enable multiple simultaneously)"""
 
     level: Literal["debug", "info", "warning", "error"] = "info"
     """Minimum logging level"""
@@ -182,6 +186,19 @@ class LoggerSettings(BaseModel):
 
     path: str = "mcp-agent.jsonl"
     """Path to log file, if logger 'type' is 'file'."""
+
+    # Support for auto-generated filenames with timestamp patterns
+    path_pattern: str = "logs/mcp-agent-{timestamp}.jsonl"
+    """
+    Path pattern for file transport with timestamp placeholder.
+    {timestamp} will be replaced with current time in format specified by timestamp_format.
+    """
+
+    timestamp_format: str = "%Y%m%d_%H%M%S"
+    """Format string for timestamp in path_pattern"""
+
+    use_run_id: bool = False
+    """Whether to use a unique run ID in the filename instead of timestamp"""
 
     batch_size: int = 100
     """Number of events to accumulate before processing"""

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -10,31 +10,6 @@ from pydantic import BaseModel, ConfigDict, field_validator, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class LogPathSettings(BaseModel):
-    """
-    Settings for configuring log file paths with dynamic elements like timestamps or session IDs.
-    """
-    path_pattern: str = "logs/mcp-agent-{unique_id}.jsonl"
-    """
-    Path pattern for log files with a {unique_id} placeholder.
-    The placeholder will be replaced according to the unique_id setting.
-    Example: "logs/mcp-agent-{unique_id}.jsonl"
-    """
-    
-    unique_id: Literal["timestamp", "session_id"] = "timestamp"
-    """
-    Type of unique identifier to use in the log filename:
-    - timestamp: Uses the current time formatted according to timestamp_format
-    - session_id: Generates a UUID for the session
-    """
-    
-    timestamp_format: str = "%Y%m%d_%H%M%S"
-    """
-    Format string for timestamps when unique_id is set to "timestamp".
-    Uses Python's datetime.strftime format.
-    """
-
-
 class MCPServerAuthSettings(BaseModel):
     """Represents authentication configuration for a server."""
 
@@ -192,6 +167,32 @@ class OpenTelemetrySettings(BaseModel):
     """Sample rate for tracing (1.0 = sample everything)"""
 
 
+class LogPathSettings(BaseModel):
+    """
+    Settings for configuring log file paths with dynamic elements like timestamps or session IDs.
+    """
+
+    path_pattern: str = "logs/mcp-agent-{unique_id}.jsonl"
+    """
+    Path pattern for log files with a {unique_id} placeholder.
+    The placeholder will be replaced according to the unique_id setting.
+    Example: "logs/mcp-agent-{unique_id}.jsonl"
+    """
+
+    unique_id: Literal["timestamp", "session_id"] = "timestamp"
+    """
+    Type of unique identifier to use in the log filename:
+    - timestamp: Uses the current time formatted according to timestamp_format
+    - session_id: Generates a UUID for the session
+    """
+
+    timestamp_format: str = "%Y%m%d_%H%M%S"
+    """
+    Format string for timestamps when unique_id is set to "timestamp".
+    Uses Python's datetime.strftime format.
+    """
+
+
 class LoggerSettings(BaseModel):
     """
     Logger settings for the MCP Agent application.
@@ -200,7 +201,7 @@ class LoggerSettings(BaseModel):
     # Original transport configuration (kept for backward compatibility)
     type: Literal["none", "console", "file", "http"] = "console"
 
-    transports: List[Literal["none", "console", "file", "http"]] = ["console"]
+    transports: List[Literal["none", "console", "file", "http"]] = []
     """List of transports to use (can enable multiple simultaneously)"""
 
     level: Literal["debug", "info", "warning", "error"] = "info"

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -6,8 +6,33 @@ for the application configuration.
 from pathlib import Path
 from typing import Dict, List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class LogPathSettings(BaseModel):
+    """
+    Settings for configuring log file paths with dynamic elements like timestamps or session IDs.
+    """
+    path_pattern: str = "logs/mcp-agent-{unique_id}.jsonl"
+    """
+    Path pattern for log files with a {unique_id} placeholder.
+    The placeholder will be replaced according to the unique_id setting.
+    Example: "logs/mcp-agent-{unique_id}.jsonl"
+    """
+    
+    unique_id: Literal["timestamp", "session_id"] = "timestamp"
+    """
+    Type of unique identifier to use in the log filename:
+    - timestamp: Uses the current time formatted according to timestamp_format
+    - session_id: Generates a UUID for the session
+    """
+    
+    timestamp_format: str = "%Y%m%d_%H%M%S"
+    """
+    Format string for timestamps when unique_id is set to "timestamp".
+    Uses Python's datetime.strftime format.
+    """
 
 
 class MCPServerAuthSettings(BaseModel):
@@ -187,20 +212,11 @@ class LoggerSettings(BaseModel):
     path: str = "mcp-agent.jsonl"
     """Path to log file, if logger 'type' is 'file'."""
 
-    # Support for auto-generated filenames with timestamp patterns
-    path_pattern: str | None = None
+    # Settings for advanced log path configuration
+    path_settings: Optional["LogPathSettings"] = None
     """
-    Path pattern for file transport with timestamp placeholder.
-    {timestamp} will be replaced with current time in format specified by timestamp_format.
-    If not specified, the standard 'path' setting will be used instead.
-    Example: "logs/mcp-agent-{timestamp}.jsonl"
+    Save log files with more advanced path semantics, like having timestamps or session id in the log name.
     """
-
-    timestamp_format: str = "%Y%m%d_%H%M%S"
-    """Format string for timestamp in path_pattern"""
-
-    use_run_id: bool = False
-    """Whether to use a unique run ID in the filename instead of timestamp"""
 
     batch_size: int = 100
     """Number of events to accumulate before processing"""

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -6,7 +6,7 @@ for the application configuration.
 from pathlib import Path
 from typing import Dict, List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, field_validator, Field
+from pydantic import BaseModel, ConfigDict, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 


### PR DESCRIPTION
Allows for a config like this:
```yaml
logger:
  transports: [file, console]
  level: debug
  path_pattern: "logs/mcp-agent-{timestamp}.jsonl"
  timestamp_format: "%Y%m%d_%H%M%S"
```

Keeps backward compatibility: 
```yaml
logger:
  type: file
  level: debug
  path: "logs/mcp-agent.jsonl"
```