### PR TITLE
Add support for Gemini models

### DIFF
--- a/examples/mcp_basic_google_agent/README.md
+++ b/examples/mcp_basic_google_agent/README.md
@@ -1,0 +1,40 @@
+# MCP Google Agent Example - "Finder" Agent
+
+This example demonstrates how to create and run a basic "Finder" Agent using Google's Gemini models and MCP. The Agent has access to the `fetch` MCP server, enabling it to retrieve information from URLs.
+
+## Setup
+
+Before running the agent, ensure you have your Gemini Developer API or Vertex AI configuration details set up:
+
+### Required Parameters
+- `api_key`: Your Gemini Developer API key (can also be set via GOOGLE_API_KEY environment variable)
+
+### Optional Parameters
+- `vertexai`: Boolean flag to enable VertexAI integration (default: false)
+- `project`: Google Cloud project ID (required if using VertexAI)
+- `location`: Google Cloud location (required if using VertexAI)
+- `default_model`: Defaults to "gemini-2.0-flash" but can be customized in your config
+
+You can provide these in one of the following ways:
+
+Configuration Options
+1. Via `mcp_agent.secrets.yaml` or `mcp_agent.config.yaml`:
+   ```yaml
+   google:
+     api_key: "your-google-api-key"
+     vertexai: false
+     # Include these if using VertexAI
+     # project: "your-google-cloud-project"
+     # location: "us-central1"
+   ```
+2. Via environment variables (e.g., GOOGLE_API_KEY)
+
+## Running the Agent
+
+To run the "Finder" agent, navigate to the example directory and execute:
+
+```bash
+cd examples/mcp_basic_google_agent
+
+uv run main.py
+```

--- a/examples/mcp_basic_google_agent/main.py
+++ b/examples/mcp_basic_google_agent/main.py
@@ -1,6 +1,8 @@
 import asyncio
 import time
 
+from pydantic import BaseModel
+
 from mcp_agent.app import MCPApp
 from mcp_agent.config import (
     GoogleSettings,
@@ -11,6 +13,13 @@ from mcp_agent.config import (
 )
 from mcp_agent.agents.agent import Agent
 from mcp_agent.workflows.llm.augmented_llm_google import GoogleAugmentedLLM
+
+
+class Essay(BaseModel):
+    title: str
+    body: str
+    conclusion: str
+
 
 settings = Settings(
     execution_engine="asyncio",
@@ -62,6 +71,12 @@ async def example_usage():
                 message="Print the first 2 paragraphs of https://modelcontextprotocol.io/introduction",
             )
             logger.info(f"First 2 paragraphs of Model Context Protocol docs: {result}")
+
+            result = await llm.generate_structured(
+                message="Create a short essay using the first 2 paragraphs.",
+                response_model=Essay,
+            )
+            logger.info(f"Structured paragraphs: {result}")
 
 
 if __name__ == "__main__":

--- a/examples/mcp_basic_google_agent/main.py
+++ b/examples/mcp_basic_google_agent/main.py
@@ -1,0 +1,73 @@
+import asyncio
+import time
+
+from mcp_agent.app import MCPApp
+from mcp_agent.config import (
+    GoogleSettings,
+    Settings,
+    LoggerSettings,
+    MCPSettings,
+    MCPServerSettings,
+)
+from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm_google import GoogleAugmentedLLM
+
+settings = Settings(
+    execution_engine="asyncio",
+    logger=LoggerSettings(type="file", level="debug"),
+    mcp=MCPSettings(
+        servers={
+            "fetch": MCPServerSettings(
+                command="uvx",
+                args=["mcp-server-fetch"],
+            ),
+        }
+    ),
+    google=GoogleSettings(
+        default_model="gemini-2.0-flash",
+    ),
+)
+
+# Settings can either be specified programmatically,
+# or loaded from mcp_agent.config.yaml/mcp_agent.secrets.yaml
+app = MCPApp(
+    name="mcp_basic_agent"
+    # settings=settings
+)
+
+
+async def example_usage():
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+        context = agent_app.context
+
+        logger.info("Current config:", data=context.config.model_dump())
+
+        finder_agent = Agent(
+            name="finder",
+            instruction="""You are an agent with the ability to fetch URLs. Your job is to identify 
+            the closest match to a user's request, make the appropriate tool calls, 
+            and return the URI and CONTENTS of the closest match.""",
+            server_names=["fetch"],
+        )
+
+        async with finder_agent:
+            logger.info("finder: Connected to server, calling list_tools...")
+            result = await finder_agent.list_tools()
+            logger.info("Tools available:", data=result.model_dump())
+
+            llm = await finder_agent.attach_llm(GoogleAugmentedLLM)
+
+            result = await llm.generate_str(
+                message="Print the first 2 paragraphs of https://modelcontextprotocol.io/introduction",
+            )
+            logger.info(f"First 2 paragraphs of Model Context Protocol docs: {result}")
+
+
+if __name__ == "__main__":
+    start = time.time()
+    asyncio.run(example_usage())
+    end = time.time()
+    t = end - start
+
+    print(f"Total run time: {t:.2f}s")

--- a/examples/mcp_basic_google_agent/mcp_agent.config.yaml
+++ b/examples/mcp_basic_google_agent/mcp_agent.config.yaml
@@ -1,0 +1,21 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  transports: [console, file]
+  level: debug
+  show_progress: true
+  path_settings:
+    path_pattern: "logs/mcp-agent-{unique_id}.jsonl"
+    unique_id: "timestamp" # Options: "timestamp" or "session_id"
+    timestamp_format: "%Y%m%d_%H%M%S"
+
+mcp:
+  servers:
+    fetch:
+      command: "uvx"
+      args: ["mcp-server-fetch"]
+
+google:
+  # Secrets (API keys, etc.) are stored in an mcp_agent.secrets.yaml file which can be gitignored
+  default_model: gemini-2.0-flash

--- a/examples/mcp_basic_google_agent/mcp_agent.secrets.yaml.example
+++ b/examples/mcp_basic_google_agent/mcp_agent.secrets.yaml.example
@@ -1,0 +1,5 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+google:
+  default_model: gemini-2.0-flash
+  api_key: changethis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ openai = [
 azure = [
     "azure-ai-inference>=1.0.0b9",
 ]
+google = [
+    "google-genai>=1.10.0",
+]
 cohere = [
     "cohere>=5.13.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "fastapi>=0.115.6",
-    "instructor>=1.7.7",
+    "instructor>=1.7.9",
     "mcp>=1.6.0",
     "opentelemetry-distro>=0.50b0",
     "opentelemetry-exporter-otlp-proto-http>=1.29.0",
@@ -36,7 +36,6 @@ temporal = [
 ]
 anthropic = [
     "anthropic>=0.48.0",
-    "instructor[anthropic]>=1.7.2",
 ]
 bedrock = [
     "boto3>=1.37.23"

--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -498,6 +498,62 @@
       "title": "AzureSettings",
       "type": "object"
     },
+    "GoogleSettings": {
+      "additionalProperties": true,
+      "description": "Settings for using Google models in the MCP Agent application.",
+      "properties": {
+        "api_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Api Key"
+        },
+        "vertexai": {
+          "anyOf": [
+            {
+              "type": "bool"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "title": "Vertex AI"
+        },
+        "project_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Project Id"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        }
+      },
+      "title": "GoogleSettings",
+      "type": "object"
+    },
     "BedrockSettings": {
       "additionalProperties": true,
       "description": "Settings for using AWS Bedrock models in the MCP Agent application.",
@@ -774,6 +830,18 @@
       ],
       "default": null,
       "description": "Settings for using Azure models in the MCP Agent application"
+    },
+    "google": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GoogleSettings"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Settings for using Google models in the MCP Agent application"
     },
     "bedrock": {
       "anyOf": [

--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -526,7 +526,7 @@
           "default": false,
           "title": "Vertex AI"
         },
-        "project_id": {
+        "project": {
           "anyOf": [
             {
               "type": "string"

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -148,6 +148,22 @@ class AzureSettings(BaseModel):
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 
+class GoogleSettings(BaseModel):
+    """
+    Settings for using Google models in the MCP Agent application.
+    """
+
+    api_key: str
+
+    vertexai: bool = False
+
+    project: str | None = None
+
+    location: str | None = None
+
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
+
 class TemporalSettings(BaseModel):
     """
     Temporal settings for the MCP Agent application.
@@ -301,6 +317,9 @@ class Settings(BaseSettings):
 
     azure: AzureSettings | None = None
     """Settings for using Azure models in the MCP Agent application"""
+
+    google: GoogleSettings | None = None
+    """Settings for using Google models in the MCP Agent application"""
 
     otel: OpenTelemetrySettings | None = OpenTelemetrySettings()
     """OpenTelemetry logging settings for the MCP Agent application"""

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -153,7 +153,8 @@ class GoogleSettings(BaseModel):
     Settings for using Google models in the MCP Agent application.
     """
 
-    api_key: str
+    api_key: str | None = None
+    """Or use the GOOGLE_API_KEY environment variable"""
 
     vertexai: bool = False
 

--- a/src/mcp_agent/workflows/llm/augmented_llm.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm.py
@@ -432,3 +432,16 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol[MessageParamT, Message
         """Log a chat finished event"""
         data = {"progress_action": "Finished", "model": model, "agent_name": self.name}
         self.logger.debug("Chat finished", data=data)
+
+
+def image_url_to_mime_and_base64(url: str) -> tuple[str, str]:
+    """
+    Extract mime type and base64 data from ImageUrl
+    """
+    import re
+
+    match = re.match(r"data:(image/\w+);base64,(.*)", url)
+    if not match:
+        raise ValueError(f"Invalid image data URI: {url[:30]}...")
+    mime_type, base64_data = match.groups()
+    return mime_type, base64_data

--- a/src/mcp_agent/workflows/llm/augmented_llm_google.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_google.py
@@ -1,0 +1,463 @@
+from typing import Type
+from google.genai import Client
+from google.genai import types
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolRequest,
+    EmbeddedResource,
+    ImageContent,
+    ModelPreferences,
+    TextContent,
+    TextResourceContents,
+    BlobResourceContents,
+)
+
+from mcp_agent.logging.logger import get_logger
+from mcp_agent.workflows.llm.augmented_llm import (
+    AugmentedLLM,
+    MCPMessageParam,
+    MCPMessageResult,
+    ModelT,
+    ProviderToMCPConverter,
+    RequestParams,
+    image_url_to_mime_and_base64,
+    CallToolResult,
+)
+
+
+class GoogleAugmentedLLM(
+    AugmentedLLM[
+        list[types.Content],
+        list[types.Content],
+    ]
+):
+    """
+    The basic building block of agentic systems is an LLM enhanced with augmentations
+    such as retrieval, tools, and memory provided from a collection of MCP servers.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, type_converter=GoogleMCPTypeConverter, **kwargs)
+
+        self.provider = "Google"
+        # Initialize logger with name if available
+        self.logger = get_logger(f"{__name__}.{self.name}" if self.name else __name__)
+
+        self.model_preferences = self.model_preferences or ModelPreferences(
+            costPriority=0.3,
+            speedPriority=0.4,
+            intelligencePriority=0.3,
+        )
+        # Get default model from config if available
+        default_model = "gemini-2.0-flash"  # Fallback default
+
+        if self.context.config.google:
+            if hasattr(self.context.config.google, "default_model"):
+                default_model = self.context.config.google.default_model
+
+        if self.context.config.google and self.context.config.google.vertexai:
+            self.google_client = Client(
+                vertexai=self.context.config.google.vertexai,
+                project=self.context.config.google.project,
+                location=self.context.config.google.location,
+            )
+        else:
+            self.google_client = Client(api_key=self.context.config.google.api_key)
+
+        self.default_request_params = self.default_request_params or RequestParams(
+            model=default_model,
+            modelPreferences=self.model_preferences,
+            maxTokens=4096,
+            systemPrompt=self.instruction,
+            parallel_tool_calls=True,
+            max_iterations=10,
+            use_history=True,
+        )
+
+    async def generate(self, message, request_params: RequestParams | None = None):
+        """
+        Process a query using an LLM and available tools.
+        The default implementation uses AWS Nova's ChatCompletion as the LLM.
+        Override this method to use a different LLM.
+        """
+
+        messages: list[types.Content] = []
+        params = self.get_request_params(request_params)
+
+        if params.use_history:
+            messages.extend(self.history.get())
+
+        if isinstance(message, str):
+            messages.append(
+                types.Content(role="user", parts=[types.Part.from_text(text=message)])
+            )
+        elif isinstance(message, list):
+            messages.extend(message)
+        else:
+            messages.append(message)
+
+        response = await self.aggregator.list_tools()
+
+        tools = [
+            types.Tool(
+                function_declarations=[
+                    types.FunctionDeclaration(
+                        name=tool.name,
+                        description=tool.description,
+                        parameters=tool.inputSchema,
+                    )
+                ]
+            )
+            for tool in response.tools
+        ]
+
+        responses: list[types.Content] = []
+        model = await self.select_model(params)
+
+        for i in range(params.max_iterations):
+            inference_config = types.GenerateContentConfig(
+                max_output_tokens=params.maxTokens,
+                temperature=params.temperature,
+                stop_sequences=params.stopSequences or [],
+                system_instruction=self.instruction or params.systemPrompt,
+                tools=tools,
+                automatic_function_calling=types.AutomaticFunctionCallingConfig(
+                    disable=True
+                ),
+                candidate_count=1,
+            )
+
+            if params.metadata:
+                inference_config = {**inference_config, **params.metadata}
+
+            arguments = {
+                "model": model,
+                "contents": messages,
+                "config": inference_config,
+            }
+
+            self.logger.debug(f"{arguments}")
+            self._log_chat_progress(chat_turn=(len(messages) + 1) // 2, model=model)
+
+            executor_result = await self.executor.execute(
+                self.google_client.models.generate_content, **arguments
+            )
+
+            response = executor_result[0]
+
+            if isinstance(response, BaseException):
+                self.logger.error(f"Error: {response}")
+                break
+
+            self.logger.debug(f"{model} response:", data=response)
+
+            candidate = response.candidates[0]
+
+            response_as_message = self.convert_message_to_message_param(
+                candidate.content
+            )
+
+            messages.append(response_as_message)
+            responses.append(candidate.content)
+
+            stopReason = candidate.finish_reason
+            if stopReason:
+                self.logger.debug(f"Iteration {i}: {candidate.finish_message}")
+                break
+            else:
+                function_calls = [
+                    self.execute_tool_call(part.function_call)
+                    for part in candidate.content.parts
+                    if part.function_call
+                ]
+
+                results = await self.executor.execute(*function_calls)
+
+                self.logger.debug(
+                    f"Iteration {i}: Tool call results: {str(results) if results else 'None'}"
+                )
+
+                for result in results:
+                    messages.append(result)
+                    responses.append(result)
+
+        if params.use_history:
+            self.history.set(messages)
+
+        self._log_chat_finished(model=model)
+
+        return responses
+
+    async def generate_str(
+        self,
+        message,
+        request_params: RequestParams | None = None,
+    ):
+        """
+        Process a query using an LLM and available tools.
+        The default implementation uses gemini-2.0-flash as the LLM
+        Override this method to use a different LLM.
+        """
+        contents = await self.generate(
+            message=message,
+            request_params=request_params,
+        )
+
+        response = types.GenerateContentResponse(
+            candidates=[
+                types.Candidate(
+                    content=types.Content(
+                        role="model",
+                        parts=[part for content in contents for part in content.parts],
+                    )
+                )
+            ]
+        )
+
+        return response.text
+
+    async def generate_structured(
+        self,
+        message,
+        response_model: Type[ModelT],
+        request_params: RequestParams | None = None,
+    ) -> ModelT:
+        request_params = request_params or RequestParams()
+        metadata = request_params.metadata or {}
+        metadata["response_schema"] = response_model
+
+        structured_response = await self.generate_str(
+            message=message, request_params=request_params
+        )
+        return structured_response
+
+    @classmethod
+    def convert_message_to_message_param(
+        cls, message: types.Content, **kwargs
+    ) -> types.Content:
+        """Convert a response object to an input parameter object to allow LLM calls to be chained."""
+        return message
+
+    async def execute_tool_call(
+        self,
+        function_call: types.FunctionCall,
+    ) -> types.Content | None:
+        """
+        Execute a single tool call and return the result message.
+        Returns None if there's no content to add to messages.
+        """
+        tool_name = function_call.name
+        tool_args = function_call.args
+        tool_call_id = function_call.id
+
+        tool_call_request = CallToolRequest(
+            method="tools/call",
+            params=CallToolRequestParams(name=tool_name, arguments=tool_args),
+        )
+
+        result = await self.call_tool(
+            request=tool_call_request, tool_call_id=tool_call_id
+        )
+
+        # Pass tool_name instead of tool_call_id because Google uses tool_name
+        # to associate function response to function call
+        function_response_content = self.from_mcp_tool_result(result, tool_name)
+
+        return function_response_content
+
+    def message_param_str(self, message: types.Content) -> str:
+        """Convert an input message to a string representation."""
+        # TODO: Jerron - is this sufficient
+        return str(message.model_dump())
+
+    def message_str(self, message: types.Content) -> str:
+        """Convert an output message to a string representation."""
+        # TODO: Jerron - is this sufficient
+        return str(message.model_dump())
+
+
+class GoogleMCPTypeConverter(ProviderToMCPConverter[types.Content, types.Content]):
+    """
+    Convert between Azure and MCP types.
+    """
+
+    @classmethod
+    def from_mcp_message_result(cls, result: MCPMessageResult) -> types.Content:
+        if result.role != "assistant":
+            raise ValueError(
+                f"Expected role to be 'assistant' but got '{result.role}' instead."
+            )
+        if isinstance(result.content, TextContent):
+            return types.Content(
+                role="model", parts=[types.Part.from_text(result.content.text)]
+            )
+        else:
+            return types.Content(
+                role="model",
+                parts=[
+                    types.Part.from_uri(
+                        mime_type=result.content.mimeType,
+                        file_uri=f"data:{result.content.mimeType};base64,{result.content.data}",
+                    )
+                ],
+            )
+
+    @classmethod
+    def from_mcp_message_param(cls, param: MCPMessageParam) -> types.Content:
+        if param.role == "assistant":
+            return types.Content(
+                role="model", parts=[types.Part.from_text(param.content)]
+            )
+        elif param.role == "user":
+            return types.Content(
+                role="user", parts=mcp_content_to_google_parts([param.content])
+            )
+        else:
+            raise ValueError(
+                f"Unexpected role: {param.role}, MCP only supports 'assistant' and 'user'"
+            )
+
+    @classmethod
+    def to_mcp_message_result(cls, result: types.Content) -> MCPMessageResult:
+        contents = google_parts_to_mcp_content(result.parts)
+        if len(contents) > 1:
+            raise NotImplementedError(
+                "Multiple content elements in a single message are not supported in MCP yet"
+            )
+        return MCPMessageResult(
+            role=result.role,
+            content=contents[0],
+            model=None,
+            stopReason=None,
+        )
+
+    @classmethod
+    def to_mcp_message_param(cls, param: types.Content) -> MCPMessageParam:
+        contents = google_parts_to_mcp_content(param.parts)
+
+        # TODO: saqadri - the mcp_content can have multiple elements
+        # while sampling message content has a single content element
+        # Right now we error out if there are > 1 elements in mcp_content
+        # We need to handle this case properly going forward
+        if len(contents) > 1:
+            raise NotImplementedError(
+                "Multiple content elements in a single message are not supported"
+            )
+        elif len(contents) == 0:
+            raise ValueError("No content elements in a message")
+
+        mcp_content: TextContent | ImageContent | EmbeddedResource = contents[0]
+
+        if param.role == "model":
+            return MCPMessageParam(
+                role="assistant",
+                content=mcp_content,
+            )
+        elif param.role == "user":
+            return MCPMessageParam(
+                role="user",
+                content=mcp_content,
+            )
+        elif param.role == "tool":
+            raise NotImplementedError(
+                "Tool messages are not supported in SamplingMessage yet"
+            )
+        else:
+            raise ValueError(
+                f"Unexpected role: {param.role}, MCP only supports 'model', 'user', 'tool'"
+            )
+
+    @classmethod
+    def from_mcp_tool_result(
+        cls, result: CallToolResult, tool_use_id: str
+    ) -> types.Content:
+        """Convert an MCP tool result to an LLM input type"""
+        if result.isError:
+            function_response = {"error": str(result.content)}
+        else:
+            function_response_parts = mcp_content_to_google_parts(result.content)
+            function_response = {"result": function_response_parts}
+
+        function_response_part = types.Part.from_function_response(
+            name=tool_use_id,
+            response=function_response,
+        )
+
+        function_response_content = types.Content(
+            role="tool", parts=[function_response_part]
+        )
+
+        return function_response_content
+
+
+def mcp_content_to_google_parts(
+    content: list[TextContent | ImageContent | EmbeddedResource],
+) -> list[types.Part]:
+    google_parts: list[types.Part] = []
+
+    for block in content:
+        if isinstance(block, TextContent):
+            google_parts.append(types.Part.from_text(text=block.text))
+        elif isinstance(block, ImageContent):
+            google_parts.append(
+                types.Part.from_uri(
+                    file_uri=f"data:{block.mimeType};base64,{block.data}",
+                    mime_type=block.mimeType,
+                )
+            )
+        elif isinstance(block, EmbeddedResource):
+            if isinstance(block.resource, TextResourceContents):
+                google_parts.append(types.Part.from_text(text=block.text))
+            else:
+                google_parts.append(
+                    types.Part.from_uri(
+                        file_uri=f"data:{block.resource.mimeType};base64,{block.resource.blob}",
+                        mime_type=block.resource.mimeType,
+                    )
+                )
+        else:
+            # Last effort to convert the content to a string
+            google_parts.append(types.Part.from_text(text=str(block)))
+    return google_parts
+
+
+def google_parts_to_mcp_content(
+    google_parts: list[types.Part],
+) -> list[TextContent | ImageContent | EmbeddedResource]:
+    mcp_content: list[TextContent | ImageContent | EmbeddedResource] = []
+
+    for part in google_parts:
+        if part.text:
+            mcp_content.append(TextContent(type="text", text=part.text))
+        elif part.file_data:
+            if part.file_data.mime_type.startswith("image/"):
+                mcp_content.append(
+                    ImageContent(
+                        type="image",
+                        mimeType=part.file_data.mime_type,
+                        data=part.file_data.data,
+                    )
+                )
+            else:
+                _, base64_data = image_url_to_mime_and_base64(part.file_data.file_uri)
+                mcp_content.append(
+                    EmbeddedResource(
+                        type="document",
+                        resource=BlobResourceContents(
+                            mimeType=part.file_data.mime_type,
+                            blob=base64_data,
+                        ),
+                    )
+                )
+        elif part.function_call:
+            mcp_content.append(
+                TextContent(
+                    type="text",
+                    text=str(part.function_call),
+                )
+            )
+        else:
+            # Last effort to convert the content to a string
+            mcp_content.append(TextContent(type="text", text=str(part)))
+
+    return mcp_content

--- a/src/mcp_agent/workflows/llm/augmented_llm_google.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_google.py
@@ -275,10 +275,6 @@ class GoogleAugmentedLLM(
         tool_args = function_call.args
         tool_call_id = function_call.id
 
-        if not tool_name or not tool_call_id:
-            self.logger.error("Missing function call name or function call id.")
-            return None
-
         tool_call_request = CallToolRequest(
             method="tools/call",
             params=CallToolRequestParams(name=tool_name, arguments=tool_args),

--- a/uv.lock
+++ b/uv.lock
@@ -134,7 +134,7 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.7.0"
+version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -142,9 +142,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/40/318e58f669b1a9e00f5c4453910682e2d9dd594334539c7b7817dabb765f/anyio-4.7.0.tar.gz", hash = "sha256:2f834749c602966b7d456a7567cafcb309f96482b5081d14ac93ccd457f9dd48", size = 177076 }
+sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/7a/4daaf3b6c08ad7ceffea4634ec206faeff697526421c20f07628c7372156/anyio-4.7.0-py3-none-any.whl", hash = "sha256:ea60c3723ab42ba6fff7e8ccb0488c898ec538ff4df1f1d5e642c3601d07e352", size = 93052 },
+    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916 },
 ]
 
 [[package]]
@@ -250,6 +250,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f6/23/f089e30c79172f17adb27b71d7f43015c09b91448ce6d23dc168fba663ae/botocore_stubs-1.37.23.tar.gz", hash = "sha256:3791f463ce9414811c96e29ab6602bc806a98cb46b1d55da13ff945de190e5b6", size = 42153 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/ec/65d2f9199a8de523be0785d71473110c895a1767c03dd59b2e9f55b687d2/botocore_stubs-1.37.23-py3-none-any.whl", hash = "sha256:13a89baddd3243506d4649999de094faf3e6c1ef2231820e50ac953187940e70", size = 65424 },
+]
+
+[[package]]
+name = "cachetools"
+version = "5.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080 },
 ]
 
 [[package]]
@@ -560,6 +569,38 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/11/de70dee31455c546fbc88301971ec03c328f3d1138cfba14263f651e9551/fsspec-2024.12.0.tar.gz", hash = "sha256:670700c977ed2fb51e0d9f9253177ed20cbde4a3e5c0283cc5385b5870c8533f", size = 291600 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/86/5486b0188d08aa643e127774a99bac51ffa6cf343e3deb0583956dca5b22/fsspec-2024.12.0-py3-none-any.whl", hash = "sha256:b520aed47ad9804237ff878b504267a3b0b441e97508bd6d2d8774e3db85cee2", size = 183862 },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/eb/d504ba1daf190af6b204a9d4714d457462b486043744901a6eeea711f913/google_auth-2.38.0.tar.gz", hash = "sha256:8285113607d3b80a3f1543b75962447ba8a09fe85783432a784fdeef6ac094c4", size = 270866 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/47/603554949a37bca5b7f894d51896a9c534b9eab808e2520a748e081669d0/google_auth-2.38.0-py2.py3-none-any.whl", hash = "sha256:e7dae6694313f434a2727bf2906f27ad259bae090d7aa896590d86feec3d9d4a", size = 210770 },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "google-auth" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/7a/224e2f70c835202042969685ee3da00a6475508d1b64f0f1e90144f96beb/google_genai-1.10.0.tar.gz", hash = "sha256:f59423e0f155dc66b7792c8a0e6724c75c72dc699d1eb7907d4d0006d4f6186f", size = 156355 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/a0/56839a2e202d79c773edd1c1db124da8eb2a7b657267a888080b678d0369/google_genai-1.10.0-py3-none-any.whl", hash = "sha256:41b105a2fcf8a027fc45cc16694cd559b8cd1272eab7345ad58cfa2c353bf34f", size = 154705 },
 ]
 
 [[package]]
@@ -896,6 +937,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "fastapi" },
+    { name = "google-genai" },
     { name = "instructor" },
     { name = "mcp" },
     { name = "numpy" },
@@ -915,12 +957,11 @@ anthropic = [
     { name = "anthropic" },
     { name = "instructor", extra = ["anthropic"] },
 ]
-bedrock = [
-    { name = "boto3" },
-    { name = "boto3-stubs", extra = ["bedrock-runtime"] },
-]
 azure = [
     { name = "azure-ai-inference" },
+]
+bedrock = [
+    { name = "boto3" },
 ]
 cohere = [
     { name = "cohere" },
@@ -935,6 +976,7 @@ temporal = [
 [package.dev-dependencies]
 dev = [
     { name = "anthropic" },
+    { name = "boto3-stubs", extra = ["bedrock-runtime"] },
     { name = "pre-commit" },
     { name = "pydantic" },
     { name = "pytest" },
@@ -948,11 +990,11 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.13" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.48.0" },
-    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.37.23" },
-    { name = "boto3-stubs", extras = ["bedrock-runtime"], marker = "extra == 'bedrock'", specifier = ">=1.37.23" },
     { name = "azure-ai-inference", marker = "extra == 'azure'", specifier = ">=1.0.0b9" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.37.23" },
     { name = "cohere", marker = "extra == 'cohere'", specifier = ">=5.13.4" },
     { name = "fastapi", specifier = ">=0.115.6" },
+    { name = "google-genai", specifier = ">=1.10.0" },
     { name = "instructor", specifier = ">=1.7.7" },
     { name = "instructor", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.7.2" },
     { name = "mcp", specifier = ">=1.6.0" },
@@ -969,11 +1011,12 @@ requires-dist = [
     { name = "temporalio", marker = "extra == 'temporal'", specifier = ">=1.8.0" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
-provides-extras = ["temporal", "anthropic", "openai", "bedrock", "azure", "cohere"]
+provides-extras = ["temporal", "anthropic", "bedrock", "openai", "azure", "cohere"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "anthropic", specifier = ">=0.42.0" },
+    { name = "boto3-stubs", extras = ["bedrock-runtime"], specifier = ">=1.37.23" },
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pydantic", specifier = ">=2.10.4" },
     { name = "pytest", specifier = ">=7.4.0" },
@@ -1429,6 +1472,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135 },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259 },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1660,6 +1724,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/65/7d973b89c4d2351d7fb232c2e452547ddfa243e93131e7cfa766da627b52/rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21", size = 29711 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7", size = 34315 },
 ]
 
 [[package]]
@@ -2052,6 +2128,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423 },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080 },
+    { url = "https://files.pythonhosted.org/packages/d5/4f/b462242432d93ea45f297b6179c7333dd0402b855a912a04e7fc61c0d71f/websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a", size = 173329 },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/6afa1f4644d7ed50284ac59cc70ef8abd44ccf7d45850d989ea7310538d0/websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e", size = 182312 },
+    { url = "https://files.pythonhosted.org/packages/dd/d4/ffc8bd1350b229ca7a4db2a3e1c482cf87cea1baccd0ef3e72bc720caeec/websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf", size = 181319 },
+    { url = "https://files.pythonhosted.org/packages/97/3a/5323a6bb94917af13bbb34009fac01e55c51dfde354f63692bf2533ffbc2/websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb", size = 181631 },
+    { url = "https://files.pythonhosted.org/packages/a6/cc/1aeb0f7cee59ef065724041bb7ed667b6ab1eeffe5141696cccec2687b66/websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d", size = 182016 },
+    { url = "https://files.pythonhosted.org/packages/79/f9/c86f8f7af208e4161a7f7e02774e9d0a81c632ae76db2ff22549e1718a51/websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9", size = 181426 },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/828b0bc6753db905b91df6ae477c0b14a141090df64fb17f8a9d7e3516cf/websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c", size = 181360 },
+    { url = "https://files.pythonhosted.org/packages/89/fb/250f5533ec468ba6327055b7d98b9df056fb1ce623b8b6aaafb30b55d02e/websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256", size = 176388 },
+    { url = "https://files.pythonhosted.org/packages/1c/46/aca7082012768bb98e5608f01658ff3ac8437e563eca41cf068bd5849a5e/websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41", size = 176830 },
+    { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423 },
+    { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082 },
+    { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330 },
+    { url = "https://files.pythonhosted.org/packages/a5/90/1c37ae8b8a113d3daf1065222b6af61cc44102da95388ac0018fcb7d93d9/websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562", size = 182878 },
+    { url = "https://files.pythonhosted.org/packages/8e/8d/96e8e288b2a41dffafb78e8904ea7367ee4f891dafc2ab8d87e2124cb3d3/websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792", size = 181883 },
+    { url = "https://files.pythonhosted.org/packages/93/1f/5d6dbf551766308f6f50f8baf8e9860be6182911e8106da7a7f73785f4c4/websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413", size = 182252 },
+    { url = "https://files.pythonhosted.org/packages/d4/78/2d4fed9123e6620cbf1706c0de8a1632e1a28e7774d94346d7de1bba2ca3/websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8", size = 182521 },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/66d4c1b444dd1a9823c4a81f50231b921bab54eee2f69e70319b4e21f1ca/websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3", size = 181958 },
+    { url = "https://files.pythonhosted.org/packages/08/ff/e9eed2ee5fed6f76fdd6032ca5cd38c57ca9661430bb3d5fb2872dc8703c/websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf", size = 181918 },
+    { url = "https://files.pythonhosted.org/packages/d8/75/994634a49b7e12532be6a42103597b71098fd25900f7437d6055ed39930a/websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85", size = 176388 },
+    { url = "https://files.pythonhosted.org/packages/98/93/e36c73f78400a65f5e236cd376713c34182e6663f6889cd45a4a04d8f203/websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065", size = 176828 },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437 },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096 },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332 },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152 },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096 },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523 },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790 },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165 },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160 },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395 },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841 },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440 },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098 },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329 },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111 },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054 },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496 },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829 },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217 },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195 },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393 },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837 },
+    { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109 },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343 },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599 },
+    { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207 },
+    { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155 },
+    { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884 },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -720,7 +720,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.7.7"
+version = "1.7.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -735,9 +735,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/83/5d257d1c4a93e7b24df4617fa299d7809b0e756d7ff733cc60aaeb63f0f7/instructor-1.7.7.tar.gz", hash = "sha256:ed91c5cdbd1eca53420e852a803b8281055459dee834f1bd315e5f3824d463f5", size = 67500094 }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/ff/a1b8d008c774bf88dbc13120719f4ab24b9c869b4dd30dc9bd49a9dcc58e/instructor-1.7.9.tar.gz", hash = "sha256:3b7ff9119b386ebdc3c683a8af3c6461f424b9d80795d5e12676990b8379dd8a", size = 69063860 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/23/aa5aa221c50c1775d8fd19e9f662909bc4cd6ef461630ee58a4f2637f037/instructor-1.7.7-py3-none-any.whl", hash = "sha256:a6565dc0a299d6b3761c7a225e83477c8956762d0d5c7e06fb0c3dd07cd705c6", size = 83921 },
+    { url = "https://files.pythonhosted.org/packages/e5/a1/aa7d1ff14070ab55f1e915566b47f8f94f7d21531276320d9a0d5ac74165/instructor-1.7.9-py3-none-any.whl", hash = "sha256:8050c3de3e38680a7fa8de03e52bb644d0cb3d5fab38fee4343977db74ed77bc", size = 86010 },
 ]
 
 [package.optional-dependencies]
@@ -937,7 +937,6 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "fastapi" },
-    { name = "google-genai" },
     { name = "instructor" },
     { name = "mcp" },
     { name = "numpy" },
@@ -965,6 +964,9 @@ bedrock = [
 ]
 cohere = [
     { name = "cohere" },
+]
+google = [
+    { name = "google-genai" },
 ]
 openai = [
     { name = "openai" },
@@ -994,8 +996,8 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.37.23" },
     { name = "cohere", marker = "extra == 'cohere'", specifier = ">=5.13.4" },
     { name = "fastapi", specifier = ">=0.115.6" },
-    { name = "google-genai", specifier = ">=1.10.0" },
-    { name = "instructor", specifier = ">=1.7.7" },
+    { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.10.0" },
+    { name = "instructor", specifier = ">=1.7.9" },
     { name = "instructor", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.7.2" },
     { name = "mcp", specifier = ">=1.6.0" },
     { name = "numpy", specifier = ">=2.1.3" },
@@ -1011,7 +1013,7 @@ requires-dist = [
     { name = "temporalio", marker = "extra == 'temporal'", specifier = ">=1.8.0" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
-provides-extras = ["temporal", "anthropic", "bedrock", "openai", "azure", "cohere"]
+provides-extras = ["temporal", "anthropic", "bedrock", "openai", "azure", "google", "cohere"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Add support for Gemini models. Currently, JSON schema is not compatible with Gemini models, so a 'good effort' conversion is used to transform it into a subset of OpenAPI 3.0, which Gemini supports.

Resolves #93, resolves #121.