### PR TITLE
fix: Add user request param and missing default_headers

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm.py
@@ -157,6 +157,12 @@ class RequestParams(CreateMessageRequestParams):
     The likelihood of the model selecting higher-probability options while generating a response.
     """
 
+    user: str | None = None
+    """
+    The user to use for the LLM generation.
+    This is used to stable identify the user in the LLM provider's logs.
+    """
+
 
 class AugmentedLLMProtocol(Protocol, Generic[MessageParamT, MessageT]):
     """Protocol defining the interface for augmented LLMs"""

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -883,6 +883,9 @@ class OpenAICompletionTasks:
                 http_client=request.config.http_client
                 if hasattr(request.config, "http_client")
                 else None,
+                default_headers=request.config.default_headers
+                if hasattr(request.config, "default_headers")
+                else None
             ),
             mode=instructor.Mode.TOOLS_STRICT,
         )
@@ -905,6 +908,9 @@ class OpenAICompletionTasks:
                     http_client=request.config.http_client
                     if hasattr(request.config, "http_client")
                     else None,
+                    default_headers=request.config.default_headers
+                    if hasattr(request.config, "default_headers")
+                    else None
                 ),
                 mode=instructor.Mode.JSON,
             )


### PR DESCRIPTION
This adds in addition to 6799107f9 the user as option for request params [^1]. Also fixing the missing option for default_headers in structured completion.

[^1]: https://platform.openai.com/docs/guides/safety-best-practices#end-user-ids