### PR TITLE
Add documentation for Elicitation and MCP primitives concepts

### DIFF
--- a/docs/concepts/elicitation.mdx
+++ b/docs/concepts/elicitation.mdx
@@ -1,0 +1,141 @@
+---
+title: "Elicitation"
+description: "Allows MCP servers to request additional information from users."
+---
+
+Elicitation is a powerful feature that allows MCP tools to pause execution and request additional information or confirmation from the user before proceeding. This enables more interactive and controlled tool behavior.
+
+## How It Works
+
+When a tool calls `ctx.elicit()`, it pauses execution and sends a request to the user. The user can then:
+
+- **Accept** the request by providing the requested information
+- **Decline** the request, causing the tool to handle the declined state
+- **Cancel** the request, stopping the tool execution
+
+```python
+# In an MCP server tool
+result = await ctx.elicit(
+    message="Confirm booking for 2 people on June 21st at 5pm?",
+    schema=ConfirmBooking
+)
+
+match result:
+    case AcceptedElicitation(data=data):
+        # User accepted and provided data
+        if data.confirm:
+            return "Booking confirmed!"
+    case DeclinedElicitation():
+        # User declined the request
+        return "Booking declined"
+    case CancelledElicitation():
+        # User cancelled the operation
+        return "Booking cancelled"
+```
+
+## Setting Up Elicitation
+
+### 1. Configure Your MCP App
+
+Your MCP app needs an elicitation callback to handle user interactions:
+
+```python
+from mcp_agent.app import MCPApp
+from mcp_agent.elicitation.handler import console_elicitation_callback
+
+app = MCPApp(
+    name="my_agent",
+    elicitation_callback=console_elicitation_callback,
+)
+```
+
+When elicitation is triggered, users see an interactive prompt like this:
+
+```
+ELICITATION RESPONSE NEEDED FROM: demo_server
+
+Elicitation Request
+
+Confirm booking for 2 on 2023-06-21T17:00:00?
+
+Type / to see available commands
+
+──────────────────────────────────────────────
+
+Enter confirm - Confirm booking?
+Type / to see available commands
+Enter: true/false, yes/no, y/n, or 1/0
+> 
+```
+
+### 2. Create Tools with Elicitation
+
+In your MCP server, define tools that use elicitation:
+
+```python
+from mcp.server.fastmcp import FastMCP, Context
+from mcp.server.elicitation import AcceptedElicitation, DeclinedElicitation, CancelledElicitation
+from pydantic import BaseModel, Field
+
+mcp = FastMCP("My Server")
+
+@mcp.tool()
+async def confirm_action(action: str, ctx: Context) -> str:
+    """Perform an action with user confirmation"""
+    
+    class ConfirmAction(BaseModel):
+        confirm: bool = Field(description="Confirm the action?")
+        notes: str = Field(default="", description="Additional notes")
+    
+    result = await ctx.elicit(
+        message=f"Are you sure you want to {action}?",
+        schema=ConfirmAction
+    )
+    
+    match result:
+        case AcceptedElicitation(data=data):
+            if data.confirm:
+                return f"Action '{action}' completed. Notes: {data.notes or 'None'}"
+            return "Action cancelled by user"
+        case DeclinedElicitation():
+            return "Action declined"
+        case CancelledElicitation():
+            return "Action cancelled"
+```
+
+## Schema Requirements
+
+<Warning>
+The elicitation schema must use only primitive types:
+- `str` - Text input
+- `int` - Integer numbers
+- `float` - Decimal numbers  
+- `bool` - True/false values
+
+Complex types like lists, dictionaries, or custom objects are not supported.
+</Warning>
+
+## Use Cases
+
+Elicitation is particularly useful for:
+
+<CardGroup cols={2}>
+  <Card title="Confirmation Dialogs" icon="circle-check">
+    "Are you sure you want to delete this file?"
+  </Card>
+  <Card title="Parameter Collection" icon="input-text">
+    "What's your preferred time for the meeting?"
+  </Card>
+  <Card title="Options Selection" icon="list">
+    "Which format would you like: PDF or Word?"
+  </Card>
+  <Card title="Safety Checks" icon="shield-check">
+    "This action will modify 50 files. Proceed?"
+  </Card>
+</CardGroup>
+
+## Complete Example
+
+<Card title="Elicitation Example" icon="github" href="https://github.com/lastmile-ai/mcp-agent/tree/main/examples/elicitation">
+  View the complete example on GitHub
+</Card>

--- a/docs/concepts/mcp-primitives.mdx
+++ b/docs/concepts/mcp-primitives.mdx
@@ -1,0 +1,180 @@
+---
+title: "MCP Primitives"
+description: "Learn how to use MCP server primitives like resources, prompts, and tools in your agent applications"
+---
+
+# MCP Primitives
+
+MCP (Model Context Protocol) primitives are standardized building blocks that enable agents to access structured data and functionality from MCP servers. This guide shows you how to use the three core MCP primitives: **resources**, **prompts**, and **tools**.
+
+## What are MCP Primitives?
+
+<CardGroup cols={3}>
+  <Card title="Resources" icon="database">
+    Data (files, database schemas, application-specific information) exposed by MCP servers, accessible via URIs
+  </Card>
+  <Card title="Prompts" icon="message-lines">
+    Messages and instructions that can be listed and invoked from MCP servers with parameters
+  </Card>
+  <Card title="Tools" icon="wrench">
+    Interact with external systems, such as querying databases, calling APIs, or performing computations
+  </Card>
+</CardGroup>
+
+## Creating an MCP Server
+
+First, create an MCP server that exposes resources and prompts:
+
+<CodeGroup>
+```python demo_server.py
+from mcp.server.fastmcp import FastMCP
+import datetime
+import json
+
+mcp = FastMCP("Resource Demo MCP Server")
+
+@mcp.resource("demo://docs/readme")
+def get_readme():
+    """Provide the README file content."""
+    return "# Demo Resource Server\n\nThis is a sample README resource."
+
+@mcp.prompt()
+def echo(message: str) -> str:
+    """Echo the provided message.
+    
+    This is a simple prompt that echoes back the input message.
+    """
+    return f"Prompt: {message}"
+
+if __name__ == "__main__":
+    mcp.run()
+```
+</CodeGroup>
+
+## Agent Configuration
+
+Configure your agent to connect to the MCP server:
+
+<CodeGroup>
+```yaml mcp_agent.config.yaml
+$schema: ../../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  transports: [console, file]
+  level: debug
+  progress_display: true
+
+mcp:
+  servers:
+    demo_server:
+      command: "uv"
+      args: ["run", "demo_server.py"]
+      description: "Demo MCP server for resources and prompts"
+
+openai:
+  default_model: "gpt-4o-mini"
+```
+</CodeGroup>
+
+## Using MCP Primitives in Your Agent
+
+Here's how to use MCP primitives in your agent application:
+
+<CodeGroup>
+```python main.py
+import asyncio
+from mcp_agent.app import MCPApp
+from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+app = MCPApp(name="mcp_basic_agent")
+
+async def example_usage():
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+        
+        # Create an agent connected to the demo server
+        agent = Agent(
+            name="agent",
+            instruction="Demo agent for MCP resource and prompt primitives",
+            server_names=["demo_server"],
+        )
+
+        async with agent:
+            # List all available resources
+            resources = await agent.list_resources("demo_server")
+            logger.info("Available resources:", data=resources.model_dump())
+
+            # List all available prompts
+            prompts = await agent.list_prompts("demo_server")
+            logger.info("Available prompts:", data=prompts.model_dump())
+
+            # Get both resource and prompt in a single call
+            combined_messages = await agent.create_prompt(
+                prompt_name="echo",
+                arguments={"message": "My name is John Doe."},
+                resource_uris="demo://docs/readme",
+                server_names=["demo_server"],
+            )
+
+            # Use LLM to process the content
+            llm = await agent.attach_llm(OpenAIAugmentedLLM)
+            res = await llm.generate_str([
+                "Summarise what are my prompts and resources?",
+                *combined_messages,
+            ])
+            logger.info(f"Summary: {res}")
+
+if __name__ == "__main__":
+    asyncio.run(example_usage())
+```
+</CodeGroup>
+
+## Key Methods
+
+### Listing Primitives
+
+<CodeGroup>
+```python
+# List all resources from a server
+resources = await agent.list_resources("demo_server")
+
+# List all prompts from a server  
+prompts = await agent.list_prompts("demo_server")
+
+# List all tools from a server
+tools = await agent.list_tools("demo_server")
+```
+</CodeGroup>
+
+
+### Using Prompts and Resources
+
+<CodeGroup>
+```python
+# Create prompt message with prompt only
+prompt_messages = await agent.create_prompt(
+    prompt_name="echo",
+    arguments={"message": "Hello, world!"},
+    server_names=["demo_server"]
+)
+
+# Create prompt messages with prompts and resources
+combined_messages = await agent.create_prompt(
+    prompt_name="echo",
+    arguments={"message": "My name is John Doe."},
+    resource_uris="demo://docs/readme",
+    server_names=["demo_server"]
+)
+```
+</CodeGroup>
+
+
+## Complete Example
+
+You can find a complete working example in our GitHub repository:
+
+<Card title="MCP Primitives Example" icon="github" href="https://github.com/lastmile-ai/mcp-agent/tree/main/examples/mcp_primitives/mcp_basic_agent">
+  View the complete example on GitHub
+</Card>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -30,7 +30,9 @@
             "pages": [
               "concepts/agents",
               "concepts/mcp-servers",
-              "concepts/augmented-llms"
+              "concepts/augmented-llms",
+              "concepts/mcp-primitives",
+              "concepts/elicitation"
             ]
           },
           {
@@ -77,7 +79,7 @@
           "icon": "discord"
         },
         {
-          "anchor": "MCP Protocol",
+          "anchor": "MCP",
           "href": "https://modelcontextprotocol.io/introduction",
           "icon": "link"
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Elicitation" guide explaining how MCP servers can interactively request user input, including workflow details, setup instructions, usage examples, and best practices.
  * Introduced a "MCP Primitives" documentation page covering resources, prompts, and tools, with step-by-step guides and code examples for integrating these features.
  * Updated the documentation navigation to include both new pages and streamlined the MCP Protocol link label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->