### PR TITLE
Set llm instruction in attach llm

### DIFF
--- a/src/mcp_agent/agents/agent.py
+++ b/src/mcp_agent/agents/agent.py
@@ -168,6 +168,8 @@ class Agent(BaseModel):
             if llm:
                 self.llm = llm
                 llm.agent = self
+                if not llm.instruction:
+                    llm.instruction = self.instruction
             elif llm_factory:
                 self.llm = llm_factory(agent=self)
             else:


### PR DESCRIPTION
Follow up to this commit https://github.com/lastmile-ai/mcp-agent/commit/54463c308f0eb2423b60f995e90169557cebd6de

`attach_llm` should set all the fields of the LLM instance as if the agent is being passed into `AugmentedLLM.init`

`AugmentedLLM` will always set a default name, so not setting name here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that language model instances automatically inherit the agent's instructions if they do not already have their own instructions set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->