### PR TITLE
Add support for websockets and an example

### DIFF
--- a/examples/mcp_websockets/README.md
+++ b/examples/mcp_websockets/README.md
@@ -1,0 +1,7 @@
+# MCP Agent example
+
+This example shows a "finder" Agent which has access to the 'fetch' and 'filesystem' MCP servers.
+
+You can ask it information about local files or URLs, and it will make the determination on what to use at what time to satisfy the request.
+
+<img width="2160" alt="Image" src="https://github.com/user-attachments/assets/14cbfdf4-306f-486b-9ec1-6576acf0aeb7" />

--- a/examples/mcp_websockets/README.md
+++ b/examples/mcp_websockets/README.md
@@ -1,7 +1,5 @@
 # MCP Agent example
 
-This example shows a "finder" Agent which has access to the 'fetch' and 'filesystem' MCP servers.
-
-You can ask it information about local files or URLs, and it will make the determination on what to use at what time to satisfy the request.
+This example shows a basic agent that can connect to an MCP server over websockets
 
 <img width="2160" alt="Image" src="https://github.com/user-attachments/assets/14cbfdf4-306f-486b-9ec1-6576acf0aeb7" />

--- a/examples/mcp_websockets/main.py
+++ b/examples/mcp_websockets/main.py
@@ -1,0 +1,59 @@
+import asyncio
+import os
+import time
+
+from mcp_agent.app import MCPApp
+from mcp_agent.config import (
+    Settings,
+    LoggerSettings,
+    MCPSettings,
+    MCPServerSettings,
+    OpenAISettings,
+    AnthropicSettings,
+)
+from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm import RequestParams
+from mcp_agent.workflows.llm.llm_selector import ModelPreferences
+from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLLM
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+
+# Settings can either be specified programmatically,
+# or loaded from mcp_agent.config.yaml/mcp_agent.secrets.yaml
+app = MCPApp(name="mcp_websockets")  # settings=settings)
+
+
+async def example_usage():
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+        context = agent_app.context
+
+        logger.info("Current config:", data=context.config.model_dump())
+
+        agent = Agent(
+            name="github-agent",
+            instruction="""You are an agent whose job is to interact with the Github
+            repository for the user.
+            """,
+            server_names=["smithery-github"],
+        )
+
+        async with agent:
+            logger.info("finder: Connected to server, calling list_tools...")
+            result = await agent.list_tools()
+            logger.info("Tools available:", data=result.model_dump())
+
+            llm = await agent.attach_llm(OpenAIAugmentedLLM)
+            result = await llm.generate(
+                message="List all Github repositories for the user",
+            )
+            logger.info(f"Github repositories: {result}")
+
+
+if __name__ == "__main__":
+    start = time.time()
+    asyncio.run(example_usage())
+    end = time.time()
+    t = end - start
+
+    print(f"Total run time: {t:.2f}s")

--- a/examples/mcp_websockets/mcp_agent.config.yaml
+++ b/examples/mcp_websockets/mcp_agent.config.yaml
@@ -1,0 +1,27 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  transports: [console, file]
+  level: debug
+  show_progress: true
+  path_settings:
+    path_pattern: "logs/mcp-agent-{unique_id}.jsonl"
+    unique_id: "timestamp" # Options: "timestamp" or "session_id"
+    timestamp_format: "%Y%m%d_%H%M%S"
+
+mcp:
+  servers:
+    smithery-github:
+      name: "@smithery/github"
+      description: "github server"
+      transport: "websocket"
+      # This URL needs to be constructed on Smithery. Smithery requires server json configSchema
+      # object to be passed in as base64. See details here:
+      # https://smithery.ai/docs/registry#connecting-to-websocket-servers
+      # url: "wss://server.smithery.ai/@smithery-ai/github/ws?config=<enter your base64 encoded configSchema object>"
+
+openai:
+  # Secrets (API keys, etc.) are stored in an mcp_agent.secrets.yaml file which can be gitignored
+  #  default_model: "o3-mini"
+  default_model: "gpt-4o-mini"

--- a/examples/mcp_websockets/mcp_agent.secrets.yaml.example
+++ b/examples/mcp_websockets/mcp_agent.secrets.yaml.example
@@ -1,0 +1,4 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+openai:
+  api_key: openai_api_key

--- a/examples/mcp_websockets/requirements.txt
+++ b/examples/mcp_websockets/requirements.txt
@@ -1,0 +1,5 @@
+# Core framework dependency
+mcp-agent @ file://../../  # Link to the local mcp-agent project root
+
+# Additional dependencies specific to this example
+openai

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "scikit-learn>=1.6.0",
     "prompt-toolkit>=3.0.50",
     "aiohttp>=3.11.13",
+    "websockets>=12.0",
 ]
 
 [project.optional-dependencies]
@@ -87,4 +88,3 @@ mcp-agent = [ # TODO: should this be mcp_agent?
     "resources/examples/**/*.csv",
     "resources/examples/**/mount-point/*.csv"
 ]
-

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -54,7 +54,7 @@ class MCPServerSettings(BaseModel):
     description: str | None = None
     """The description of the server."""
 
-    transport: Literal["stdio", "sse"] = "stdio"
+    transport: Literal["stdio", "sse", "websocket"] = "stdio"
     """The transport mechanism."""
 
     command: str | None = None

--- a/src/mcp_agent/mcp/mcp_connection_manager.py
+++ b/src/mcp_agent/mcp/mcp_connection_manager.py
@@ -30,6 +30,7 @@ from mcp_agent.event_progress import ProgressAction
 from mcp_agent.logging.logger import get_logger
 from mcp_agent.mcp.mcp_agent_client_session import MCPAgentClientSession
 from mcp_agent.mcp.stdio import stdio_client_with_rich_stderr
+from mcp_agent.mcp.websocket import websocket_client
 from mcp_agent.context_dependent import ContextDependent
 
 if TYPE_CHECKING:
@@ -278,6 +279,8 @@ class MCPConnectionManager(ContextDependent):
                 return stdio_client_with_rich_stderr(server_params)
             elif config.transport == "sse":
                 return sse_client(config.url)
+            elif config.transport == "websocket":
+                return websocket_client(config.url)
             else:
                 raise ValueError(f"Unsupported transport: {config.transport}")
 

--- a/src/mcp_agent/mcp/websocket.py
+++ b/src/mcp_agent/mcp/websocket.py
@@ -1,0 +1,113 @@
+"""
+Websocket transport layer for MCP agent to connect to MCP servers.
+"""
+
+import json
+import anyio
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from contextlib import asynccontextmanager
+from pydantic import ValidationError
+from typing import AsyncGenerator
+from websockets.asyncio.client import connect as ws_connect
+from websockets.typing import Subprotocol
+
+import mcp.types as types
+from mcp_agent.logging.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@asynccontextmanager
+async def websocket_client(
+    url: str,
+) -> AsyncGenerator[
+    tuple[
+        MemoryObjectReceiveStream[types.JSONRPCMessage | Exception],
+        MemoryObjectSendStream[types.JSONRPCMessage],
+    ],
+    None,
+]:
+    """
+    WebSocket client transport for MCP Agent.
+
+    Connects to 'url' using the 'mcp' subprotocol, then yields:
+        (read_stream, write_stream)
+
+    - read_stream: As you read from this stream, you'll receive either valid
+      JSONRPCMessage objects or Exception objects (when validation fails).
+    - write_stream: Write JSONRPCMessage objects to this stream to send them
+      over the WebSocket to the server.
+    """
+
+    # Create two in-memory streams:
+    # - One for incoming messages (read_stream, written by ws_reader)
+    # - One for outgoing messages (write_stream, read by ws_writer)
+    read_stream: MemoryObjectReceiveStream[types.JSONRPCMessage | Exception]
+    read_stream_writer: MemoryObjectSendStream[types.JSONRPCMessage | Exception]
+    write_stream: MemoryObjectSendStream[types.JSONRPCMessage]
+    write_stream_reader: MemoryObjectReceiveStream[types.JSONRPCMessage]
+
+    read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
+    write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
+
+    logger.debug(f"Connecting to MCP server via WebSocket at {url}")
+
+    try:
+        # Connect using websockets, requesting the "mcp" subprotocol
+        async with ws_connect(url, subprotocols=[Subprotocol("mcp")]) as ws:
+            logger.debug(f"WebSocket connection established to {url}")
+
+            async def ws_reader():
+                """
+                Reads text messages from the WebSocket, parses them as JSON-RPC messages,
+                and sends them into read_stream_writer.
+                """
+                try:
+                    async with read_stream_writer:
+                        async for raw_text in ws:
+                            try:
+                                message = types.JSONRPCMessage.model_validate_json(raw_text)
+                                await read_stream_writer.send(message)
+                            except ValidationError as exc:
+                                # If JSON parse or model validation fails, send the exception
+                                logger.warning(f"Failed to parse WebSocket message: {exc}")
+                                await read_stream_writer.send(exc)
+                except anyio.ClosedResourceError:
+                    await anyio.lowlevel.checkpoint()
+                except Exception as e:
+                    logger.error(f"Error in WebSocket reader: {e}")
+
+            async def ws_writer():
+                """
+                Reads JSON-RPC messages from write_stream_reader and
+                sends them to the server.
+                """
+                try:
+                    async with write_stream_reader:
+                        async for message in write_stream_reader:
+                            # Convert to a dict, then to JSON
+                            msg_dict = message.model_dump(
+                                by_alias=True, mode="json", exclude_none=True
+                            )
+                            await ws.send(json.dumps(msg_dict))
+                except anyio.ClosedResourceError:
+                    await anyio.lowlevel.checkpoint()
+                except Exception as e:
+                    logger.error(f"Error in WebSocket writer: {e}")
+
+            async with anyio.create_task_group() as tg:
+                # Start reader and writer tasks
+                tg.start_soon(ws_reader)
+                tg.start_soon(ws_writer)
+
+                try:
+                    # Yield the receive/send streams
+                    yield (read_stream, write_stream)
+                except Exception as e:
+                    logger.error(f"Error in WebSocket transport: {e}")
+                finally:
+                    # Once the caller's 'async with' block exits, we shut down
+                    tg.cancel_scope.cancel()
+    except Exception as e:
+        logger.error(f"Failed to establish WebSocket connection to {url}: {e}")
+        raise

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,181 @@
+import pytest
+import anyio
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator, List, Tuple, Dict
+from unittest.mock import patch, AsyncMock, MagicMock, call
+
+import mcp.types as types
+from mcp_agent.mcp.websocket import websocket_client
+from mcp_agent.config import MCPServerSettings, MCPServerAuthSettings
+
+
+class MockWebSocket:
+    """Mock WebSocket connection for testing."""
+
+    def __init__(self, messages: List[str] = None):
+        self.messages = messages or []
+        self.sent_messages = []
+        self._message_iterator = None
+
+    async def send(self, data: str):
+        """Store sent messages."""
+        self.sent_messages.append(data)
+
+    def __aiter__(self):
+        """Return self as an async iterator."""
+        self._message_iterator = iter(self.messages)
+        return self
+
+    async def __anext__(self):
+        """Return the next message or raise StopAsyncIteration."""
+        try:
+            return next(self._message_iterator)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+@asynccontextmanager
+async def mock_ws_connect(*args, **kwargs):
+    """Mock the websockets.connect function."""
+    mock_ws = MockWebSocket([
+        json.dumps({"jsonrpc": "2.0", "method": "initialize", "id": 1}),
+        json.dumps({"jsonrpc": "2.0", "result": {"protocolVersion": "2023-12-07"}, "id": 1})
+    ])
+    yield mock_ws
+
+
+@pytest.mark.asyncio
+async def test_websocket_client():
+    """Test that websocket_client correctly handles JSON-RPC messages."""
+
+    with patch("mcp_agent.mcp.websocket.ws_connect", new=mock_ws_connect):
+        async with websocket_client("ws://localhost:8000") as (read_stream, write_stream):
+            # Test receiving a message
+            message = await read_stream.receive()
+            assert isinstance(message, types.JSONRPCMessage)
+            assert message.method == "initialize"
+
+            # Test sending a message
+            response = types.JSONRPCMessage(
+                jsonrpc="2.0",
+                result={"message": "Hello World"},
+                id=1
+            )
+            await write_stream.send(response)
+
+            # Wait a bit for the message to be processed
+            await anyio.sleep(0.1)
+
+            # Receive the second message
+            message = await read_stream.receive()
+            assert isinstance(message, types.JSONRPCMessage)
+            assert message.result["protocolVersion"] == "2023-12-07"
+
+
+@pytest.mark.asyncio
+async def test_websocket_client_with_auth():
+    """Test that websocket_client correctly handles authentication."""
+
+    with patch("mcp_agent.mcp.websocket.ws_connect", side_effect=mock_ws_connect) as mock_connect:
+        auth_settings = {"api_key": "test-api-key"}
+        async with websocket_client("ws://localhost:8000", auth_settings=auth_settings) as (read_stream, write_stream):
+            # Verify that ws_connect was called with the correct headers
+            mock_connect.assert_called_once()
+            _, kwargs = mock_connect.call_args
+            assert "extra_headers" in kwargs
+            assert kwargs["extra_headers"]["Authorization"] == "Bearer test-api-key"
+
+
+@pytest.mark.asyncio
+async def test_transport_factory_websocket():
+    """Test that the websocket transport is correctly configured in the connection manager."""
+
+    from mcp_agent.mcp.mcp_connection_manager import MCPConnectionManager
+
+    # Create a configuration with websocket transport
+    config = MCPServerSettings(
+        name="test-server",
+        transport="websocket",
+        url="ws://localhost:8000"
+    )
+
+    # Mock the MCPConnectionManager to avoid actual connections
+    with patch("mcp_agent.mcp.mcp_connection_manager.websocket_client", new=AsyncMock()) as mock_websocket:
+        # Create a mock registry
+        mock_registry = MagicMock()
+        mock_registry.get_server_config.return_value = config
+
+        # Create a connection manager with the mock registry
+        connection_manager = MCPConnectionManager(mock_registry)
+
+        # Call launch_server which will use our transport_context_factory
+        with patch.object(connection_manager, "_tg", new=MagicMock()):
+            with patch.object(connection_manager, "running_servers", new={}):
+                await connection_manager.launch_server("test-server", MagicMock())
+
+        # Check that websocket_client was called with the right URL and no auth
+        mock_websocket.assert_called_once_with("ws://localhost:8000", auth_settings=None)
+
+
+@pytest.mark.asyncio
+async def test_transport_factory_websocket_with_auth():
+    """Test that the websocket transport passes authentication settings correctly."""
+
+    from mcp_agent.mcp.mcp_connection_manager import MCPConnectionManager
+
+    # Create a configuration with websocket transport and auth
+    config = MCPServerSettings(
+        name="test-server",
+        transport="websocket",
+        url="ws://localhost:8000",
+        auth=MCPServerAuthSettings(api_key="test-api-key")
+    )
+
+    # Mock the MCPConnectionManager to avoid actual connections
+    with patch("mcp_agent.mcp.mcp_connection_manager.websocket_client", new=AsyncMock()) as mock_websocket:
+        # Create a mock registry
+        mock_registry = MagicMock()
+        mock_registry.get_server_config.return_value = config
+
+        # Create a connection manager with the mock registry
+        connection_manager = MCPConnectionManager(mock_registry)
+
+        # Call launch_server which will use our transport_context_factory
+        with patch.object(connection_manager, "_tg", new=MagicMock()):
+            with patch.object(connection_manager, "running_servers", new={}):
+                await connection_manager.launch_server("test-server", MagicMock())
+
+        # Check that websocket_client was called with auth settings
+        mock_websocket.assert_called_once()
+        args, kwargs = mock_websocket.call_args
+        assert args[0] == "ws://localhost:8000"
+        assert kwargs["auth_settings"] == {"api_key": "test-api-key"}
+
+
+@pytest.mark.asyncio
+async def test_missing_url_websocket():
+    """Test that an error is raised when url is missing for websocket transport."""
+
+    from mcp_agent.mcp.mcp_connection_manager import MCPConnectionManager
+
+    # Create a configuration with websocket transport but no URL
+    config = MCPServerSettings(
+        name="test-server",
+        transport="websocket",
+        url=None
+    )
+
+    # Mock the MCPConnectionManager to avoid actual connections
+    mock_registry = MagicMock()
+    mock_registry.get_server_config.return_value = config
+
+    # Create a connection manager with the mock registry
+    connection_manager = MCPConnectionManager(mock_registry)
+
+    # Call launch_server which will use our transport_context_factory
+    with patch.object(connection_manager, "_tg", new=MagicMock()):
+        with patch.object(connection_manager, "running_servers", new={}):
+            with pytest.raises(ValueError, match="URL is required for WebSocket transport"):
+                await connection_manager.launch_server("test-server", MagicMock())

--- a/uv.lock
+++ b/uv.lock
@@ -908,6 +908,7 @@ dependencies = [
     { name = "rich" },
     { name = "scikit-learn" },
     { name = "typer" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -915,12 +916,11 @@ anthropic = [
     { name = "anthropic" },
     { name = "instructor", extra = ["anthropic"] },
 ]
-bedrock = [
-    { name = "boto3" },
-    { name = "boto3-stubs", extra = ["bedrock-runtime"] },
-]
 azure = [
     { name = "azure-ai-inference" },
+]
+bedrock = [
+    { name = "boto3" },
 ]
 cohere = [
     { name = "cohere" },
@@ -935,6 +935,7 @@ temporal = [
 [package.dev-dependencies]
 dev = [
     { name = "anthropic" },
+    { name = "boto3-stubs", extra = ["bedrock-runtime"] },
     { name = "pre-commit" },
     { name = "pydantic" },
     { name = "pytest" },
@@ -948,9 +949,8 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.13" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.48.0" },
-    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.37.23" },
-    { name = "boto3-stubs", extras = ["bedrock-runtime"], marker = "extra == 'bedrock'", specifier = ">=1.37.23" },
     { name = "azure-ai-inference", marker = "extra == 'azure'", specifier = ">=1.0.0b9" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.37.23" },
     { name = "cohere", marker = "extra == 'cohere'", specifier = ">=5.13.4" },
     { name = "fastapi", specifier = ">=0.115.6" },
     { name = "instructor", specifier = ">=1.7.7" },
@@ -968,12 +968,14 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.6.0" },
     { name = "temporalio", marker = "extra == 'temporal'", specifier = ">=1.8.0" },
     { name = "typer", specifier = ">=0.15.1" },
+    { name = "websockets", specifier = ">=12.0" },
 ]
-provides-extras = ["temporal", "anthropic", "openai", "bedrock", "azure", "cohere"]
+provides-extras = ["temporal", "anthropic", "bedrock", "openai", "azure", "cohere"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "anthropic", specifier = ">=0.42.0" },
+    { name = "boto3-stubs", extras = ["bedrock-runtime"], specifier = ">=1.37.23" },
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pydantic", specifier = ">=2.10.4" },
     { name = "pytest", specifier = ">=7.4.0" },
@@ -2052,6 +2054,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423 },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080 },
+    { url = "https://files.pythonhosted.org/packages/d5/4f/b462242432d93ea45f297b6179c7333dd0402b855a912a04e7fc61c0d71f/websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a", size = 173329 },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/6afa1f4644d7ed50284ac59cc70ef8abd44ccf7d45850d989ea7310538d0/websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e", size = 182312 },
+    { url = "https://files.pythonhosted.org/packages/dd/d4/ffc8bd1350b229ca7a4db2a3e1c482cf87cea1baccd0ef3e72bc720caeec/websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf", size = 181319 },
+    { url = "https://files.pythonhosted.org/packages/97/3a/5323a6bb94917af13bbb34009fac01e55c51dfde354f63692bf2533ffbc2/websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb", size = 181631 },
+    { url = "https://files.pythonhosted.org/packages/a6/cc/1aeb0f7cee59ef065724041bb7ed667b6ab1eeffe5141696cccec2687b66/websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d", size = 182016 },
+    { url = "https://files.pythonhosted.org/packages/79/f9/c86f8f7af208e4161a7f7e02774e9d0a81c632ae76db2ff22549e1718a51/websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9", size = 181426 },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/828b0bc6753db905b91df6ae477c0b14a141090df64fb17f8a9d7e3516cf/websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c", size = 181360 },
+    { url = "https://files.pythonhosted.org/packages/89/fb/250f5533ec468ba6327055b7d98b9df056fb1ce623b8b6aaafb30b55d02e/websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256", size = 176388 },
+    { url = "https://files.pythonhosted.org/packages/1c/46/aca7082012768bb98e5608f01658ff3ac8437e563eca41cf068bd5849a5e/websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41", size = 176830 },
+    { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423 },
+    { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082 },
+    { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330 },
+    { url = "https://files.pythonhosted.org/packages/a5/90/1c37ae8b8a113d3daf1065222b6af61cc44102da95388ac0018fcb7d93d9/websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562", size = 182878 },
+    { url = "https://files.pythonhosted.org/packages/8e/8d/96e8e288b2a41dffafb78e8904ea7367ee4f891dafc2ab8d87e2124cb3d3/websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792", size = 181883 },
+    { url = "https://files.pythonhosted.org/packages/93/1f/5d6dbf551766308f6f50f8baf8e9860be6182911e8106da7a7f73785f4c4/websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413", size = 182252 },
+    { url = "https://files.pythonhosted.org/packages/d4/78/2d4fed9123e6620cbf1706c0de8a1632e1a28e7774d94346d7de1bba2ca3/websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8", size = 182521 },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/66d4c1b444dd1a9823c4a81f50231b921bab54eee2f69e70319b4e21f1ca/websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3", size = 181958 },
+    { url = "https://files.pythonhosted.org/packages/08/ff/e9eed2ee5fed6f76fdd6032ca5cd38c57ca9661430bb3d5fb2872dc8703c/websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf", size = 181918 },
+    { url = "https://files.pythonhosted.org/packages/d8/75/994634a49b7e12532be6a42103597b71098fd25900f7437d6055ed39930a/websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85", size = 176388 },
+    { url = "https://files.pythonhosted.org/packages/98/93/e36c73f78400a65f5e236cd376713c34182e6663f6889cd45a4a04d8f203/websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065", size = 176828 },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437 },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096 },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332 },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152 },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096 },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523 },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790 },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165 },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160 },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395 },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841 },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440 },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098 },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329 },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111 },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054 },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496 },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829 },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217 },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195 },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393 },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837 },
+    { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109 },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343 },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599 },
+    { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207 },
+    { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155 },
+    { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884 },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add support for connecting over websockets
- Tested against a real websocket server hosted on smithery.ai. Added this as an example.
- Proposed tests (by AI) but these haven't been tested for correctness yet. Happy to remove these from the PR until package wide testing is figured out.