### PR TITLE
fix example streamlit_mcp_rag_agent with last mcp-server-qdrant 

### DIFF
--- a/examples/streamlit_mcp_rag_agent/mcp_agent.config.yaml
+++ b/examples/streamlit_mcp_rag_agent/mcp_agent.config.yaml
@@ -17,14 +17,14 @@ mcp:
       command: "uvx"
       args:
         [
-          "mcp-server-qdrant",
-          "--qdrant-url",
-          "http://localhost:6333",
-          "--collection-name",
-          "my_collection",
-          "--embedding-model",
-          "BAAI/bge-small-en-v1.5",
+          "mcp-server-qdrant"
         ]
+      env:
+        {
+          "QDRANT_URL": "http://localhost:6333",
+          "COLLECTION_NAME": "my_collection",
+          "EMBEDDING_MODEL": "BAAI/bge-small-en-v1.5"
+        }
 
 openai:
   # Secrets (API keys, etc.) are stored in an mcp_agent.secrets.yaml file which can be gitignored


### PR DESCRIPTION
> From [v0.7.0](https://github.com/qdrant/mcp-server-qdrant/releases/tag/v0.7.0) Command parameters are no longer supported. All the configuration has to be done with environmental variables.

Qdrant MCP server parameters are moved from arg to env.