### PR TITLE
fix: improve server name parsing in tool calls

### DIFF
--- a/src/mcp_agent/mcp/mcp_aggregator.py
+++ b/src/mcp_agent/mcp/mcp_aggregator.py
@@ -267,7 +267,17 @@ class MCPAggregator(ContextDependent):
         local_tool_name: str = None
 
         if SEP in name:  # Namespaced tool name
-            server_name, local_tool_name = name.split(SEP, 1)
+            parts = name.split(SEP)
+            
+            for i in range(len(parts) - 1, 0, -1):
+                potential_server_name = SEP.join(parts[:i])
+                if potential_server_name in self.server_names:
+                    server_name = potential_server_name
+                    local_tool_name = SEP.join(parts[i:])
+                    break
+                
+            if server_name is None:
+                server_name, local_tool_name = name.split(SEP, 1)
         else:
             # Assume un-namespaced, loop through all servers to find the tool. First match wins.
             for _, tools in self._server_to_tool_map.items():


### PR DESCRIPTION
Fix #36 
Handle tool names with multiple separators by finding the longest matching server name prefix. This fixes issues with tools like 'firecrawl-mcp-firecrawl_search' where the server name should be 'firecrawl-mcp' not just 'firecrawl'.