### PR TITLE
Adding example for a Github to Slack agent

### DIFF
--- a/examples/mcp_github_to_slack_agent/README.md
+++ b/examples/mcp_github_to_slack_agent/README.md
@@ -1,0 +1,48 @@
+# GitHub PRs to Slack Summary Agent
+
+This application creates an MCP Agent that monitors GitHub pull requests and submits prioritized summaries to Slack. The agent uses a LLM to analyze PR information, prioritize issues, and create informative summaries.
+
+## How It Works
+
+1. The application connects to both GitHub and Slack via their respective MCP servers
+2. The agent retrieves the latest pull requests from a specified GitHub repository
+3. It analyzes each PR and prioritizes them based on importance factors:
+   - PRs marked as high priority or urgent
+   - PRs addressing security vulnerabilities
+   - PRs fixing critical bugs
+   - PRs blocking other work
+   - PRs that have been open for a long time
+4. The agent formats a professional summary of high-priority items
+5. The summary is posted to the specified Slack channel
+
+## Setup
+
+### Prerequisites
+
+- Python 3.10 or higher
+- MCP Agent framework
+- GitHub MCP Server
+- Slack MCP Server
+- Access to a GitHub repository
+- Access to a Slack workspace
+
+### Installation
+
+1. Install dependencies:
+```
+uv sync --dev
+```
+
+2. Create a secrets file:
+```
+cp mcp_agent.secrets.yaml mcp_agent.secrets.yaml
+```
+
+3. Update the secrets file with your API keys
+
+### Usage
+
+Run the application with:
+```
+uv run main.py --owner <github-owner> --repo <repository-name> --channel <slack-channel>
+```

--- a/examples/mcp_github_to_slack_agent/README.md
+++ b/examples/mcp_github_to_slack_agent/README.md
@@ -26,6 +26,28 @@ This application creates an MCP Agent that monitors GitHub pull requests and sub
 - Access to a GitHub repository
 - Access to a Slack workspace
 
+### Getting a Slack Bot Token and Team ID
+
+1. Head to [Slack API apps](https://api.slack.com/apps)
+
+2. Create a **New App**
+
+3. Click on the option to **Create from scratch**
+
+4. In the app view, go to **OAuth & Permissions** on the left-hand navigation
+
+5. Copy the **Bot User OAuth Token**
+   
+6. *[Optional] In OAuth & Permissions, add chat:write, users:read, im:history, chat:write.public to the Bot Token Scopes*
+
+7. For **Team ID**, go to the browser and log into your workspace.
+   
+8. In the browser, take the **TEAM ID** from the url: `https://app.slack.com/client/TEAM_ID`
+
+9. Add the **OAuth Token** and the **Team ID** to your `mcp_agent.secrets.yaml` file
+
+10. *[Optional] Make sure to launch and install your Slack bot to your workspace. And, invite the new bot to the channel you want to interact with.*
+
 ### Installation
 
 1. Install dependencies:

--- a/examples/mcp_github_to_slack_agent/README.md
+++ b/examples/mcp_github_to_slack_agent/README.md
@@ -21,8 +21,8 @@ This application creates an MCP Agent that monitors GitHub pull requests and sub
 
 - Python 3.10 or higher
 - MCP Agent framework
-- GitHub MCP Server
-- Slack MCP Server
+- [GitHub MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/github)
+- [Slack MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/slack)
 - Access to a GitHub repository
 - Access to a Slack workspace
 

--- a/examples/mcp_github_to_slack_agent/main.py
+++ b/examples/mcp_github_to_slack_agent/main.py
@@ -73,10 +73,6 @@ async def github_to_slack(github_owner: str, github_repo: str, slack_channel: st
                 # Clean up the agent
                 await github_to_slack_agent.close()
 
-    # Ensure logging is properly shutdown
-    await LoggingConfig.shutdown()
-
-
 def parse_args():
     parser = argparse.ArgumentParser(description="GitHub to Slack PR Summary Tool")
     parser.add_argument("--owner", required=True, help="GitHub repository owner")

--- a/examples/mcp_github_to_slack_agent/main.py
+++ b/examples/mcp_github_to_slack_agent/main.py
@@ -1,0 +1,101 @@
+import asyncio
+import time
+import argparse
+from mcp_agent.app import MCPApp
+from mcp_agent.agents.agent import Agent
+from mcp_agent.mcp.mcp_connection_manager import MCPConnectionManager
+from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLLM
+from mcp_agent.logging.logger import LoggingConfig
+from rich import print
+
+app = MCPApp(name="github_to_slack")
+
+async def github_to_slack(github_owner: str, github_repo: str, slack_channel: str):
+    async with app.run() as agent_app:
+        context = agent_app.context
+
+        async with MCPConnectionManager(context.server_registry):
+            github_to_slack_agent = Agent(
+                name="github_to_slack_agent",
+                instruction=f"""You are an agent that monitors GitHub pull requests and provides summaries to Slack.
+                Your tasks are:
+                1. Use the GitHub server to retrieve information about the latest pull requests for the repository {github_owner}/{github_repo}
+                2. Analyze and prioritize the pull requests based on their importance, urgency, and impact
+                3. Format a concise summary of high-priority items
+                4. Submit this summary to the Slack server in the channel {slack_channel}
+                
+                For prioritization, consider:
+                - PRs marked as high priority or urgent
+                - PRs that address security vulnerabilities
+                - PRs that fix critical bugs
+                - PRs that are blocking other work
+                - PRs that have been open for a long time
+                
+                Your Slack summary should be professional, concise, and highlight the most important information.""",
+                server_names=["github", "slack"],
+            )
+
+            try:
+                llm = await github_to_slack_agent.attach_llm(AnthropicAugmentedLLM)
+
+                prompt = f"""Complete the following workflow:
+
+                1. Retrieve the latest pull requests from the GitHub repository {github_owner}/{github_repo}.
+                   Use the GitHub server to get this information.
+                   Gather details such as PR title, author, creation date, status, and description.
+
+                2. Analyze the pull requests you've retrieved and prioritize them.
+                   Identify high-priority items based on:
+                   - PRs marked as high priority or urgent in their title or description
+                   - PRs that address security vulnerabilities
+                   - PRs that fix critical bugs
+                   - PRs that are blocking other work
+                   - PRs that have been open for a long time
+                   Create a list of high-priority PRs with brief explanations of why they are prioritized.
+
+                3. Format a professional and concise summary of the high-priority pull requests
+                   to share on Slack. The summary should:
+                   - Start with a brief overview of what's included
+                   - List each high-priority PR with its key details
+                   - Include links to the PRs
+                   - End with any relevant action items or recommendations
+                
+                4. Use the Slack server to post this summary to the channel {slack_channel}.
+                """
+
+                # Execute the workflow
+                print("Executing GitHub to Slack workflow...")
+                result = await llm.generate_str(prompt)
+                
+                print("Workflow completed successfully!")
+
+            finally:
+                # Clean up the agent
+                await github_to_slack_agent.close()
+
+    # Ensure logging is properly shutdown
+    await LoggingConfig.shutdown()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="GitHub to Slack PR Summary Tool")
+    parser.add_argument("--owner", required=True, help="GitHub repository owner")
+    parser.add_argument("--repo", required=True, help="GitHub repository name")
+    parser.add_argument("--channel", required=True, help="Slack channel to post to")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    start = time.time()
+    try:
+        asyncio.run(github_to_slack(args.owner, args.repo, args.channel))
+    except KeyboardInterrupt:
+        print("\nReceived keyboard interrupt, shutting down gracefully...")
+    except Exception as e:
+        print(f"Error during execution: {e}")
+        raise
+    finally:
+        end = time.time()
+        t = end - start
+        print(f"Total run time: {t:.2f}s")

--- a/examples/mcp_github_to_slack_agent/main.py
+++ b/examples/mcp_github_to_slack_agent/main.py
@@ -65,7 +65,7 @@ async def github_to_slack(github_owner: str, github_repo: str, slack_channel: st
 
                 # Execute the workflow
                 print("Executing GitHub to Slack workflow...")
-                result = await llm.generate_str(prompt)
+                await llm.generate_str(prompt)
                 
                 print("Workflow completed successfully!")
 

--- a/examples/mcp_github_to_slack_agent/main.py
+++ b/examples/mcp_github_to_slack_agent/main.py
@@ -5,7 +5,6 @@ from mcp_agent.app import MCPApp
 from mcp_agent.agents.agent import Agent
 from mcp_agent.mcp.mcp_connection_manager import MCPConnectionManager
 from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLLM
-from mcp_agent.logging.logger import LoggingConfig
 from rich import print
 
 app = MCPApp(name="github_to_slack")

--- a/examples/mcp_github_to_slack_agent/mcp_agent.config.yaml
+++ b/examples/mcp_github_to_slack_agent/mcp_agent.config.yaml
@@ -1,0 +1,21 @@
+execution_engine: asyncio
+logger:
+  transports: [console, file]
+  level: info
+  show_progress: true
+  path: "logs/github-to-slack.jsonl"
+  path_settings:
+    path_pattern: "logs/github-to-slack-{unique_id}.jsonl"
+    unique_id: "timestamp"
+    timestamp_format: "%Y%m%d_%H%M%S"
+
+mcp:
+  servers:
+    github:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-github"]
+      description: "Access GitHub API operations"
+    slack:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-slack"]
+      description: "Access Slack API operations"

--- a/examples/mcp_github_to_slack_agent/mcp_agent.secrets.yaml.example
+++ b/examples/mcp_github_to_slack_agent/mcp_agent.secrets.yaml.example
@@ -1,0 +1,21 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+mcp:
+  servers:
+    # Slack configuration
+    # Create a Slack Bot Token and get your Team ID
+    # https://api.slack.com/apps
+    slack:
+      env:
+        SLACK_BOT_TOKEN: "xoxb-your-bot-token"
+        SLACK_TEAM_ID: "T01234567"
+
+    # GitHub configuration
+    # Create a GitHub Personal Access Token with repo scope
+    # https://github.com/settings/tokens
+    github:
+      env:
+        GITHUB_PERSONAL_ACCESS_TOKEN: "github_pat_your-access-token"
+
+anthropic:
+  api_key: your-anthropic-api-key

--- a/examples/mcp_github_to_slack_agent/requirements.txt
+++ b/examples/mcp_github_to_slack_agent/requirements.txt
@@ -1,0 +1,3 @@
+mcp-agent>=0.0.14
+anthropic>=0.48.0
+instructor[anthropic]>=1.7.2


### PR DESCRIPTION
Adding an example agent for Github to Slack:
- Reads PRs from Github
- Prioritizes the PRs based on status, date created, state, etc.
- Posts a summary of the prioritization to a Slack channel