### PR TITLE
Add tls temporal config

### DIFF
--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -208,6 +208,7 @@ class TemporalSettings(BaseModel):
     max_concurrent_activities: int | None = None
     api_key: str | None = None
     timeout_seconds: int | None = 60
+    tls: bool = False
 
 
 class UsageTelemetrySettings(BaseModel):

--- a/src/mcp_agent/executor/temporal/__init__.py
+++ b/src/mcp_agent/executor/temporal/__init__.py
@@ -260,6 +260,7 @@ class TemporalExecutor(Executor):
                 namespace=self.config.namespace,
                 api_key=self.config.api_key,
                 data_converter=pydantic_data_converter,
+                tls=self.config.tls,
             )
 
         return self.client


### PR DESCRIPTION
Add tls to temporal setting to make tls configuration for temporal client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for enabling or disabling TLS (Transport Layer Security) for Temporal connections via a new setting.
- **Chores**
  - Updated client connection setup to respect the TLS configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->