### PR TITLE
Updating the Github to Slack Agent with Github MCP Server

### DIFF
--- a/examples/mcp_github_to_slack_agent/README.md
+++ b/examples/mcp_github_to_slack_agent/README.md
@@ -21,8 +21,10 @@ This application creates an MCP Agent that monitors GitHub pull requests and sub
 
 - Python 3.10 or higher
 - MCP Agent framework
-- [GitHub MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/github)
+- [GitHub MCP Server](https://github.com/github/github-mcp-server))
 - [Slack MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/slack)
+- Node.js and npm (this is for the Slack server)
+- [Docker](https://www.docker.com/)
 - Access to a GitHub repository
 - Access to a Slack workspace
 
@@ -55,12 +57,9 @@ This application creates an MCP Agent that monitors GitHub pull requests and sub
 uv sync --dev
 ```
 
-2. Create a secrets file:
-```
-cp mcp_agent.secrets.yaml mcp_agent.secrets.yaml
-```
+2. Create a `mcp_agent.secrets.yaml` secrets file
 
-3. Update the secrets file with your API keys
+3. Update the secrets file with your API keys and Tokens
 
 ### Usage
 

--- a/examples/mcp_github_to_slack_agent/mcp_agent.config.yaml
+++ b/examples/mcp_github_to_slack_agent/mcp_agent.config.yaml
@@ -12,8 +12,15 @@ logger:
 mcp:
   servers:
     github:
-      command: "npx"
-      args: ["-y", "@modelcontextprotocol/server-github"]
+      command: "docker"
+      args: [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ]
       description: "Access GitHub API operations"
     slack:
       command: "npx"


### PR DESCRIPTION
Github added their own natively supported MCP Server.

Updating to switch to the natively supported [Github MCP server](https://github.com/github/github-mcp-server).