### PR TITLE
fix(google): Exclude 'additionalProperties' from tool schema

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_google.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_google.py
@@ -539,7 +539,8 @@ def transform_mcp_tool_schema(schema: dict) -> dict:
 
     # Properties to exclude even if they would otherwise be supported
     # 'default' is excluded because Google throws error if included.
-    EXCLUDED_PROPERTIES = {"default"}
+    # 'additionalProperties' is excluded because Google throws an "Unknown name" error.
+    EXCLUDED_PROPERTIES = {"default", "additionalProperties"}
 
     # Special case mappings for camelCase to snake_case conversions
     CAMEL_TO_SNAKE_MAPPINGS = {


### PR DESCRIPTION
# Description
This PR addresses a critical 400 INVALID_ARGUMENT error that occurs when making tool calls to Google's Gemini models (e.g., Gemini 2.5 Pro). The root cause is that the Gemini API does not recognize the additionalProperties field within the function declaration's parameter schema. This field is standard in JSON Schema but is not supported by Gemini's current implementation for tool definitions.
When a tool with a schema containing additionalProperties is passed to the LLM, the API call fails with the following error, preventing any tool-based interaction with Gemini models:

`Invalid JSON payload received. Unknown name "additional_properties" at 'tools[0].function_declarations[0].parameters': Cannot find field.`

# Solution
The fix is implemented within the transform_mcp_tool_schema function in src/mcp_agent/workflows/llm/augmented_llm_google.py.
I have updated the EXCLUDED_PROPERTIES set to include "additionalProperties". This ensures that this unsupported field is stripped from the tool schema before it's sent to the Gemini API. This is a surgical fix that prevents the validation error and allows tool calls to proceed successfully without affecting other schema transformation logic.
## How to Reproduce and Test
1. Configure mcp-agent to use a Google Gemini model (e.g., gemini-2.5-pro-preview-06-05).
2. Define an agent that utilizes a tool whose argument schema resolves to an object (which typically defaults to including additionalProperties: true).
3. Run a workflow that triggers a call to this tool.
4. Before this change: The LLM call will consistently fail with the 400 INVALID_ARGUMENT error.
5. After this change: The LLM call will succeed, and the tool call will be executed as expected.
This change ensures more robust and reliable integration with Google's Gemini models.