### PR TITLE
fix: Rename and update content conversion functions for OpenAI integration

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -404,7 +404,7 @@ class OpenAIAugmentedLLM(
                 role="tool",
                 tool_call_id=tool_call_id,
                 content="\n".join(
-                    str(mcp_content_to_openai_content(c)) for c in result.content
+                    str(mcp_content_to_openai_content_part(c)) for c in result.content
                 ),
             )
 
@@ -467,7 +467,7 @@ class MCPOpenAITypeConverter(
         return MCPMessageResult(
             role=result.role,
             content=TextContent(type="text", text=result.content),
-            model=None,
+            model="",
             stopReason=None,
             # extras for ChatCompletionMessage fields
             **result.model_dump(exclude={"role", "content"}),
@@ -482,14 +482,14 @@ class MCPOpenAITypeConverter(
             extras = param.model_dump(exclude={"role", "content"})
             return ChatCompletionAssistantMessageParam(
                 role="assistant",
-                content=mcp_content_to_openai_content(param.content),
+                content=[mcp_content_to_openai_content_part(param.content)],
                 **extras,
             )
         elif param.role == "user":
             extras = param.model_dump(exclude={"role", "content"})
             return ChatCompletionUserMessageParam(
                 role="user",
-                content=mcp_content_to_openai_content(param.content),
+                content=[mcp_content_to_openai_content_part(param.content)],
                 **extras,
             )
         else:
@@ -547,16 +547,9 @@ class MCPOpenAITypeConverter(
             )
 
 
-def mcp_content_to_openai_content(
+def mcp_content_to_openai_content_part(
     content: TextContent | ImageContent | EmbeddedResource,
-) -> ChatCompletionContentPartTextParam:
-    if isinstance(content, list):
-        # Handle list of content items
-        return ChatCompletionContentPartTextParam(
-            type="text",
-            text="\n".join(mcp_content_to_openai_content(c) for c in content),
-        )
-
+) -> ChatCompletionContentPartParam:
     if isinstance(content, TextContent):
         return ChatCompletionContentPartTextParam(type="text", text=content.text)
     elif isinstance(content, ImageContent):


### PR DESCRIPTION
Address error due to mismatch in types between `ChatCompletionMessageParam` content and `mcp_content_to_openai_content` response. #25