### PR TITLE
fix: refactor assistant message arguments in OpenAIAugmentedLLM

### DIFF
--- a/examples/mcp_basic_slack_agent/main.py
+++ b/examples/mcp_basic_slack_agent/main.py
@@ -7,6 +7,7 @@ from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
 
 app = MCPApp(name="mcp_basic_agent")
 
+
 async def example_usage():
     async with app.run() as agent_app:
         logger = agent_app.logger

--- a/examples/mcp_github_to_slack_agent/main.py
+++ b/examples/mcp_github_to_slack_agent/main.py
@@ -9,6 +9,7 @@ from rich import print
 
 app = MCPApp(name="github_to_slack")
 
+
 async def github_to_slack(github_owner: str, github_repo: str, slack_channel: str):
     async with app.run() as agent_app:
         context = agent_app.context
@@ -65,12 +66,13 @@ async def github_to_slack(github_owner: str, github_repo: str, slack_channel: st
                 # Execute the workflow
                 print("Executing GitHub to Slack workflow...")
                 await llm.generate_str(prompt)
-                
+
                 print("Workflow completed successfully!")
 
             finally:
                 # Clean up the agent
                 await github_to_slack_agent.close()
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="GitHub to Slack PR Summary Tool")

--- a/examples/mcp_hello_world/main.py
+++ b/examples/mcp_hello_world/main.py
@@ -33,9 +33,12 @@ async def example_usage():
 
             try:
                 filesystem_client = await connection_manager.get_server(
-                    server_name="filesystem", client_session_factory=MCPAgentClientSession
+                    server_name="filesystem",
+                    client_session_factory=MCPAgentClientSession,
                 )
-                logger.info("filesystem: Connected to server with persistent connection.")
+                logger.info(
+                    "filesystem: Connected to server with persistent connection."
+                )
 
                 fetch_client = await connection_manager.get_server(
                     server_name="fetch", client_session_factory=MCPAgentClientSession

--- a/examples/mcp_researcher/main.py
+++ b/examples/mcp_researcher/main.py
@@ -13,6 +13,7 @@ from rich import print
 
 app = MCPApp(name="mcp_root_test")
 
+
 async def example_usage():
     async with app.run() as agent_app:
         folder_path = Path("agent_folder")
@@ -22,13 +23,13 @@ async def example_usage():
 
         # Overwrite the config because full path to agent folder needs to be passed
         context.config.mcp.servers["interpreter"].args = [
-          "run",
-          "-i",
-          "--rm",
-          "--pull=always",
-          "-v",
-          f"{os.path.abspath('agent_folder')}:/mnt/data/",
-          "ghcr.io/evalstate/mcp-py-repl:latest",
+            "run",
+            "-i",
+            "--rm",
+            "--pull=always",
+            "-v",
+            f"{os.path.abspath('agent_folder')}:/mnt/data/",
+            "ghcr.io/evalstate/mcp-py-repl:latest",
         ]
 
         async with MCPConnectionManager(context.server_registry):


### PR DESCRIPTION
This change ensures that the code follows the API reference.

- refactor assistant role arguments of chat completion messages in OpenAIAugmentedLLM to follow [OpenAI API reference](https://platform.openai.com/docs/api-reference/chat/create)
  - `content` and `tool_calls` are optional but not null
- fix code format by lint.py
