### PR TITLE
Fix duplicated system message (prompt cache)

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -111,14 +111,14 @@ class OpenAIAugmentedLLM(
         messages: List[ChatCompletionMessageParam] = []
         params = self.get_request_params(request_params)
 
+        if params.use_history:
+            messages.extend(self.history.get())
+
         system_prompt = self.instruction or params.systemPrompt
-        if system_prompt:
+        if system_prompt and len(messages) == 0:
             messages.append(
                 ChatCompletionSystemMessageParam(role="system", content=system_prompt)
             )
-
-        if params.use_history:
-            messages.extend(self.history.get())
 
         if isinstance(message, str):
             messages.append(


### PR DESCRIPTION
A tiny change, fix the system prompt which added to top of messages in every turn, even it's already in messages history.
That break the prompt cache hit, make api call more slow and expensive.