### PR TITLE
Update mcp_basic_azure_agent README.md

### DIFF
--- a/examples/mcp_basic_azure_agent/README.md
+++ b/examples/mcp_basic_azure_agent/README.md
@@ -39,5 +39,5 @@ To run the "Finder" agent, navigate to the example directory and execute:
 ```bash
 cd examples/mcp_basic_azure_agent
 
-uv run main.py
+uv run --extra azure main.py
 ```


### PR DESCRIPTION
Solution for `ModuleNotFoundError` when setting up this example.