### PR TITLE
fix: Make LLMIntentClassifier.initialize() asynchronous

### DIFF
--- a/src/mcp_agent/workflows/intent_classifier/intent_classifier_llm.py
+++ b/src/mcp_agent/workflows/intent_classifier/intent_classifier_llm.py
@@ -103,7 +103,7 @@ class LLMIntentClassifier(IntentClassifier):
         self, request: str, top_k: int = 1
     ) -> List[LLMIntentClassificationResult]:
         if not self.initialized:
-            self.initialize()
+            await self.initialize()
 
         classification_instruction = (
             self.classification_instruction or DEFAULT_INTENT_CLASSIFICATION_INSTRUCTION


### PR DESCRIPTION
fix warning when running Intention Classifier: `RuntimeWarning: coroutine 'IntentClassifier.initialize' was never awaited`