### PR TITLE
Remove aexit call in mcp aggregator

### DIFF
--- a/src/mcp_agent/mcp/mcp_aggregator.py
+++ b/src/mcp_agent/mcp/mcp_aggregator.py
@@ -225,16 +225,6 @@ class MCPAggregator(ContextDependent):
                                         "Timeout during disconnect_all(), forcing shutdown"
                                     )
 
-                                # Ensure the exit method is called regardless
-                                try:
-                                    await self._persistent_connection_manager.__aexit__(
-                                        None, None, None
-                                    )
-                                except Exception as e:
-                                    logger.error(
-                                        f"Error during connection manager __aexit__: {e}"
-                                    )
-
                                 # Clean up the connection manager from the context
                                 delattr(self.context, "_mcp_connection_manager")
                                 logger.info(


### PR DESCRIPTION
I don't know if this is the best fix.

Temporal workflows when run with non local Temporal instance would get stuck at

1. shutdown_aggregator_task
2. self._persistent_connection_manager.__aexit__
3. self._tg.__aexit__

Then it would eventually error out with "Attempted to exit cancel scope in a different task than it was entered in"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the shutdown process by streamlining cleanup steps for connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->