### PR TITLE
Fix OpenAI ChatCompletion message content format issue

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -368,7 +368,7 @@ class OpenAIAugmentedLLM(
             return ChatCompletionToolMessageParam(
                 role="tool",
                 tool_call_id=tool_call_id,
-                content=[mcp_content_to_openai_content(c) for c in result.content],
+                content="\n".join(str(mcp_content_to_openai_content(c)) for c in result.content),
             )
 
         return None


### PR DESCRIPTION
- Modified `execute_tool_call` method in OpenAIAugmentedLLM to convert content list to string
- Used "\n".join() to concatenate list items into a single string
- This addresses issue #25 where OpenAI API rejects list-type content
- Follows OpenAI API specification requiring content to be string or null
- Prevents errors with LLMs like deepseek that strictly validate input format

The change ensures compatibility with OpenAI's API requirements which specify: "content can only be a string or null. It cannot be a list, object, or any other type."