### PR TITLE
fix: Adding user to OpenAIAugmentedLLM generate_structured

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -75,6 +75,7 @@ class RequestStructuredCompletionRequest(BaseModel):
     serialized_response_model: str | None = None
     response_str: str
     model: str
+    user: str | None = None
 
 
 class OpenAIAugmentedLLM(
@@ -458,6 +459,8 @@ class OpenAIAugmentedLLM(
                     serialized_response_model=serialized_response_model,
                     response_str=response,
                     model=model,
+                    user=params.user or getattr(self.context.config.openai,
+                                                "user", None),
                 ),
             )
             # TODO: saqadri (MAC) - fix request_structured_completion_task to return ensure_serializable
@@ -914,6 +917,7 @@ class OpenAICompletionTasks:
                 messages=[
                     {"role": "user", "content": request.response_str},
                 ],
+                user=request.user,
             )
         except InstructorRetryException:
             # Retry the request with JSON mode
@@ -937,6 +941,7 @@ class OpenAICompletionTasks:
                 messages=[
                     {"role": "user", "content": request.response_str},
                 ],
+                user=request.user,
             )
 
         return structured_response


### PR DESCRIPTION
Noticed that during generate_structured the user was not passed. This should add it in case configured or individually set to request params.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for including an optional user identifier in structured completion requests to enhance personalization and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->