### PR TITLE
feat: Add additional OpenAI LLM config options

### DIFF
--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -159,6 +159,10 @@ class OpenAISettings(BaseModel):
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
+    user: str | None = None
+
+    default_headers: Dict[str, str] | None = None
+
 
 class AzureSettings(BaseModel):
     """

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -221,6 +221,9 @@ class OpenAIAugmentedLLM(
                     "stop": params.stopSequences,
                     "tools": available_tools,
                 }
+                user_value = getattr(self.context.config.openai, "user", None)
+                if user_value:
+                    arguments["user"] = user_value
                 if self._reasoning(model):
                     arguments = {
                         **arguments,
@@ -842,6 +845,9 @@ class OpenAICompletionTasks:
             base_url=request.config.base_url,
             http_client=request.config.http_client
             if hasattr(request.config, "http_client")
+            else None,
+            default_headers=request.config.default_headers
+            if hasattr(request.config, "default_headers")
             else None,
         )
 


### PR DESCRIPTION
This adds additional, optional config options:
user - to add user argument to requests
default_headers - to add additional default headers

These are needed for example in custom, enterprise API environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying a user identifier and custom HTTP headers when configuring OpenAI model integrations. This enables enhanced customization and control over requests made to OpenAI services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->