### PR TITLE
Propagate Trace Context to MCP SSE Servers

### DIFF
--- a/examples/tracing/mcp/README.md
+++ b/examples/tracing/mcp/README.md
@@ -1,0 +1,57 @@
+# SSE example
+
+This example shows distributed tracing between a client and an SSE server. `mcp-agent` automatically propagates
+trace context in the client requests to the server; the server should be instrumented with opentelemetry and
+have MCPInstrumentor auto-instrumentation configured (from `openinference-instrumentation-mcp`).
+
+- `server.py` is a simple server that runs on localhost:8000
+- `main.py` is the mcp-agent client that uses the SSE server.py
+
+<img width="1848" alt="image" src="https://github.com/user-attachments/assets/94c1e17c-a8d7-4455-8008-8f02bc404c28" />
+
+## `1` App set up
+
+First, clone the repo and navigate to the tracing/mcp example:
+
+```bash
+git clone https://github.com/lastmile-ai/mcp-agent.git
+cd mcp-agent/examples/tracing/mcp
+```
+
+Install the UV tool (if you don’t have it) to manage dependencies:
+
+```bash
+pip install uv
+
+uv pip install -r requirements.txt
+```
+
+## `2` Set up secrets and environment variables
+
+Copy and configure your secrets and env variables:
+
+```bash
+cp mcp_agent.secrets.yaml.example mcp_agent.secrets.yaml
+```
+
+Then open `mcp_agent.secrets.yaml` and add your api key for your preferred LLM for your MCP servers.
+
+## `3` Configure Jaeger Collector
+
+[Run Jaeger locally](https://www.jaegertracing.io/docs/2.5/getting-started/) and then update the `mcp_agent.config.yaml` for this example to have `otel.otlp_settings.endpoint` point to the collector endpoint (e.g. `http://localhost:4318/v1/traces` is the default for Jaeger via HTTP).
+
+## `4` Run locally
+
+In one terminal, run:
+
+```bash
+uv run server.py
+```
+
+In another terminal, run:
+
+```bash
+uv run main.py
+```
+
+<img width="2160" alt="Image" src="https://github.com/user-attachments/assets/06db5a26-ab07-4454-8e87-295bde7ff6ae" />

--- a/examples/tracing/mcp/main.py
+++ b/examples/tracing/mcp/main.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from dotenv import load_dotenv
+from rich import print
+from mcp.types import CallToolResult
+from mcp_agent.agents.agent import Agent
+from mcp_agent.app import MCPApp
+
+load_dotenv()  # load environment variables from .env
+
+
+async def test_sse():
+    app: MCPApp = MCPApp(name="test-app")
+    async with app.run():
+        print("MCP App initialized.")
+
+        agent: Agent = Agent(
+            name="agent",
+            instruction="You are an assistant",
+            server_names=["mcp_test_server_sse"],
+        )
+
+        async with agent:
+            print(await agent.list_tools())
+            call_tool_result: CallToolResult = await agent.call_tool(
+                "mcp_test_server_sse_get-magic-number"
+            )
+
+            assert call_tool_result.content[0].text == "42"
+            print("SSE test passed!")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_sse())

--- a/examples/tracing/mcp/mcp_agent.config.yaml
+++ b/examples/tracing/mcp/mcp_agent.config.yaml
@@ -1,0 +1,24 @@
+$schema: ../../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  type: file
+  level: debug
+
+mcp:
+  servers:
+    mcp_test_server_sse:
+      transport: sse
+      url: http://localhost:8000/sse
+
+openai:
+  # Secrets (API keys, etc.) are stored in an mcp_agent.secrets.yaml file which can be gitignored
+  default_model: gpt-4o
+
+otel:
+  enabled: true
+  exporters: ["otlp"]
+  # If running jaeger locally, uncomment the following lines and add "otlp" to the exporters list
+  otlp_settings:
+    endpoint: "http://localhost:4318/v1/traces"
+  service_name: "MCPAgentSSEExample"

--- a/examples/tracing/mcp/mcp_agent.secrets.yaml.example
+++ b/examples/tracing/mcp/mcp_agent.secrets.yaml.example
@@ -1,0 +1,7 @@
+$schema: ../../../schema/mcp-agent.config.schema.json
+
+openai:
+  api_key: openai_api_key
+
+anthropic:
+  api_key: anthropic_api_key

--- a/examples/tracing/mcp/requirements.txt
+++ b/examples/tracing/mcp/requirements.txt
@@ -1,0 +1,7 @@
+# Core framework dependency
+mcp-agent @ file://../../../../  # Link to the local mcp-agent project root
+
+# Additional dependencies specific to this example
+anthropic
+openai
+openinference-instrumentation-mcp

--- a/examples/tracing/mcp/server.py
+++ b/examples/tracing/mcp/server.py
@@ -1,0 +1,100 @@
+from typing import Any
+
+import uvicorn
+from mcp import Tool
+from mcp.server import InitializationOptions, NotificationOptions, Server
+from mcp.server.sse import SseServerTransport
+from mcp.types import EmbeddedResource, ImageContent, TextContent
+from openinference.instrumentation.mcp import MCPInstrumentor
+from opentelemetry import trace
+from pydantic import BaseModel, create_model
+from starlette.applications import Starlette
+from starlette.routing import Mount, Route
+
+from mcp_agent.tracing.semconv import GEN_AI_TOOL_NAME
+from mcp_agent.tracing.telemetry import record_attributes, telemetry
+
+
+def _configure_server_otel():
+    """
+    Configure OpenTelemetry for the MCP server.
+    This function sets up the global textmap propagator and initializes the tracer provider.
+    """
+    MCPInstrumentor().instrument()
+
+
+def some_tool_function():
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("some_tool_function") as span:
+        span.set_attribute("example.attribute", "value")
+        result = 42
+        span.set_attribute("result", result)
+        return result
+
+
+def main():
+    sse_server_transport: SseServerTransport = SseServerTransport("/messages/")
+    server: Server = Server("test-service")
+
+    @server.list_tools()
+    @telemetry.traced(kind=trace.SpanKind.SERVER)
+    async def handle_list_tools() -> list[Tool]:
+        # Create an empty schema (or define a real one if you need parameters)
+        EmptyInputSchema = create_model("EmptyInputSchema", __base__=BaseModel)
+
+        return [
+            Tool(
+                name="get-magic-number",
+                description="Returns the magic number",
+                inputSchema=EmptyInputSchema.model_json_schema(),  # Add the required inputSchema
+            )
+        ]
+
+    @server.call_tool()
+    @telemetry.traced(kind=trace.SpanKind.SERVER)
+    async def handle_call_tool(
+        name: str, arguments: dict[str, Any] | None
+    ) -> list[TextContent | ImageContent | EmbeddedResource]:
+        span = trace.get_current_span()
+        res = str(some_tool_function())
+        span.set_attribute(GEN_AI_TOOL_NAME, name)
+        span.set_attribute("result", res)
+        if arguments:
+            record_attributes(span, arguments)
+
+        return [
+            TextContent(type="text", text=res)
+        ]  # Return a list, not awaiting the content
+
+    initialization_options: InitializationOptions = InitializationOptions(
+        server_name=server.name,
+        server_version="1.0.0",
+        capabilities=server.get_capabilities(
+            notification_options=NotificationOptions(),
+            experimental_capabilities={},
+        ),
+    )
+
+    async def handle_sse(request):
+        async with sse_server_transport.connect_sse(
+            scope=request.scope, receive=request.receive, send=request._send
+        ) as streams:
+            await server.run(
+                read_stream=streams[0],
+                write_stream=streams[1],
+                initialization_options=initialization_options,
+            )
+
+    starlette_app: Starlette = Starlette(
+        routes=[
+            Route("/sse", endpoint=handle_sse),
+            Mount("/messages/", app=sse_server_transport.handle_post_message),
+        ],
+    )
+
+    uvicorn.run(starlette_app, host="0.0.0.0", port=8000, log_level=-10000)
+
+
+if __name__ == "__main__":
+    _configure_server_otel()
+    main()

--- a/src/mcp_agent/mcp/mcp_agent_client_session.py
+++ b/src/mcp_agent/mcp/mcp_agent_client_session.py
@@ -237,8 +237,6 @@ class MCPAgentClientSession(ClientSession, ContextDependent):
                         params.model_dump(),
                         MCP_REQUEST_ARGUMENT_KEY,
                     )
-                else:
-                    params = NotificationParams()
 
                 # Propagate trace context in request.params._meta
                 trace_headers = {}


### PR DESCRIPTION
## Summary
For https://github.com/lastmile-ai/mcp-agent/issues/239 -- handle propagating trace context through client request params to MCP servers (SSE).

## Changes
- Update `send_notification` and `send_request` in `mcp_agent_client_session.py` to set `traceparent` and `tracestate` in `params._meta`; NOTE: pydantic requires proper typing for Meta within the params so using the `inject_trace_context` utility would not work without exhaustively re-creating each param subtype
- Remove unused  `MCPRequestTrace` (`inject_trace_context` and `start_span_from_mcp_request`) from telemetry utils for now -- note that `start_span_from_mcp_request` would not work directly anyway since mcp server decorators abstract away the raw request and call the decorated functions with narrowed params

## Testing
Added new example with a client and separate server and see that the tracing joins within a single span

<img width="1619" alt="Screenshot 2025-05-27 at 2 15 13 PM" src="https://github.com/user-attachments/assets/775fabde-e46e-4453-b69c-e0cfb918ba95" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an example demonstrating distributed tracing between a client and SSE server using OpenTelemetry.
	- Added sample server and client scripts, configuration, and setup instructions for tracing with Jaeger.
- **Documentation**
	- Added a detailed README with setup steps, architecture diagrams, and example outputs.
- **Chores**
	- Provided example configuration and secrets files, and a requirements list for dependencies.
- **Refactor**
	- Updated client session to propagate trace context in requests and notifications.
	- Removed a class related to manual trace context handling to streamline telemetry logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->