### PR TITLE
feat: Implement memory sharing for EvaluatorOptimizerLLM

### DIFF
--- a/src/mcp_agent/workflows/evaluator_optimizer/evaluator_optimizer.py
+++ b/src/mcp_agent/workflows/evaluator_optimizer/evaluator_optimizer.py
@@ -150,7 +150,7 @@ class EvaluatorOptimizerLLM(AugmentedLLM[MessageParamT, MessageT]):
         else:
             raise ValueError(f"Unsupported evaluator type: {type(evaluator)}")
         if share_memory:
-            self.evaluator_llm.share_memory_from(self.optimizer_llm)
+            self.evaluator_llm.history = self.optimizer_llm.history
         self.min_rating = min_rating
         self.max_refinements = max_refinements
 

--- a/src/mcp_agent/workflows/llm/augmented_llm.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm.py
@@ -274,26 +274,6 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol[MessageParamT, Message
         self.model_selector = self.context.model_selector
         self.type_converter = type_converter
 
-    def share_memory_from(self, other: "AugmentedLLM"):
-        """
-        Share memory from another AugmentedLLM instance.
-
-        This creates a reference to the other instance's history, meaning both
-        instances will share the same memory object and any changes to history
-        in either instance will be reflected in both.
-
-        Args:
-        other: The AugmentedLLM instance to share memory from
-
-        Raises:
-        ValueError: If other is None or not an AugmentedLLM instance
-        """
-        if other is None:
-            raise ValueError("Cannot share memory from None")
-        if not isinstance(other, AugmentedLLM):
-            raise ValueError("Can only share memory from another AugmentedLLM instance")
-        self.history = other.history
-
     @abstractmethod
     async def generate(
         self,


### PR DESCRIPTION
feat: Implement memory sharing for EvaluatorOptimizerLLM
- Add a shared memory parameter to the EvaluatorOptimizerLLM class.
- Implement the `share_memory_from` method to enable memory sharing functionality.

This change aims to optimize memory management between the evaluator and optimizer.

For example, the `optimizer_llm` is often bound to an MCP server. After invoking the MCP and receiving content, the LLM might sometimes "hallucinate" or produce responses inconsistent with the MCP's returned content. The `evaluator_llm`, when performing its assessment, needs access to the `optimizer_llm`'s memory to better determine if it is hallucinating or generating unexpected output. MeanWhile, optimizer_llm can do better work when having evaluator_llm's memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to enable shared memory between the evaluator and optimizer, allowing them to reference the same history when desired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->