### PR TITLE
Fix structure and code block issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,11 +584,11 @@ lost_baggage = SwarmAgent(
 
 </details>
 
-## App Config
+### App Config
 
-Create an [`mcp_agent.config.yaml`](/schema/mcp-agent.config.schema.json) and a gitignored [`mcp_agent.secrets.yaml`](./examples/mcp_basic_agent/mcp_agent.secrets.yaml.example) to define MCP app configuration. This controls logging, execution, LLM provider APIs, and MCP server configuration:
+Create an [`mcp_agent.config.yaml`](/schema/mcp-agent.config.schema.json) and a gitignored [`mcp_agent.secrets.yaml`](./examples/mcp_basic_agent/mcp_agent.secrets.yaml.example) to define MCP app configuration. This controls logging, execution, LLM provider APIs, and MCP server configuration.
 
-## MCP server management
+### MCP server management
 
 mcp-agent makes it trivial to connect to MCP servers. Create an [`mcp_agent.config.yaml`](/schema/mcp-agent.config.schema.json) to define server configuration under the `mcp` section:
 
@@ -601,7 +601,7 @@ mcp:
       description: "Fetch content at URLs from the world wide web"
 ```
 
-### [`gen_client`](src/mcp_agent/mcp/gen_client.py)
+#### [`gen_client`](src/mcp_agent/mcp/gen_client.py)
 
 Manage the lifecycle of an MCP server within an async context manager:
 
@@ -617,7 +617,7 @@ async with gen_client("fetch") as fetch_client:
 
 The gen_client function makes it easy to spin up connections to MCP servers.
 
-### Persistent server connections
+#### Persistent server connections
 
 In many cases, you want an MCP server to stay online for persistent use (e.g. in a multi-step tool use workflow).
 For persistent connections, use:
@@ -640,6 +640,7 @@ finally:
 
 <details>
 <summary>Example</summary>
+
 ```python
 from mcp_agent.context import get_current_context
 from mcp_agent.mcp.mcp_connection_manager import MCPConnectionManager
@@ -653,12 +654,11 @@ result = fetch_client.list_tool()
 fetch_client2 = await connection_manager.get_server("fetch") # Reuses same server connection
 
 # All servers managed by connection manager are automatically disconnected/shut down
-
-````
+```
 
 </details>
 
-### MCP Server Aggregator
+#### MCP Server Aggregator
 
 [`MCPAggregator`](src/mcp_agent/mcp/mcp_aggregator.py) acts as a "server-of-servers".
 It provides a single MCP server interface for interacting with multiple MCP servers.


### PR DESCRIPTION
1. The structure of contents and `Table of Contents` does not match.
2. There is an issue with the python code block in `Persistent server connections`.