### PR TITLE
feat: Add non-invasive tool filtering for MCP agents

### DIFF
--- a/examples/basic/mcp_tool_filter/README.md
+++ b/examples/basic/mcp_tool_filter/README.md
@@ -1,0 +1,122 @@
+# MCP Tool Filter Example
+
+This example demonstrates a **non-invasive** approach to filtering MCP tools without modifying any core mcp-agent code.
+
+## Overview
+
+The MCP Tool Filter provides:
+- ✅ **Zero code modification** - Works with existing mcp-agent installation
+- ✅ **Dynamic filtering** - Change filters at runtime
+- ✅ **Model agnostic** - Works with any LLM provider
+- ✅ **Minimal overhead** - Simple wrapper pattern
+- ✅ **Flexible rules** - Whitelist, blacklist, or custom logic
+
+## Quick Start
+
+1. **Install dependencies**:
+   ```bash
+   cp mcp_agent.secrets.yaml.example mcp_agent.secrets.yaml
+   # Edit mcp_agent.secrets.yaml with your API keys
+   ```
+
+2. **Run the example**:
+   ```bash
+   python main.py
+   ```
+
+3. **Try the quickstart**:
+   ```bash
+   python quickstart.py
+   ```
+
+## How It Works
+
+The tool filter wraps the LLM's `generate` method to intercept tool listings:
+
+```python
+# 1. Create your agent and LLM as usual
+agent = Agent(name="my_agent", server_names=["filesystem"])
+llm = await agent.attach_llm(OpenAIAugmentedLLM)
+
+# 2. Create a filter
+filter = ToolFilter(allowed=["filesystem_read_file", "filesystem_list_directory"])
+
+# 3. Apply the filter
+apply_tool_filter(llm, filter)
+
+# 4. Use normally - the LLM only sees filtered tools
+result = await llm.generate_str("List the files")
+```
+
+## Filter Types
+
+### 1. Allowed List (Whitelist)
+Only allow specific tools:
+```python
+filter = ToolFilter(allowed=["filesystem_read_file", "filesystem_list_directory"])
+```
+
+### 2. Excluded List (Blacklist)
+Block specific tools:
+```python
+filter = ToolFilter(excluded=["filesystem_delete_file", "filesystem_write_file"])
+```
+
+### 3. Server-Specific Filters
+Different rules for different servers:
+```python
+filter = ToolFilter(
+    server_filters={
+        "filesystem": {"allowed": ["read_file", "list_directory"]},
+        "github": {"excluded": ["delete_repository"]}
+    }
+)
+```
+
+### 4. Custom Filter Function
+Complete control over filtering logic:
+```python
+def my_filter(tool):
+    return "read" in tool.name.lower()
+
+filter = ToolFilter(custom_filter=my_filter)
+```
+
+## Tool Naming Convention
+
+MCP tools are namespaced using the format `server_tool` with underscore as separator:
+
+- Full name: `filesystem_read_file`
+- Server: `filesystem`
+- Tool: `read_file`
+
+The filter intelligently handles both formats:
+- Simple names: `read_file` matches any server's read_file tool
+- Full names: `filesystem_read_file` matches exactly
+
+## Examples in This Directory
+
+- `main.py` - Interactive demo with 4 filtering scenarios
+- `quickstart.py` - Minimal example to get started
+
+## Benefits
+
+1. **Reduced Token Usage**: Fewer tools in prompts = lower costs
+2. **Improved Safety**: Prevent accidental dangerous operations
+3. **Better Focus**: Agents only see relevant tools for their task
+4. **Easy Testing**: Quickly test with different tool sets
+5. **No Lock-in**: Remove filtering anytime without code changes
+
+## Implementation Details
+
+The filter works by:
+1. Wrapping the LLM's `generate` method
+2. Temporarily modifying the agent's `list_tools` method
+3. Filtering the tool list before it's sent to the LLM
+4. Restoring original behavior after each call
+
+This approach:
+- Doesn't modify any source files
+- Works with all LLM providers
+- Has minimal performance impact
+- Can be applied/removed dynamically

--- a/examples/basic/mcp_tool_filter/README.md
+++ b/examples/basic/mcp_tool_filter/README.md
@@ -57,7 +57,7 @@ filter = ToolFilter(allowed=["filesystem_read_file", "filesystem_list_directory"
 ```
 
 ### 2. Excluded List (Blacklist)
-Block specific tools:
+Block-specific tools:
 ```python
 filter = ToolFilter(excluded=["filesystem_delete_file", "filesystem_write_file"])
 ```

--- a/examples/basic/mcp_tool_filter/main.py
+++ b/examples/basic/mcp_tool_filter/main.py
@@ -1,0 +1,212 @@
+"""
+MCP Tool Filter Example
+
+This example demonstrates how to filter MCP tools without modifying any core code.
+"""
+
+import asyncio
+import os
+
+from mcp_agent.app import MCPApp
+from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+from mcp_agent.utils.tool_filter import ToolFilter, apply_tool_filter
+
+
+app = MCPApp(name="mcp_tool_filter")
+
+
+async def example_1_basic_filtering():
+    """Example 1: Basic tool filtering with allowed list"""
+    print("\n=== Example 1: Basic Filtering (Whitelist) ===")
+    
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+        context = agent_app.context
+        
+        # Configure filesystem server
+        if "filesystem" in context.config.mcp.servers:
+            cwd = os.getcwd()
+            if cwd not in context.config.mcp.servers["filesystem"].args:
+                context.config.mcp.servers["filesystem"].args.append(cwd)
+        
+        # Create agent
+        agent = Agent(
+            name="filtered_agent",
+            instruction="You are a helpful file assistant.",
+            server_names=["filesystem"]
+        )
+        
+        async with agent:
+            # Create LLM
+            llm = await agent.attach_llm(OpenAIAugmentedLLM)
+            
+            # Apply filter - only allow read operations
+            filter = ToolFilter(allowed=["filesystem_read_file", "filesystem_list_directory"])
+            apply_tool_filter(llm, filter)
+            
+            logger.info("Filter applied: Only read operations allowed")
+            
+            # Test with a read task
+            result = await llm.generate_str(
+                "Please list the files in the current directory."
+            )
+            logger.info(f"Result: {result}")
+
+
+async def example_2_excluded_filter():
+    """Example 2: Filter using excluded list (blacklist)"""
+    print("\n=== Example 2: Excluded List Filter (Blacklist) ===")
+    
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+        context = agent_app.context
+        
+        if "filesystem" in context.config.mcp.servers:
+            cwd = os.getcwd()
+            if cwd not in context.config.mcp.servers["filesystem"].args:
+                context.config.mcp.servers["filesystem"].args.append(cwd)
+        
+        agent = Agent(
+            name="safe_agent",
+            instruction="You are a safe file assistant that cannot delete or modify files.",
+            server_names=["filesystem"]
+        )
+        
+        async with agent:
+            llm = await agent.attach_llm(OpenAIAugmentedLLM)
+            
+            # Exclude dangerous operations
+            filter = ToolFilter(
+                excluded=[
+                    "filesystem_write_file", 
+                    "filesystem_delete_file",
+                    "filesystem_move_file"
+                ]
+            )
+            apply_tool_filter(llm, filter)
+            
+            logger.info("Filter applied: Write/delete operations excluded")
+            
+            # List available tools
+            tools = await agent.list_tools()
+            logger.info(f"Available tools after filtering: {len(tools.tools)}")
+            for tool in tools.tools:
+                logger.info(f"  - {tool.name}")
+
+
+async def example_3_server_specific():
+    """Example 3: Different filters for different servers"""
+    print("\n=== Example 3: Server-Specific Filtering ===")
+    
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+        context = agent_app.context
+        
+        if "filesystem" in context.config.mcp.servers:
+            cwd = os.getcwd()
+            if cwd not in context.config.mcp.servers["filesystem"].args:
+                context.config.mcp.servers["filesystem"].args.append(cwd)
+        
+        # Agent with multiple servers
+        agent = Agent(
+            name="multi_server_agent",
+            instruction="You are an assistant with file and web access.",
+            server_names=["filesystem", "fetch"]
+        )
+        
+        async with agent:
+            llm = await agent.attach_llm(OpenAIAugmentedLLM)
+            
+            # Server-specific filters
+            filter = ToolFilter(
+                server_filters={
+                    "filesystem": {
+                        "allowed": ["read_file", "list_directory"]
+                    },
+                    "fetch": {
+                        "allowed": ["fetch"]
+                    }
+                }
+            )
+            
+            apply_tool_filter(llm, filter)
+            
+            logger.info("Server-specific filters applied")
+            
+            # Test task
+            result = await llm.generate_str(
+                "Check if there's a README.md file and summarize what this project is about."
+            )
+            logger.info(f"Result: {result}")
+
+
+async def example_4_dynamic_filtering():
+    """Example 4: Change filters during runtime"""
+    print("\n=== Example 4: Dynamic Filtering ===")
+    
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+        
+        agent = Agent(
+            name="dynamic_agent",
+            instruction="You are a helpful assistant.",
+            server_names=["filesystem"]
+        )
+        
+        async with agent:
+            llm = await agent.attach_llm(OpenAIAugmentedLLM)
+            
+            # Start with read-only
+            logger.info("Applying read-only filter...")
+            filter1 = ToolFilter(allowed=["filesystem_read_file", "filesystem_list_directory"])
+            apply_tool_filter(llm, filter1)
+            
+            result = await llm.generate_str("List available tools")
+            logger.info(f"With read-only filter: {result}")
+            
+            # Remove all filters
+            logger.info("\nRemoving all filters...")
+            apply_tool_filter(llm, None)
+            
+            result = await llm.generate_str("List available tools now")
+            logger.info(f"Without filter: {result}")
+
+
+def main():
+    """Run examples"""
+    print("MCP Tool Filter Examples")
+    print("========================")
+    print("\nThis demo shows how to filter MCP tools without modifying core code.")
+    print("Make sure to set up your API keys in mcp_agent.secrets.yaml\n")
+    
+    examples = [
+        ("Basic Filtering (Whitelist)", example_1_basic_filtering),
+        ("Excluded List Filter (Blacklist)", example_2_excluded_filter),
+        ("Server-Specific Filtering", example_3_server_specific),
+        ("Dynamic Filtering", example_4_dynamic_filtering),
+    ]
+    
+    print("Available examples:")
+    for i, (name, _) in enumerate(examples, 1):
+        print(f"{i}. {name}")
+    
+    try:
+        choice = input("\nEnter example number (1-4) or 'all' to run all: ").strip().lower()
+        
+        if choice == 'all':
+            print("\nRunning all examples...")
+            for name, func in examples:
+                print(f"\n{'=' * 60}")
+                asyncio.run(func())
+        elif choice.isdigit() and 1 <= int(choice) <= len(examples):
+            _, func = examples[int(choice) - 1]
+            asyncio.run(func())
+        else:
+            print("Invalid choice. Please run the script again.")
+    except KeyboardInterrupt:
+        print("\nExiting...")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/basic/mcp_tool_filter/main.py
+++ b/examples/basic/mcp_tool_filter/main.py
@@ -210,7 +210,7 @@ def main():
         
         if choice == 'all':
             print("\nRunning all examples...")
-            for name, func in examples:
+            for _, func in examples:
                 print(f"\n{'=' * 60}")
                 asyncio.run(func())
         elif choice.isdigit() and 1 <= int(choice) <= len(examples):

--- a/examples/basic/mcp_tool_filter/mcp_agent.config.yaml
+++ b/examples/basic/mcp_tool_filter/mcp_agent.config.yaml
@@ -1,0 +1,24 @@
+$schema: ../../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  transports: [console, file]
+  level: info
+  progress_display: true
+  path_settings:
+    path_pattern: "logs/mcp-agent-{unique_id}.jsonl"
+    unique_id: "timestamp" # Options: "timestamp" or "session_id"
+    timestamp_format: "%Y%m%d_%H%M%S"
+
+mcp:
+  servers:
+    filesystem:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-filesystem"]
+    fetch:
+      command: "uvx"
+      args: ["mcp-server-fetch"]
+
+openai:
+  # Secrets (API keys, etc.) are stored in an mcp_agent.secrets.yaml file which can be gitignored
+  default_model: "gpt-4o-mini"

--- a/examples/basic/mcp_tool_filter/mcp_agent.secrets.yaml.example
+++ b/examples/basic/mcp_tool_filter/mcp_agent.secrets.yaml.example
@@ -1,0 +1,7 @@
+# Copy this file to mcp_agent.secrets.yaml and add your API keys
+
+openai:
+  api_key: "sk-your-openai-api-key"
+
+anthropic:
+  api_key: "sk-your-anthropic-api-key"

--- a/examples/basic/mcp_tool_filter/quickstart.py
+++ b/examples/basic/mcp_tool_filter/quickstart.py
@@ -6,6 +6,7 @@ This is the minimal code needed to use tool filtering.
 """
 
 import asyncio
+import os
 from mcp_agent.app import MCPApp
 from mcp_agent.agents.agent import Agent
 from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
@@ -16,7 +17,15 @@ async def main():
     # Create app
     app = MCPApp(name="quickstart")
     
-    async with app.run():
+    async with app.run() as agent_app:
+        context = agent_app.context
+        
+        # Configure filesystem server
+        if "filesystem" in context.config.mcp.servers:
+            cwd = os.getcwd()
+            if cwd not in context.config.mcp.servers["filesystem"].args:
+                context.config.mcp.servers["filesystem"].args.append(cwd)
+        
         # Create agent
         agent = Agent(
             name="my_agent",

--- a/examples/basic/mcp_tool_filter/quickstart.py
+++ b/examples/basic/mcp_tool_filter/quickstart.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Quickstart example for MCP Tool Filter
+
+This is the minimal code needed to use tool filtering.
+"""
+
+import asyncio
+from mcp_agent.app import MCPApp
+from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+from mcp_agent.utils.tool_filter import ToolFilter, apply_tool_filter
+
+
+async def main():
+    # Create app
+    app = MCPApp(name="quickstart")
+    
+    async with app.run():
+        # Create agent
+        agent = Agent(
+            name="my_agent",
+            instruction="You are a helpful assistant.",
+            server_names=["filesystem"]
+        )
+        
+        async with agent:
+            # Attach LLM
+            llm = await agent.attach_llm(OpenAIAugmentedLLM)
+            
+            # Apply filter - only allow read operations
+            filter = ToolFilter(allowed=["filesystem_read_file", "filesystem_list_directory"])
+            apply_tool_filter(llm, filter)
+            
+            # Use the filtered LLM
+            result = await llm.generate_str("What files are in the current directory?")
+            print(f"\nResult: {result}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/basic/mcp_tool_filter/requirements.txt
+++ b/examples/basic/mcp_tool_filter/requirements.txt
@@ -1,0 +1,6 @@
+# Core framework dependency
+mcp-agent @ file://../../../  # Link to the local mcp-agent project root
+
+# Additional dependencies specific to this example
+anthropic
+openai

--- a/src/mcp_agent/utils/tool_filter.py
+++ b/src/mcp_agent/utils/tool_filter.py
@@ -5,7 +5,7 @@ This module provides a non-invasive way to filter MCP tools at the LLM level,
 allowing you to control which tools are available without modifying the core code.
 """
 
-from typing import List, Set, Dict, Optional, Callable
+from typing import List, Dict, Optional, Callable
 from mcp.types import Tool
 
 from mcp_agent.logging.logger import get_logger

--- a/src/mcp_agent/utils/tool_filter.py
+++ b/src/mcp_agent/utils/tool_filter.py
@@ -1,0 +1,196 @@
+"""
+Lightweight tool filtering utilities for mcp-agent.
+
+This module provides a non-invasive way to filter MCP tools at the LLM level,
+allowing you to control which tools are available without modifying the core code.
+"""
+
+from typing import List, Set, Dict, Optional, Callable, Union
+from mcp.types import Tool
+
+from mcp_agent.logging.logger import get_logger
+
+# Use the project's logger system
+logger = get_logger(__name__)
+
+
+class ToolFilter:
+    """
+    A simple tool filter that can be applied to any LLM instance.
+    
+    Usage:
+        # Create a filter
+        filter = ToolFilter(allowed=["read_file", "list_directory"])
+        
+        # Apply to an LLM
+        filtered_llm = apply_tool_filter(llm, filter)
+    """
+    
+    def __init__(
+        self,
+        allowed: Optional[List[str]] = None,
+        excluded: Optional[List[str]] = None,
+        server_filters: Optional[Dict[str, Dict[str, List[str]]]] = None,
+        custom_filter: Optional[Callable[[Tool], bool]] = None
+    ):
+        """
+        Initialize a tool filter.
+        
+        Args:
+            allowed: Global list of allowed tool names (whitelist)
+            excluded: Global list of excluded tool names (blacklist)
+            server_filters: Server-specific filters, e.g.:
+                {
+                    "filesystem": {"allowed": ["read_file"], "excluded": ["delete_file"]},
+                    "github": {"allowed": ["search_repositories"]}
+                }
+            custom_filter: Custom filter function that takes a Tool and returns bool
+        
+        Priority:
+            1. custom_filter (if provided)
+            2. allowed list (if specified)
+            3. excluded list (if specified)
+            4. Default: allow all
+        """
+        self.allowed_global = set(allowed) if allowed else None
+        self.excluded_global = set(excluded) if excluded else None
+        self.server_filters = server_filters or {}
+        self.custom_filter = custom_filter
+    
+    def should_include_tool(self, tool: Tool) -> bool:
+        """
+        Determine if a tool should be included.
+        
+        Args:
+            tool: The tool to check
+            
+        Returns:
+            True if the tool should be included, False otherwise
+        """
+        # Custom filter takes precedence
+        if self.custom_filter:
+            return self.custom_filter(tool)
+        
+        tool_name = tool.name
+        server_name = None
+        
+        # Extract server name from namespaced tools (format: "server_toolname")
+        if "_" in tool_name:
+            # First, try to match against known server filters
+            if self.server_filters:
+                # Check all configured server names, preferring longer matches
+                # This handles cases where server names might contain underscores
+                for srv_name in sorted(self.server_filters.keys(), key=len, reverse=True):
+                    prefix = srv_name + "_"
+                    if tool_name.startswith(prefix):
+                        server_name = srv_name
+                        tool_name = tool_name[len(prefix):]
+                        break
+            
+            # If no server filter matched, try simple split for global filters
+            # This assumes the first part before "_" is the server name
+            if server_name is None:
+                parts = tool_name.split("_", 1)
+                if len(parts) == 2:
+                    # Keep the original tool.name for full name matching
+                    # but also prepare the extracted tool name
+                    server_name = parts[0]
+                    tool_name = parts[1]
+        
+        # Check server-specific filters first
+        if server_name and server_name in self.server_filters:
+            server_filter = self.server_filters[server_name]
+            
+            # Server-specific allowed list
+            if "allowed" in server_filter:
+                return tool_name in server_filter["allowed"]
+            
+            # Server-specific excluded list
+            if "excluded" in server_filter:
+                return tool_name not in server_filter["excluded"]
+        
+        # Check global allowed list
+        if self.allowed_global is not None:
+            return tool.name in self.allowed_global or tool_name in self.allowed_global
+        
+        # Check global excluded list
+        if self.excluded_global is not None:
+            return tool.name not in self.excluded_global and tool_name not in self.excluded_global
+        
+        # Default: include all tools
+        return True
+    
+    def filter_tools(self, tools: List[Tool]) -> List[Tool]:
+        """Filter a list of tools based on the configured rules."""
+        filtered_tools = [tool for tool in tools if self.should_include_tool(tool)]
+        
+        # Log filtering summary
+        if len(filtered_tools) != len(tools):
+            logger.info(f"Tool filtering applied: {len(filtered_tools)}/{len(tools)} tools retained")
+            
+        return filtered_tools
+
+
+def apply_tool_filter(llm_instance, tool_filter: Optional[ToolFilter]):
+    """
+    Apply a tool filter to an LLM instance without modifying its source code.
+    
+    This function wraps the LLM's generate methods to filter tools during execution.
+    
+    Args:
+        llm_instance: An instance of AugmentedLLM (e.g., OpenAIAugmentedLLM)
+        tool_filter: The ToolFilter to apply, or None to remove filtering
+        
+    Returns:
+        The same LLM instance with filtering applied
+        
+    Example:
+        llm = await agent.attach_llm(OpenAIAugmentedLLM)
+        filter = ToolFilter(allowed=["read_file", "list_directory"])
+        apply_tool_filter(llm, filter)
+    """
+    # Store original method
+    if not hasattr(llm_instance, '_original_generate'):
+        llm_instance._original_generate = llm_instance.generate
+    
+    # If no filter, restore original method
+    if tool_filter is None:
+        if hasattr(llm_instance, '_original_generate'):
+            logger.info("Tool filter removed from LLM instance")
+            llm_instance.generate = llm_instance._original_generate
+        return llm_instance
+    
+    # Log filter configuration
+    filter_info = []
+    if tool_filter.allowed_global:
+        filter_info.append(f"allowed: {list(tool_filter.allowed_global)}")
+    if tool_filter.excluded_global:
+        filter_info.append(f"excluded: {list(tool_filter.excluded_global)}")
+    if tool_filter.server_filters:
+        filter_info.append(f"server-specific: {tool_filter.server_filters}")
+    if tool_filter.custom_filter:
+        filter_info.append("custom filter function")
+    
+    logger.info(f"Tool filter applied to LLM instance with: {', '.join(filter_info) if filter_info else 'no constraints'}")
+    
+    # Create wrapper function that applies filtering
+    async def filtered_generate(message, request_params=None):
+        # Temporarily wrap the agent's list_tools method
+        original_list_tools = llm_instance.agent.list_tools
+        
+        async def filtered_list_tools(server_name=None):
+            result = await original_list_tools(server_name)
+            if tool_filter:
+                result.tools = tool_filter.filter_tools(result.tools)
+            return result
+        
+        llm_instance.agent.list_tools = filtered_list_tools
+        try:
+            return await llm_instance._original_generate(message, request_params)
+        finally:
+            llm_instance.agent.list_tools = original_list_tools
+    
+    # Apply the wrapped method
+    llm_instance.generate = filtered_generate
+    
+    return llm_instance

--- a/src/mcp_agent/utils/tool_filter.py
+++ b/src/mcp_agent/utils/tool_filter.py
@@ -5,7 +5,7 @@ This module provides a non-invasive way to filter MCP tools at the LLM level,
 allowing you to control which tools are available without modifying the core code.
 """
 
-from typing import List, Set, Dict, Optional, Callable, Union
+from typing import List, Set, Dict, Optional, Callable
 from mcp.types import Tool
 
 from mcp_agent.logging.logger import get_logger
@@ -194,3 +194,22 @@ def apply_tool_filter(llm_instance, tool_filter: Optional[ToolFilter]):
     llm_instance.generate = filtered_generate
     
     return llm_instance
+
+
+async def get_filtered_tools(agent, tool_filter: Optional[ToolFilter]) -> List[Tool]:
+    """
+    Helper function to get the filtered list of tools.
+    
+    This simulates what tools the LLM would see after filtering.
+    
+    Args:
+        agent: The Agent instance
+        tool_filter: The ToolFilter to apply (or None for no filtering)
+        
+    Returns:
+        List of filtered tools
+    """
+    result = await agent.list_tools()
+    if tool_filter:
+        return tool_filter.filter_tools(result.tools)
+    return result.tools


### PR DESCRIPTION
  ## Summary

  This PR introduces a lightweight, non-invasive tool filtering mechanism for mcp-agent that allows users to control which MCP tools are available to LLMs without modifying any core code.

  ## Motivation

  - Reduce token usage by limiting tools sent to LLMs
  - Improve safety by restricting access to dangerous operations
  - Better focus agents on specific tasks with relevant tools
  - Support dynamic filtering during runtime

  ## Changes

  1. **Added tool filter module** (`src/mcp_agent/utils/tool_filter.py`):
     - `ToolFilter` class with support for whitelist/blacklist filtering
     - Server-specific filtering capabilities
     - Custom filter function support
     - `apply_tool_filter()` function to wrap LLM instances
     - `get_filtered_tools()` helper for programmatic access

  2. **Added comprehensive examples** (`examples/basic/mcp_tool_filter/`):
     - Interactive demo with 4 filtering scenarios
     - Quickstart example for minimal usage
     - Complete documentation and configuration

  ## Key Features

  - ✅ Zero code modification - Works with existing mcp-agent
  - ✅ Dynamic filtering - Change filters at runtime
  - ✅ Model agnostic - Works with any LLM provider
  - ✅ Flexible rules - Whitelist, blacklist, or custom logic
  - ✅ Minimal overhead - Simple wrapper pattern

  ## Usage Example

  ```python
# Create agent and LLM as usual
  agent = Agent(name="my_agent", server_names=["filesystem"])
  llm = await agent.attach_llm(OpenAIAugmentedLLM)

  # Apply filter - only allow read operations
  filter = ToolFilter(allowed=["filesystem_read_file", "filesystem_list_directory"])
  apply_tool_filter(llm, filter)

  # Use normally - the LLM only sees filtered tools
  result = await llm.generate_str("List the files in current directory")

  # Dynamic filter changes
  apply_tool_filter(llm, None)  # Remove all filters
  apply_tool_filter(llm, ToolFilter(excluded=["filesystem_delete_file"]))  # Apply new filter

```
  ## Testing

  The implementation has been tested with:
  - Various filtering scenarios (whitelist, blacklist, server-specific)
  - Dynamic filter changes during runtime
  - Multiple LLM providers (OpenAI, Anthropic)
  
  To run the examples:
  ```bash
  cd examples/basic/mcp_tool_filter
  cp mcp_agent.secrets.yaml.example mcp_agent.secrets.yaml
  # Add your API keys
  python quickstart.py  # Quick demo
  python main.py        # Interactive examples
```
## Implementation Notes

  - The filter works by wrapping the LLM's `generate` method
  - Temporarily modifies `agent.list_tools` during generation
  - Automatically restores original behavior after each call
  - No modifications to mcp-agent source code required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a tool filtering utility enabling dynamic control over accessible tools in MCP agents, supporting whitelist, blacklist, server-specific, and custom filtering logic.
  - Added example scripts and a quickstart guide demonstrating multiple filtering strategies, including runtime changes and server-specific rules.
  - Provided configuration and sample secrets files for easy setup of the MCP Tool Filter examples.

- **Documentation**
  - Added comprehensive README documentation detailing tool filtering features, setup instructions, usage examples, and benefits.

- **Chores**
  - Included a requirements file specifying dependencies needed for running the tool filter examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->