### PR TITLE
Fix/tool arguments prefix

### DIFF
--- a/examples/tracing/mcp/main.py
+++ b/examples/tracing/mcp/main.py
@@ -20,13 +20,16 @@ async def test_sse():
             server_names=["mcp_test_server_sse"],
         )
 
+        original_number = 1
+
         async with agent:
             print(await agent.list_tools())
             call_tool_result: CallToolResult = await agent.call_tool(
-                "mcp_test_server_sse_get-magic-number"
+                "mcp_test_server_sse_get-magic-number",
+                {"original_number": original_number},
             )
 
-            assert call_tool_result.content[0].text == "42"
+            assert call_tool_result.content[0].text == str(42 + original_number)
             print("SSE test passed!")
 
 

--- a/examples/tracing/mcp/requirements.txt
+++ b/examples/tracing/mcp/requirements.txt
@@ -1,5 +1,5 @@
 # Core framework dependency
-mcp-agent @ file://../../../../  # Link to the local mcp-agent project root
+mcp-agent @ file://../../../  # Link to the local mcp-agent project root
 
 # Additional dependencies specific to this example
 anthropic

--- a/examples/tracing/mcp/server.py
+++ b/examples/tracing/mcp/server.py
@@ -7,7 +7,6 @@ from mcp.server.sse import SseServerTransport
 from mcp.types import EmbeddedResource, ImageContent, TextContent
 from openinference.instrumentation.mcp import MCPInstrumentor
 from opentelemetry import trace
-from pydantic import BaseModel, create_model
 from starlette.applications import Starlette
 from starlette.routing import Mount, Route
 

--- a/examples/tracing/mcp/server.py
+++ b/examples/tracing/mcp/server.py
@@ -23,11 +23,11 @@ def _configure_server_otel():
     MCPInstrumentor().instrument()
 
 
-def some_tool_function():
+def get_magic_number(original_number: int = 0) -> int:
     tracer = trace.get_tracer(__name__)
     with tracer.start_as_current_span("some_tool_function") as span:
         span.set_attribute("example.attribute", "value")
-        result = 42
+        result = 42 + original_number
         span.set_attribute("result", result)
         return result
 
@@ -39,14 +39,14 @@ def main():
     @server.list_tools()
     @telemetry.traced(kind=trace.SpanKind.SERVER)
     async def handle_list_tools() -> list[Tool]:
-        # Create an empty schema (or define a real one if you need parameters)
-        EmptyInputSchema = create_model("EmptyInputSchema", __base__=BaseModel)
-
         return [
             Tool(
                 name="get-magic-number",
-                description="Returns the magic number",
-                inputSchema=EmptyInputSchema.model_json_schema(),  # Add the required inputSchema
+                description="Returns a magic number",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"original_number": {"type": "number"}},
+                },
             )
         ]
 
@@ -56,7 +56,7 @@ def main():
         name: str, arguments: dict[str, Any] | None
     ) -> list[TextContent | ImageContent | EmbeddedResource]:
         span = trace.get_current_span()
-        res = str(some_tool_function())
+        res = str(get_magic_number(arguments.get("original_number", 0)))
         span.set_attribute(GEN_AI_TOOL_NAME, name)
         span.set_attribute("result", res)
         if arguments:

--- a/examples/tracing/mcp/server.py
+++ b/examples/tracing/mcp/server.py
@@ -60,7 +60,7 @@ def main():
         span.set_attribute(GEN_AI_TOOL_NAME, name)
         span.set_attribute("result", res)
         if arguments:
-            record_attributes(span, arguments)
+            record_attributes(span, arguments, "arguments")
 
         return [
             TextContent(type="text", text=res)

--- a/src/mcp_agent/agents/agent.py
+++ b/src/mcp_agent/agents/agent.py
@@ -23,7 +23,11 @@ from mcp.types import (
 
 from mcp_agent.core.context import Context
 from mcp_agent.tracing.semconv import GEN_AI_AGENT_NAME, GEN_AI_TOOL_NAME
-from mcp_agent.tracing.telemetry import get_tracer, record_attributes
+from mcp_agent.tracing.telemetry import (
+    annotate_span_for_call_tool_result,
+    get_tracer,
+    record_attributes,
+)
 from mcp_agent.mcp.mcp_agent_client_session import MCPAgentClientSession
 from mcp_agent.mcp.mcp_aggregator import (
     MCPAggregator,
@@ -853,28 +857,7 @@ class Agent(BaseModel):
             def _annotate_span_for_result(result: CallToolResult):
                 if not self.context.tracing_enabled:
                     return
-                if hasattr(result, "isError"):
-                    span.set_attribute("result.isError", result.isError)
-                    if result.isError:
-                        span.set_status(trace.Status(trace.StatusCode.ERROR))
-                        error_message = (
-                            result.content[0].text
-                            if len(result.content) > 0
-                            and result.content[0].type == "text"
-                            else "Error calling tool"
-                        )
-                        span.record_exception(Exception(error_message))
-                    else:
-                        if hasattr(result, "content"):
-                            for idx, content in enumerate(result.content):
-                                span.set_attribute(
-                                    f"result.content.{idx}.type", content.type
-                                )
-                                if content.type == "text":
-                                    span.set_attribute(
-                                        f"result.content.{idx}.text",
-                                        result.content[idx].text,
-                                    )
+                annotate_span_for_call_tool_result(span, result)
 
             if name == HUMAN_INPUT_TOOL_NAME:
                 # Call the human input tool

--- a/src/mcp_agent/agents/agent.py
+++ b/src/mcp_agent/agents/agent.py
@@ -853,22 +853,28 @@ class Agent(BaseModel):
             def _annotate_span_for_result(result: CallToolResult):
                 if not self.context.tracing_enabled:
                     return
-                span.set_attribute("result.isError", result.isError)
-                if result.isError:
-                    span.set_status(trace.Status(trace.StatusCode.ERROR))
-                    error_message = (
-                        result.content[0].text
-                        if len(result.content) > 0 and result.content[0].type == "text"
-                        else "Error calling tool"
-                    )
-                    span.record_exception(Exception(error_message))
-                else:
-                    for idx, content in enumerate(result.content):
-                        span.set_attribute(f"result.content.{idx}.type", content.type)
-                        if content.type == "text":
-                            span.set_attribute(
-                                f"result.content.{idx}.text", result.content[idx].text
-                            )
+                if hasattr(result, "isError"):
+                    span.set_attribute("result.isError", result.isError)
+                    if result.isError:
+                        span.set_status(trace.Status(trace.StatusCode.ERROR))
+                        error_message = (
+                            result.content[0].text
+                            if len(result.content) > 0
+                            and result.content[0].type == "text"
+                            else "Error calling tool"
+                        )
+                        span.record_exception(Exception(error_message))
+                    else:
+                        if hasattr(result, "content"):
+                            for idx, content in enumerate(result.content):
+                                span.set_attribute(
+                                    f"result.content.{idx}.type", content.type
+                                )
+                                if content.type == "text":
+                                    span.set_attribute(
+                                        f"result.content.{idx}.text",
+                                        result.content[idx].text,
+                                    )
 
             if name == HUMAN_INPUT_TOOL_NAME:
                 # Call the human input tool

--- a/src/mcp_agent/tracing/telemetry.py
+++ b/src/mcp_agent/tracing/telemetry.py
@@ -13,6 +13,9 @@ from opentelemetry import trace
 from opentelemetry.trace import SpanKind, Status, StatusCode
 
 from mcp_agent.core.context_dependent import ContextDependent
+from mcp.types import (
+    CallToolResult,
+)
 
 if TYPE_CHECKING:
     from mcp_agent.core.context import Context
@@ -136,7 +139,7 @@ def serialize_attributes(
     return serialized
 
 
-def record_attribute(span, key, value):
+def record_attribute(span: trace.Span, key, value):
     """Record a single serializable value on the span."""
     if is_otel_serializable(value):
         span.set_attribute(key, value)
@@ -146,7 +149,7 @@ def record_attribute(span, key, value):
             span.set_attribute(attr_key, attr_value)
 
 
-def record_attributes(span, attributes: Dict[str, Any], prefix: str = ""):
+def record_attributes(span: trace.Span, attributes: Dict[str, Any], prefix: str = ""):
     """Record a dict of attributes on the span after serialization."""
     serialized = serialize_attributes(attributes, prefix)
     for attr_key, attr_value in serialized.items():
@@ -170,6 +173,33 @@ def get_tracer(context: "Context") -> trace.Tracer:
     Get the OpenTelemetry tracer for the context.
     """
     return getattr(context, "tracer", None) or trace.get_tracer("mcp-agent")
+
+
+def annotate_span_for_call_tool_result(span: trace.Span, result: CallToolResult):
+    """
+    Annotate the span with attributes from the CallToolResult.
+    """
+    if hasattr(result, "isError"):
+        span.set_attribute("result.isError", result.isError)
+
+    content = getattr(result, "content", [])
+
+    if getattr(result, "isError", False):
+        span.set_status(trace.Status(trace.StatusCode.ERROR))
+        error_message = (
+            content[0].text
+            if len(content) > 0 and content[0].type == "text"
+            else "Error calling tool"
+        )
+        span.record_exception(Exception(error_message))
+
+    for idx, content in enumerate(content):
+        span.set_attribute(f"result.content.{idx}.type", content.type)
+        if content.type == "text":
+            span.set_attribute(
+                f"result.content.{idx}.text",
+                content[idx].text,
+            )
 
 
 telemetry = TelemetryManager()

--- a/src/mcp_agent/tracing/telemetry.py
+++ b/src/mcp_agent/tracing/telemetry.py
@@ -182,23 +182,23 @@ def annotate_span_for_call_tool_result(span: trace.Span, result: CallToolResult)
     if hasattr(result, "isError"):
         span.set_attribute("result.isError", result.isError)
 
-    content = getattr(result, "content", [])
+    result_content = getattr(result, "content", [])
 
     if getattr(result, "isError", False):
         span.set_status(trace.Status(trace.StatusCode.ERROR))
         error_message = (
-            content[0].text
-            if len(content) > 0 and content[0].type == "text"
+            result_content[0].text
+            if len(result_content) > 0 and result_content[0].type == "text"
             else "Error calling tool"
         )
         span.record_exception(Exception(error_message))
 
-    for idx, content in enumerate(content):
+    for idx, content in enumerate(result_content):
         span.set_attribute(f"result.content.{idx}.type", content.type)
         if content.type == "text":
             span.set_attribute(
                 f"result.content.{idx}.text",
-                content[idx].text,
+                content.text,
             )
 
 


### PR DESCRIPTION
## Description
Fixing the mcp tracing example to have arguments annotated under `arguments` prefix, similar to other places in the codebase. When testing, found and fixed a couple issues:
- example requirements.txt path to mcp-agent package root has one too many `../` now. Remove
- if the server is not running there is a `ServerInitializationError` that would result in an error in annotating the span; it turns out the CallToolResult type is just a suggestion in that case and the `ServerInitializationError` has no `isError` attribute. So, fix to do proper `attr` checks instead of indexing by attribute name. Pulled into a helper for reuse

## Testing
- Ran the tracing example successfully now; with server not running ensure there is no longer an error thrown in annotating the span

Correct span args:
<img width="1340" alt="Screenshot 2025-07-09 at 1 44 51 PM" src="https://github.com/user-attachments/assets/b4314d49-b83e-4c81-86ad-7ab5fdedc261" />
<img width="887" alt="Screenshot 2025-07-09 at 3 16 12 PM" src="https://github.com/user-attachments/assets/f6893f01-780e-4665-ba4d-6c69885b6777" />
<img width="903" alt="Screenshot 2025-07-09 at 3 16 24 PM" src="https://github.com/user-attachments/assets/4d6279ce-d4d6-478d-81e9-9d5962396818" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "magic number" tool now accepts a user-provided input number and returns the sum with 42.
  * Tool descriptions and input requirements are more explicit and user-friendly.

* **Bug Fixes**
  * Test cases updated to align with the enhanced tool input and output behavior.

* **Chores**
  * Updated local agent package dependency path.
  * Enhanced tracing and error reporting for tool calls with improved span annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->