### PR TITLE
fix: serialise list and tuple attributes in span

### DIFF
--- a/src/mcp_agent/tracing/telemetry.py
+++ b/src/mcp_agent/tracing/telemetry.py
@@ -101,6 +101,10 @@ def serialize_attribute(key: str, value: Any) -> Dict[str, Any]:
         for sub_key, sub_value in value.items():
             serialized.update(serialize_attribute(f"{key}.{sub_key}", sub_value))
 
+    elif isinstance(value, (list, tuple)):
+        for idx, item in enumerate(value):
+            serialized.update(serialize_attribute(f"{key}.{idx}", item))
+
     elif isinstance(value, Callable):
         serialized[f"{key}_callable_name"] = getattr(value, "__qualname__", str(value))
         serialized[f"{key}_callable_module"] = getattr(value, "__module__", "unknown")
@@ -109,6 +113,11 @@ def serialize_attribute(key: str, value: Any) -> Dict[str, Any]:
     elif inspect.iscoroutine(value):
         serialized[f"{key}_coroutine"] = str(value)
         serialized[f"{key}_is_coroutine"] = True
+
+    else:
+        s = str(value)
+        # TODO: jerron - Truncate very long strings. Not sure if this is necessary.
+        serialized[key] = s if len(s) < 256 else s[:255] + "…"
 
     return serialized
 


### PR DESCRIPTION
Currently, the content of MCP tool call responses is not recorded in the span because list types were not supported. Enhanced serialize_attributes to flatten list and tuple types, and added a fallback to stringify attribute values.

Sample serialised tool result output: 
```python
{
  'result.meta': 'None', 
  'result.content.0.type': 'text', 
  'result.content.0.text': 'Contents of https: //modelcontextprotocol.io/introduction:\nMCP is an open protocol tha...om/en/articles/9015913-how-to-get-support)', 
  'result.content.0.annotations': 'None', 
  'result.content.0.meta': 'None', 
  'result.structuredContent': 'None', 
  'result.isError': False
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of attribute values in telemetry to support lists, tuples, and non-serializable objects, ensuring they are properly serialized for tracing.
  * Long strings are now truncated to 255 characters with an ellipsis to maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->