### PR TITLE
Fixing absolute path of server in basic/decorator/yaml

### DIFF
--- a/examples/basic/decorator/mcp_agent.config.yaml
+++ b/examples/basic/decorator/mcp_agent.config.yaml
@@ -11,7 +11,7 @@ mcp:
     mcp_root:
       type: "mcp_root"
       command: "uv"
-      args: ["run", "../mcp_root_test/root_test_server.py"]
+      args: ["run", "../../mcp/mcp_root_test/root_test_server.py"]
 
 openai:
   # Secrets (API keys, etc.) are stored in an mcp_agent.secrets.yaml file


### PR DESCRIPTION
When going to `cd examples/basic/decorator` and running the main script with `python main.py` it failed because of a wrong path to the launch server. This PR fixes it.