### PR TITLE
Fix for workflow signals in temporal

### DIFF
--- a/examples/temporal/interactive.py
+++ b/examples/temporal/interactive.py
@@ -38,7 +38,7 @@ class WorkflowWithInteraction(InteractiveWorkflow[str]):
         Run the workflow, processing the input data.
 
         Args:
-            input_data: The data to process
+            input: The data to process
 
         Returns:
             A WorkflowResult containing the processed data

--- a/examples/temporal/interactive.py
+++ b/examples/temporal/interactive.py
@@ -1,0 +1,73 @@
+"""
+Example of using Temporal as the execution engine for MCP Agent workflows.
+This example demonstrates how to include human interaction through the
+InteractiveWorkflow class, allowing the workflow to pause and wait for user input.
+
+When running this workflow, it will pause for human input. From the temporal UI,
+you can inspect the requested information by going to the "Queries" tab
+and executing the `get_human_input_request` query to see the requested information.
+The response can be provided by sending a signal of type "provide_human_input", 
+with a message body like '{"response": "Your input here"}'
+"""
+
+import asyncio
+import logging
+
+from mcp_agent.agents.agent import Agent
+from mcp_agent.executor.temporal import TemporalExecutor
+from mcp_agent.executor.temporal.interactive_workflow import InteractiveWorkflow
+from mcp_agent.executor.workflow import WorkflowResult
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+from main import app
+
+# Initialize logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@app.workflow
+class WorkflowWithInteraction(InteractiveWorkflow[str]):
+    """
+    A simple workflow that demonstrates the human interaction in a temporal workflow.
+    """
+
+    @app.workflow_run
+    async def run(self, input: str) -> WorkflowResult[str]:
+        """
+        Run the workflow, processing the input data.
+
+        Args:
+            input_data: The data to process
+
+        Returns:
+            A WorkflowResult containing the processed data
+        """
+        poet = Agent(
+            name="poet",
+            instruction="""You are a helpful assistant.""",
+            human_input_callback=self.create_input_callback(),
+        )
+
+        async with poet:
+            finder_llm = await poet.attach_llm(OpenAIAugmentedLLM)
+
+            result = await finder_llm.generate_str(
+                message=input,
+            )
+            return WorkflowResult(value=result)
+
+
+async def main():
+    async with app.run() as agent_app:
+        executor: TemporalExecutor = agent_app.executor
+        handle = await executor.start_workflow(
+            "WorkflowWithInteraction",
+            "Ask the user for a subject, then generate a poem about it.",
+        )
+        a = await handle.result()
+        print(a)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/temporal/run_worker.py
+++ b/examples/temporal/run_worker.py
@@ -15,6 +15,7 @@ from evaluator_optimizer import EvaluatorOptimizerWorkflow  # noqa: F401
 from orchestrator import OrchestratorWorkflow  # noqa: F401
 from parallel import ParallelWorkflow  # noqa: F401
 from router import RouterWorkflow  # noqa: F401
+from interactive import WorkflowWithInteraction  # noqa: F401
 
 from mcp_agent.executor.temporal import create_temporal_worker_for_app
 

--- a/src/mcp_agent/agents/agent.py
+++ b/src/mcp_agent/agents/agent.py
@@ -785,12 +785,19 @@ class Agent(BaseModel):
                                 "metadata": json.dumps(user_input.metadata or {}),
                             },
                         )
+
                     await self.context.executor.signal(
-                        signal_name=request_id, payload=user_input
+                        signal_name=request_id,
+                        payload=user_input,
+                        workflow_id=request.workflow_id,
+                        run_id=request.run_id,
                     )
                 except Exception as e:
                     await self.context.executor.signal(
-                        request_id, payload=f"Error getting human input: {str(e)}"
+                        request_id,
+                        payload=f"Error getting human input: {str(e)}",
+                        workflow_id=request.workflow_id,
+                        run_id=request.run_id,
                     )
 
             asyncio.create_task(call_callback_and_signal())
@@ -899,7 +906,9 @@ class Agent(BaseModel):
     ) -> CallToolResult:
         # Handle human input request
         try:
-            request = HumanInputRequest(**arguments["request"])
+            request = self.context.executor.create_human_input_request(
+                arguments["request"]
+            )
             result: HumanInputResponse = await self.request_human_input(request=request)
             return CallToolResult(
                 content=[

--- a/src/mcp_agent/executor/executor.py
+++ b/src/mcp_agent/executor/executor.py
@@ -18,6 +18,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
+from mcp_agent.human_input.types import HumanInputRequest
 from pydantic import BaseModel, ConfigDict
 
 from mcp_agent.core.context_dependent import ContextDependent
@@ -107,6 +108,13 @@ class Executor(ABC, ContextDependent):
         **kwargs: Any,
     ) -> AsyncIterator[R | BaseException]:
         """Execute tasks and yield results as they complete"""
+
+    @abstractmethod
+    def create_human_input_request(
+        self,
+        request: dict,
+    ) -> HumanInputRequest:
+        """Create a HumanInputRequest for the given request."""
 
     async def map(
         self,
@@ -411,3 +419,15 @@ class AsyncioExecutor(Executor):
             timeout_seconds,
             signal_type,
         )
+
+    def create_human_input_request(self, request: dict) -> HumanInputRequest:
+        """
+        Create a human input request from the arguments.
+
+        Args:
+            request: Optional arguments to include in the request.
+
+        Returns:
+            A HumanInputRequest object.
+        """
+        return HumanInputRequest(**request)

--- a/src/mcp_agent/executor/temporal/__init__.py
+++ b/src/mcp_agent/executor/temporal/__init__.py
@@ -21,6 +21,7 @@ from typing import (
 )
 import inspect
 
+from mcp_agent.human_input.types import HumanInputRequest
 from pydantic import ConfigDict
 from temporalio import activity, workflow, exceptions
 from temporalio.client import Client as TemporalClient, WorkflowHandle
@@ -366,6 +367,22 @@ class TemporalExecutor(Executor):
         """
         return await self.start_workflow(
             workflow_type, *workflow_args, wait_for_result=True, **workflow_kwargs
+        )
+
+    def create_human_input_request(self, request: dict) -> HumanInputRequest:
+        """
+        Create a human input request from the arguments.
+
+        Args:
+            request: Optional arguments to include in the request.
+
+        Returns:
+            A HumanInputRequest object with workflow_id and run_id populated.
+        """
+        return HumanInputRequest(
+            **request,
+            workflow_id=workflow.info().workflow_id,
+            run_id=workflow.info().run_id,
         )
 
     async def terminate_workflow(

--- a/src/mcp_agent/executor/temporal/interactive_workflow.py
+++ b/src/mcp_agent/executor/temporal/interactive_workflow.py
@@ -1,0 +1,84 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from mcp_agent.executor.workflow import Workflow
+from mcp_agent.human_input.types import HumanInputRequest, HumanInputResponse
+from mcp_agent.logging.logger import get_logger
+
+from temporalio import workflow
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+
+@dataclass
+class HumanResponse:
+    response: str
+
+
+class InteractiveWorkflow(Workflow[T], Generic[T]):
+    """
+    A workflow with support for handling human input requests and responses.
+
+    Example:
+        To use this workflow, create a workflow like this:
+
+        @app.workflow
+        class MyWorkflow(InteractiveWorkflow):
+            @app.workflow_run
+            async def run(self, input: str) -> WorkflowResult[str]:
+                interactive_agent = Agent(
+                    name="basic_interactive_agent",
+                    instruction="You are a helpful assistant that can interact with the user.",
+                    human_input_callback=self.create_input_callback(), # <--- this enables human input handling
+                )
+
+                # etc.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._lock = asyncio.Lock()
+        self._request: HumanInputRequest = None
+        self._response: str = None
+
+    @workflow.query
+    def get_human_input_request(self) -> str:
+        """
+        A query returning the current human input request as a JSON string, if any.
+        """
+        if self._request is None:
+            return "{}"
+        return self._request.model_dump_json(include={'prompt', 'description'})
+
+    @workflow.signal
+    async def provide_human_input(self, input: HumanResponse) -> None:
+        """
+        Signal to set the human input response.
+        """
+        async with self._lock:
+            self._request = None
+            self._response = input.response.strip()
+
+    def create_input_callback(self) -> callable:
+        """
+        Create a callback function that can be used to handle human input requests.
+        """
+
+        async def input_callback(request: HumanInputRequest) -> HumanInputResponse:
+            self._response = None
+            self._request = request
+
+            await workflow.wait_condition(lambda: self._response is not None)
+
+            if self._response is None:
+                logger.warning("Input request timed out after")
+                return HumanInputResponse(request_id=request.request_id, response="")
+
+            return HumanInputResponse(
+                request_id=request.request_id, response=self._response
+            )
+
+        return input_callback

--- a/src/mcp_agent/executor/temporal/interactive_workflow.py
+++ b/src/mcp_agent/executor/temporal/interactive_workflow.py
@@ -74,7 +74,7 @@ class InteractiveWorkflow(Workflow[T], Generic[T]):
             await workflow.wait_condition(lambda: self._response is not None)
 
             if self._response is None:
-                logger.warning("Input request timed out after")
+                logger.warning("Input request timed out")
                 return HumanInputResponse(request_id=request.request_id, response="")
 
             return HumanInputResponse(

--- a/src/mcp_agent/human_input/types.py
+++ b/src/mcp_agent/human_input/types.py
@@ -19,6 +19,9 @@ class HumanInputRequest(BaseModel):
     workflow_id: str | None = None
     """Optional workflow ID if using workflow engine"""
 
+    run_id: str | None = None
+    """Optional run ID if using workflow engine"""
+
     timeout_seconds: int | None = None
     """Optional timeout in seconds"""
 


### PR DESCRIPTION
Discovered two bugs while trying to get human interaction to work from a temporal workflow:

- the HumanInputRequest should include the workflow_id and run_id, so that when the input is provided, the signal can be sent to the correct workflow
- temporal workflows cannot signal themselves; instead the signal handler can directly add deliver the signal to the mailbox

Also added a helper `InteractiveWorkflow` class that exposes the information asked for by the LLM through a `query`, and a `signal` to provide the requested input. A new example demonstrates how to use this workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive Temporal workflow example demonstrating human-in-the-loop agent workflows with UI-based human input and response handling.
  - Added an `InteractiveWorkflow` class enabling workflows to pause and await user input, featuring query and signal methods for interaction.
- **Enhancements**
  - Enhanced human input request handling by including workflow and run identifiers for precise workflow context association.
  - Standardized human input request creation across executor implementations.
- **Bug Fixes**
  - Prevented workflows from signaling themselves in Temporal to avoid runtime errors.
- **Documentation**
  - Provided usage instructions and example code for running and interacting with the new interactive workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->