### PR TITLE
fix examples

### DIFF
--- a/examples/mcp_basic_slack_agent/main.py
+++ b/examples/mcp_basic_slack_agent/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 from mcp_agent.app import MCPApp
 from mcp_agent.agents.agent import Agent
@@ -6,10 +7,11 @@ from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
 
 app = MCPApp(name="mcp_basic_agent")
 
-
 async def example_usage():
     async with app.run() as agent_app:
         logger = agent_app.logger
+        context = agent_app.context
+
         slack_agent = Agent(
             name="slack_finder",
             instruction="""You are an agent with access to the filesystem, 
@@ -18,6 +20,8 @@ async def example_usage():
             and return the results.""",
             server_names=["filesystem", "slack"],
         )
+
+        context.config.mcp.servers["filesystem"].args.extend([os.getcwd()])
 
         async with slack_agent:
             logger.info("slack: Connected to server, calling list_tools...")

--- a/examples/mcp_basic_slack_agent/mcp_agent.config.yaml
+++ b/examples/mcp_basic_slack_agent/mcp_agent.config.yaml
@@ -17,9 +17,7 @@ mcp:
       args:
         [
           "-y",
-          "@modelcontextprotocol/server-filesystem",
-          "/Users/saqadri/Desktop",
-          "/Users/saqadri/Downloads",
+          "@modelcontextprotocol/server-filesystem"
         ]
 
 openai:

--- a/examples/mcp_hello_world/main.py
+++ b/examples/mcp_hello_world/main.py
@@ -25,34 +25,34 @@ async def example_usage():
             result = await fetch_client.list_tools()
             logger.info("Tools available:", data=result.model_dump())
 
-        # Connect to the filesystem server using a persistent connection via connect/disconnect
-        # This is useful when you need to make multiple requests to the same server
+            # Connect to the filesystem server using a persistent connection via connect/disconnect
+            # This is useful when you need to make multiple requests to the same server
 
-        connection_manager = MCPConnectionManager(context.server_registry)
-        await connection_manager.__aenter__()
+            connection_manager = MCPConnectionManager(context.server_registry)
+            await connection_manager.__aenter__()
 
-        try:
-            filesystem_client = await connection_manager.get_server(
-                server_name="filesystem", client_session_factory=MCPAgentClientSession
-            )
-            logger.info("filesystem: Connected to server with persistent connection.")
+            try:
+                filesystem_client = await connection_manager.get_server(
+                    server_name="filesystem", client_session_factory=MCPAgentClientSession
+                )
+                logger.info("filesystem: Connected to server with persistent connection.")
 
-            fetch_client = await connection_manager.get_server(
-                server_name="fetch", client_session_factory=MCPAgentClientSession
-            )
-            logger.info("fetch: Connected to server with persistent connection.")
+                fetch_client = await connection_manager.get_server(
+                    server_name="fetch", client_session_factory=MCPAgentClientSession
+                )
+                logger.info("fetch: Connected to server with persistent connection.")
 
-            result = await filesystem_client.session.list_tools()
-            logger.info("filesystem: Tools available:", data=result.model_dump())
+                result = await filesystem_client.session.list_tools()
+                logger.info("filesystem: Tools available:", data=result.model_dump())
 
-            result = await fetch_client.session.list_tools()
-            logger.info("fetch: Tools available:", data=result.model_dump())
-        finally:
-            await connection_manager.disconnect_server(server_name="filesystem")
-            logger.info("filesystem: Disconnected from server.")
-            await connection_manager.disconnect_server(server_name="fetch")
-            logger.info("fetch: Disconnected from server.")
-            await connection_manager.__aexit__(None, None, None)
+                result = await fetch_client.session.list_tools()
+                logger.info("fetch: Tools available:", data=result.model_dump())
+            finally:
+                await connection_manager.disconnect_server(server_name="filesystem")
+                logger.info("filesystem: Disconnected from server.")
+                await connection_manager.disconnect_server(server_name="fetch")
+                logger.info("fetch: Disconnected from server.")
+                await connection_manager.__aexit__(None, None, None)
 
 
 if __name__ == "__main__":

--- a/examples/mcp_model_selector/mcp_agent.config.yaml
+++ b/examples/mcp_model_selector/mcp_agent.config.yaml
@@ -21,7 +21,5 @@ mcp:
       args:
         [
           "-y",
-          "@modelcontextprotocol/server-filesystem",
-          "/Users/saqadri/Desktop",
-          "/Users/saqadri/Downloads",
+          "@modelcontextprotocol/server-filesystem"
         ]

--- a/examples/mcp_researcher/main.py
+++ b/examples/mcp_researcher/main.py
@@ -1,5 +1,7 @@
 import asyncio
 import time
+import os
+from pathlib import Path
 
 from mcp_agent.app import MCPApp
 from mcp_agent.agents.agent import Agent
@@ -11,10 +13,23 @@ from rich import print
 
 app = MCPApp(name="mcp_root_test")
 
-
 async def example_usage():
     async with app.run() as agent_app:
+        folder_path = Path("agent_folder")
+        folder_path.mkdir(exist_ok=True)
+
         context = agent_app.context
+        logger = agent_app.logger
+
+        context.config.mcp.servers["interpreter"].args = [
+          "run",
+          "-i",
+          "--rm",
+          "--pull=always",
+          "-v",
+          f"{os.path.abspath('agent_folder')}:/mnt/data/",
+          "ghcr.io/evalstate/mcp-py-repl:latest",
+        ]
 
         async with MCPConnectionManager(context.server_registry):
             interpreter_agent = Agent(

--- a/examples/mcp_researcher/main.py
+++ b/examples/mcp_researcher/main.py
@@ -19,8 +19,8 @@ async def example_usage():
         folder_path.mkdir(exist_ok=True)
 
         context = agent_app.context
-        logger = agent_app.logger
 
+        # Overwrite the config because full path to agent folder needs to be passed
         context.config.mcp.servers["interpreter"].args = [
           "run",
           "-i",

--- a/examples/workflow_evaluator_optimizer/mcp_agent.config.yaml
+++ b/examples/workflow_evaluator_optimizer/mcp_agent.config.yaml
@@ -21,9 +21,7 @@ mcp:
       args:
         [
           "-y",
-          "@modelcontextprotocol/server-filesystem",
-          "/Users/saqadri/Desktop",
-          "/Users/saqadri/Downloads",
+          "@modelcontextprotocol/server-filesystem"
         ]
 
 openai:


### PR DESCRIPTION
Fixes a variety of problems in examples found during testing

1. Indentation in `mcp_hello_world` was incorrect, causing the example to not run after client is instantiated
2. References to `saqadri` local filesystem in `mcp_basic_slack_agent`, `mcp_model_selector`, workflow_evaluator_optimizer`
3. `mcp_basic_slack` requires path to folder on local filesystem, similar to other examples
4. `mcp_researcher` could not resolve relative path `./agent_folder`. Had to pass the full path using `os.path.abspath`. Also need to create the `agent_folder` directory if it doesn't exist on local filesystem

Example error from `mcp_basic_slack`

```
Error accessing directory /Users/saqadri/Desktop: Error: ENOENT: no such file or 
directory, stat '/Users/saqadri/Desktop'
    at async Object.stat (node:internal/fs/promises:1037:18)
    at async file:///Users/bochen/.npm/_npx/a3241bba59c344f5/node_modules/@modelcontextprotocol/server-filesystem/dist/index.js:33:23
    at async Promise.all (index 0)
    at async file:///Users/bochen/.npm/_npx/a3241bba59c344f5/node_modules/@modelcontextprotocol/server-filesystem/dist/index.js:31:1 {
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: '/Users/saqadri/Desktop'
}
```

Example error from `mcp_researcher`

```
{"level":"INFO","timestamp":"2025-03-31T13:21:05.308384","namespace":"mcp_agent.mcp.stdio.mcpserver.stderr","message":"docker: Error response from daemon: create ./agent_folder: \"./agent_folder\" includes invalid characters for a local volume name, only \"[a-zA-Z0-9][a-zA-Z0-9_.-]\" are allowed. If you intended to pass a host directory, use absolute path.\nSee 'docker run --help'."}
```