### PR TITLE
Relax numpy dependency constraing, now requiring numpy>=2.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "rich>=13.9.4",
     "typer>=0.15.1",
-    "numpy>=2.2.1",
+    "numpy>=2.1.3",
     "scikit-learn>=1.6.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 
 [manifest]
@@ -828,7 +829,7 @@ requires-dist = [
     { name = "instructor", specifier = ">=1.7.0" },
     { name = "instructor", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.7.2" },
     { name = "mcp", specifier = ">=1.2.1" },
-    { name = "numpy", specifier = ">=2.2.1" },
+    { name = "numpy", specifier = ">=2.1.3" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.58.1" },
     { name = "opentelemetry-distro", specifier = ">=0.50b0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29.0" },
@@ -840,6 +841,7 @@ requires-dist = [
     { name = "temporalio", marker = "extra == 'temporal'", specifier = ">=1.8.0" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
+provides-extras = ["temporal", "anthropic", "openai", "cohere"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
As per #51 

Unfortunately we cannot use mcp-agent because of our numba dependency. This would resolve it. And it doesn't seem to affect anything.