### PR TITLE
update settings fetch to prioritize `config_path` config AND secrets 

### DIFF
--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -331,7 +331,6 @@ def get_settings(config_path: str | None = None) -> Settings:
         return _settings
 
     import yaml  # pylint: disable=C0415
-    from .console import error_console
 
     merged_settings = {}
 
@@ -339,7 +338,6 @@ def get_settings(config_path: str | None = None) -> Settings:
     if config_path:
         config_file = Path(config_path)
         if not config_file.exists():
-            error_console.print(f"Config file not found: {config_path}")
             raise FileNotFoundError(f"Config file not found: {config_path}")
     else:
         config_file = Settings.find_config()
@@ -363,7 +361,7 @@ def get_settings(config_path: str | None = None) -> Settings:
                 break
 
         # If no secrets were found in the config directory, fall back to discovery
-        if not secrets_found and not config_path:
+        if not secrets_found:
             secrets_file = Settings.find_secrets()
             if secrets_file and secrets_file.exists():
                 with open(secrets_file, "r", encoding="utf-8") as f:

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -331,7 +331,7 @@ def get_settings(config_path: str | None = None) -> Settings:
         return _settings
 
     import yaml  # pylint: disable=C0415
-    from .console import console
+    from .console import error_console
 
     merged_settings = {}
 
@@ -339,7 +339,7 @@ def get_settings(config_path: str | None = None) -> Settings:
     if config_path:
         config_file = Path(config_path)
         if not config_file.exists():
-            console.error(f"Config file not found: {config_path}")
+            error_console.print(f"Config file not found: {config_path}")
             raise FileNotFoundError(f"Config file not found: {config_path}")
     else:
         config_file = Settings.find_config()


### PR DESCRIPTION
  ## Fix for loading secrets alongside explicit config files

  ### Problem
  When an explicit config path is provided to `get_settings()`, the function looks for secrets using `Settings.find_secrets()`, which starts from the current working directory rather than the directory containing the config file. This causes issues when running tools from a different directory from where the config files are located.

  ### Solution
  This PR modifies `get_settings()` to prioritize looking for secrets in the same directory as an explicitly provided config file:

  1. When an explicit config path is provided, check for secrets files in the same directory
  2. Support both naming conventions (`mcp-agent.secrets.yaml` and `mcp_agent.secrets.yaml`)
  3. Only fall back to the standard discovery method if no secrets are found alongside the config

  ### Benefits
  - Improves usability for tools and CLIs that might be run from any directory
  - Allows proper separation of config and secrets files while maintaining their association
  - Maintains backward compatibility with the current behavior
  - Provides a more intuitive experience when explicit paths are used

  ### Testing
  Tested with a CLI tool that uses MCP agent and has its config/secrets stored in a subdirectory. Before this change, the tool needed to be run from the directory containing the config/secrets. After this change, it can be run from any directory.
  
  Worth mentioning that a previous version had this behavior, but I don't have any context on whether this was a deliberate change: 
```
>> previous impl
            # Load main config
            with open(config_file, "r", encoding="utf-8") as f:
                yaml_settings = yaml.safe_load(f) or {}
                merged_settings = yaml_settings

            # Look for secrets file in the same directory
            secrets_file = config_file.parent / "mcp_agent.secrets.yaml"
            if secrets_file.exists():
                with open(secrets_file, "r", encoding="utf-8") as f:
                    yaml_secrets = yaml.safe_load(f) or {}
                    merged_settings = deep_merge(merged_settings, yaml_secrets)
```