### PR TITLE
Remove unnecessary call to init_queue in AsyncEventBus constructor

### DIFF
--- a/src/mcp_agent/logging/transport.py
+++ b/src/mcp_agent/logging/transport.py
@@ -273,7 +273,6 @@ class AsyncEventBus:
         self.listeners: Dict[str, EventListener] = {}
         self._task: asyncio.Task | None = None
         self._running = False
-        self.init_queue()
 
     def init_queue(self):
         if self._running:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the initialization process for background event handling to require explicit activation, improving control over when asynchronous resources are started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->