### PR TITLE
Fix parallel workflow schema in mcp_agent_server basic example

### DIFF
--- a/examples/basic/mcp_agent_server/server.py
+++ b/examples/basic/mcp_agent_server/server.py
@@ -121,13 +121,13 @@ async def handle_list_tools() -> list[types.Tool]:
                         },
                         "required": ["agent_name", "instruction", "server_names"],
                     },
-                    "required": [
-                        "agent_names",
-                        "instructions",
-                        "message",
-                        "aggregator_agent",
-                    ],
                 },
+                "required": [
+                    "agent_names",
+                    "instructions",
+                    "message",
+                    "aggregator_agent",
+                ],
             },
         ),
         types.Tool(


### PR DESCRIPTION
The schema is incorrect - the required property needed to be promoted to a slightly higher level.