### PR TITLE
Add FastAPI + websocket example

### DIFF
--- a/examples/usecases/fastapi_websocket/README.md
+++ b/examples/usecases/fastapi_websocket/README.md
@@ -1,0 +1,261 @@
+# FastAPI WebSocket Example with MCP Agent
+
+This example demonstrates how to integrate MCP Agent with FastAPI WebSocket connections to create a real-time chat application that supports multiple users with persistent sessions.
+
+## Features
+
+- 🚀 **FastAPI WebSocket Server**: Real-time bidirectional communication
+- 👥 **Multi-user Support**: Individual sessions per user ID
+- 🧠 **MCP Agent Integration**: Each user gets their own MCP agent instance
+- 📁 **File System Access**: Agents can read/write files in the current directory
+- 🌐 **Web Fetch Capabilities**: Agents can fetch content from URLs
+- 🔄 **Session Management**: Automatic cleanup of inactive sessions
+- 🎨 **Built-in Test Interface**: HTML page for testing WebSocket connections
+
+## Project Structure
+
+```
+fastapi_websocket/
+├── main.py                          # FastAPI server with WebSocket endpoints
+├── session_manager.py               # User session management
+├── websocket_client_async.py        # Improved async WebSocket client
+├── mcp_agent.config.yaml            # MCP agent configuration
+├── mcp_agent.secrets.yaml.example   # Example secrets file
+├── requirements.txt                 # Dependencies
+└── README.md                        # This file
+```
+
+## Setup
+
+1. **Install dependencies**:
+   ```bash
+   uv pip install -r requirements.txt
+   ```
+
+2. **Set up API keys**:
+   ```bash
+   cp mcp_agent.secrets.yaml.example mcp_agent.secrets.yaml
+   # Edit mcp_agent.secrets.yaml and add your OpenAI API key
+   ```
+
+3. **Create logs directory**:
+   ```bash
+   mkdir -p logs
+   ```
+
+## Running the Server
+
+Start the FastAPI server:
+
+```bash
+uv run main.py
+```
+
+The server will start on `http://localhost:8000`
+
+## Usage
+
+### Web Interface
+
+1. Open `http://localhost:8000` in your browser
+2. Enter a user ID (or use the default "test_user")
+3. Click "Connect" to establish WebSocket connection
+4. Type messages and get AI responses in real-time
+
+### API Endpoints
+
+- `GET /`: HTML test interface
+- `WebSocket /ws/{user_id}`: WebSocket endpoint for chat
+- `GET /health`: Health check endpoint
+- `GET /sessions`: List active sessions
+
+### WebSocket Message Format
+
+**Client to Server:**
+```json
+{
+  "message": "Your message here"
+}
+```
+
+**Server to Client:**
+```json
+{
+  "message": "AI response here",
+  "user_id": "user123",
+  "session_id": "uuid-session-id"
+}
+```
+
+**Error Response:**
+```json
+{
+  "error": "Error message here"
+}
+```
+
+## Python WebSocket Client
+
+### Async Client
+For better async handling, use the improved client:
+
+```bash
+uv run websocket_client_async.py
+```
+
+Or create your own client:
+
+```python
+import asyncio
+import websockets
+import json
+
+async def client():
+    uri = "ws://localhost:8000/ws/your_user_id"
+    async with websockets.connect(uri) as websocket:
+        # Send message
+        await websocket.send(json.dumps({"message": "Hello, AI!"}))
+        
+        # Receive response
+        response = await websocket.recv()
+        data = json.loads(response)
+        print(f"AI: {data['message']}")
+
+asyncio.run(client())
+```
+
+## Session Management
+
+- Each user ID gets a unique session with its own MCP agent
+- Sessions are automatically cleaned up after 2 hours of inactivity
+- Session cleanup runs every hour
+- Each session maintains conversation history
+
+## MCP Agent Capabilities
+
+Each user session includes an MCP agent with:
+
+- **Filesystem Access**: Read/write files in the current directory
+- **Web Fetching**: Retrieve content from URLs
+- **OpenAI Integration**: GPT-4o-mini for text generation
+- **Tool Calling**: Automatic tool selection and execution
+
+## Configuration
+
+### MCP Agent Configuration (`mcp_agent.config.yaml`)
+
+```yaml
+execution_engine: asyncio
+logger:
+  transports: [console, file]
+  level: debug
+
+mcp:
+  servers:
+    fetch:
+      command: "uvx"
+      args: ["mcp-server-fetch"]
+    filesystem:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-filesystem"]
+
+openai:
+  default_model: "gpt-4o-mini"
+```
+
+### Secrets Configuration (`mcp_agent.secrets.yaml`)
+
+```yaml
+openai:
+  api_key: "sk-your-openai-api-key-here"
+```
+
+## Examples
+
+### Basic Chat
+```
+User: Hello, who are you?
+AI: I'm an AI assistant with access to filesystem and web resources. I can help you with file operations, web searches, and general assistance.
+```
+
+### File Operations
+```
+User: List the files in the current directory
+AI: [Lists files using filesystem tools]
+
+User: Create a file called test.txt with "Hello World"
+AI: [Creates the file using filesystem tools]
+```
+
+### Web Fetching
+```
+User: Get the content from https://example.com
+AI: [Fetches and displays the content]
+```
+
+## Error Handling
+
+The server includes comprehensive error handling:
+
+- JSON parsing errors
+- WebSocket connection errors
+- MCP agent initialization errors
+- Session management errors
+- Tool execution errors
+
+## Development
+
+### Adding New Features
+
+1. **New MCP Servers**: Add server configurations to `mcp_agent.config.yaml`
+2. **Custom Tools**: Extend the agent initialization in `session_manager.py`
+3. **Session Enhancements**: Modify the `UserSession` class
+4. **API Endpoints**: Add new routes to `main.py`
+
+### Testing
+
+- Use the built-in web interface at `http://localhost:8000`
+- Run the Python client: `uv run websocket_client_async.py`
+- Test health endpoint: `curl http://localhost:8000/health`
+- List sessions: `curl http://localhost:8000/sessions`
+
+## Production Considerations
+
+- Set up proper logging and monitoring
+- Implement authentication and authorization
+- Add rate limiting
+- Use a production WSGI server
+- Set up SSL/TLS for secure WebSocket connections
+- Configure session persistence for scalability
+- Add database storage for conversation history
+
+## Troubleshooting
+
+### Common Issues
+
+1. **WebSocket Connection Failed**
+   - Check if the server is running on port 8000
+   - Verify firewall settings
+
+2. **MCP Agent Initialization Error**
+   - Ensure OpenAI API key is set in `mcp_agent.secrets.yaml`
+   - Check if required MCP servers are installed
+
+3. **Tool Execution Errors**
+   - Verify MCP server installations: `uvx mcp-server-fetch` and `npx @modelcontextprotocol/server-filesystem`
+   - Check file permissions for filesystem operations
+
+4. **Session Management Issues**
+   - Monitor logs for cleanup task errors
+   - Check memory usage for large numbers of sessions
+
+### Debug Mode
+
+Run with debug logging:
+```bash
+uv run main.py --log-level debug
+```
+
+## License
+
+This example is part of the MCP Agent project and follows the same license terms.

--- a/examples/usecases/fastapi_websocket/main.py
+++ b/examples/usecases/fastapi_websocket/main.py
@@ -1,0 +1,201 @@
+import json
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
+import uvicorn
+from contextlib import asynccontextmanager
+
+from session_manager import SessionManager
+
+
+# Global session manager
+session_manager = SessionManager()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Startup and shutdown events for the FastAPI application."""
+    # Startup
+    await session_manager.initialize()
+    yield
+    # Shutdown
+    await session_manager.cleanup()
+
+
+app = FastAPI(title="MCP Agent WebSocket Server", lifespan=lifespan)
+
+
+@app.get("/")
+async def get():
+    """Serve a simple HTML page for testing WebSocket connections."""
+    return HTMLResponse("""
+<!DOCTYPE html>
+<html>
+<head>
+    <title>MCP Agent WebSocket Test</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        #messages { border: 1px solid #ccc; height: 400px; overflow-y: auto; padding: 10px; margin: 10px 0; }
+        #userInput { width: 70%; padding: 10px; }
+        #sendBtn { padding: 10px 20px; }
+        .message { margin: 5px 0; padding: 5px; border-radius: 3px; }
+        .user { background-color: #e3f2fd; }
+        .assistant { background-color: #f1f8e9; }
+        .system { background-color: #fff3e0; }
+    </style>
+</head>
+<body>
+    <h1>MCP Agent WebSocket Test</h1>
+    <div>
+        <label for="userId">User ID:</label>
+        <input type="text" id="userId" value="test_user" />
+        <button onclick="connect()">Connect</button>
+        <button onclick="disconnect()">Disconnect</button>
+        <span id="status">Disconnected</span>
+    </div>
+    <div id="messages"></div>
+    <div>
+        <input type="text" id="userInput" placeholder="Type your message..." onkeypress="handleKeyPress(event)" />
+        <button id="sendBtn" onclick="sendMessage()">Send</button>
+    </div>
+
+    <script>
+        let ws = null;
+        let userId = 'test_user';
+
+        function connect() {
+            userId = document.getElementById('userId').value || 'test_user';
+            ws = new WebSocket(`ws://localhost:8000/ws/${userId}`);
+            
+            ws.onopen = function(event) {
+                document.getElementById('status').textContent = 'Connected';
+                addMessage('system', 'Connected to WebSocket server');
+            };
+            
+            ws.onmessage = function(event) {
+                const data = JSON.parse(event.data);
+                addMessage('assistant', data.message);
+            };
+            
+            ws.onclose = function(event) {
+                document.getElementById('status').textContent = 'Disconnected';
+                addMessage('system', 'Disconnected from WebSocket server');
+            };
+            
+            ws.onerror = function(error) {
+                addMessage('system', 'WebSocket error: ' + error);
+            };
+        }
+
+        function disconnect() {
+            if (ws) {
+                ws.close();
+            }
+        }
+
+        function sendMessage() {
+            const input = document.getElementById('userInput');
+            const message = input.value.trim();
+            if (message && ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({message: message}));
+                addMessage('user', message);
+                input.value = '';
+            }
+        }
+
+        function handleKeyPress(event) {
+            if (event.key === 'Enter') {
+                sendMessage();
+            }
+        }
+
+        function addMessage(type, message) {
+            const messagesDiv = document.getElementById('messages');
+            const messageDiv = document.createElement('div');
+            messageDiv.className = `message ${type}`;
+            messageDiv.textContent = `${type.toUpperCase()}: ${message}`;
+            messagesDiv.appendChild(messageDiv);
+            messagesDiv.scrollTop = messagesDiv.scrollHeight;
+        }
+    </script>
+</body>
+</html>
+    """)
+
+
+@app.websocket("/ws/{user_id}")
+async def websocket_endpoint(websocket: WebSocket, user_id: str):
+    """WebSocket endpoint for user sessions."""
+    await websocket.accept()
+
+    try:
+        # Get or create user session
+        user_session = await session_manager.get_or_create_session(user_id)
+
+        # Send welcome message
+        await websocket.send_text(
+            json.dumps(
+                {
+                    "message": f"Welcome! You are connected as user: {user_id}",
+                    "user_id": user_id,
+                    "session_id": user_session.session_id,
+                }
+            )
+        )
+
+        while True:
+            try:
+                # Receive message from client
+                data = await websocket.receive_text()
+                message_data = json.loads(data)
+                user_message = message_data.get("message", "")
+
+                if not user_message:
+                    continue
+
+                # Process message through MCP agent
+                response = await user_session.process_message(user_message)
+
+                # Send response back to client
+                await websocket.send_text(
+                    json.dumps(
+                        {
+                            "message": response,
+                            "user_id": user_id,
+                            "session_id": user_session.session_id,
+                        }
+                    )
+                )
+
+            except WebSocketDisconnect:
+                break
+            except json.JSONDecodeError:
+                await websocket.send_text(json.dumps({"error": "Invalid JSON format"}))
+            except Exception as e:
+                await websocket.send_text(
+                    json.dumps({"error": f"An error occurred: {str(e)}"})
+                )
+
+    except Exception as e:
+        await websocket.send_text(json.dumps({"error": f"Session error: {str(e)}"}))
+    finally:
+        # Clean up session if needed
+        await session_manager.cleanup_session(user_id)
+
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint."""
+    return {"status": "healthy", "active_sessions": len(session_manager.sessions)}
+
+
+@app.get("/sessions")
+async def list_sessions():
+    """List active sessions."""
+    return {
+        "active_sessions": list(session_manager.sessions.keys()),
+        "total_sessions": len(session_manager.sessions),
+    }
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/examples/usecases/fastapi_websocket/mcp_agent.config.yaml
+++ b/examples/usecases/fastapi_websocket/mcp_agent.config.yaml
@@ -1,0 +1,24 @@
+$schema: ../../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  transports: [console, file]
+  level: debug
+  progress_display: false
+  path_settings:
+    path_pattern: "logs/mcp-agent-{unique_id}.jsonl"
+    unique_id: "timestamp"
+    timestamp_format: "%Y%m%d_%H%M%S"
+
+mcp:
+  servers:
+    fetch:
+      command: "uvx"
+      args: ["mcp-server-fetch"]
+    filesystem:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-filesystem"]
+
+openai:
+  # API key should be set in mcp_agent.secrets.yaml
+  default_model: "gpt-4o-mini"

--- a/examples/usecases/fastapi_websocket/mcp_agent.secrets.yaml.example
+++ b/examples/usecases/fastapi_websocket/mcp_agent.secrets.yaml.example
@@ -1,0 +1,9 @@
+# Copy this file to mcp_agent.secrets.yaml and fill in your API keys
+# This file should be gitignored to avoid exposing secrets
+
+openai:
+  api_key: "sk-your-openai-api-key-here"
+
+# Optional: Add Anthropic API key if you want to use Claude
+# anthropic:
+#   api_key: "sk-your-anthropic-api-key-here"

--- a/examples/usecases/fastapi_websocket/requirements.txt
+++ b/examples/usecases/fastapi_websocket/requirements.txt
@@ -1,0 +1,16 @@
+# Core framework dependency
+mcp-agent @ file://../../../  # Link to the local mcp-agent project root
+
+# FastAPI and WebSocket dependencies
+fastapi
+uvicorn[standard]
+websockets
+python-multipart
+
+# LLM providers
+openai
+anthropic
+
+# Additional utilities
+python-dateutil
+aioconsole

--- a/examples/usecases/fastapi_websocket/session_manager.py
+++ b/examples/usecases/fastapi_websocket/session_manager.py
@@ -11,36 +11,36 @@ from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
 
 class UserSession:
     """Represents a user session with MCP agent integration."""
-    
+
     def __init__(self, user_id: str, session_id: str):
         self.user_id = user_id
         self.session_id = session_id
         self.created_at = datetime.now()
         self.last_activity = datetime.now()
         self.message_history = []
-        
+
         # MCP agent components
         self.mcp_app: Optional[MCPApp] = None
         self.agent_app = None
         self.agent: Optional[Agent] = None
         self.llm = None
-        
+
     async def initialize(self):
         """Initialize the MCP agent for this session."""
         try:
             # Create MCP app for this session
             self.mcp_app = MCPApp(name=f"mcp_websocket_session_{self.user_id}")
-            
+
             # Start the MCP app
             self.agent_app = await self.mcp_app.run().__aenter__()
-            
+
             # Get context and logger
             context = self.agent_app.context
             logger = self.agent_app.logger
-            
+
             # Add current directory to filesystem server args
             context.config.mcp.servers["filesystem"].args.extend([os.getcwd()])
-            
+
             # Create agent with access to filesystem and fetch servers
             self.agent = Agent(
                 name=f"websocket_agent_{self.user_id}",
@@ -49,57 +49,63 @@ class UserSession:
                 Always be helpful, accurate, and concise in your responses.""",
                 server_names=["fetch", "filesystem"],
             )
-            
+
             # Initialize the agent
             await self.agent.__aenter__()
-            
+
             # Attach LLM to the agent
             self.llm = await self.agent.attach_llm(OpenAIAugmentedLLM)
-            
+
             logger.info(f"Session initialized for user {self.user_id}")
-            
+
         except Exception as e:
             if self.agent_app:
                 await self.agent_app.__aexit__(None, None, None)
             raise e
-    
+
     async def process_message(self, message: str) -> str:
         """Process a user message through the MCP agent."""
         try:
             # Update last activity
             self.last_activity = datetime.now()
-            
+
             # Add to message history
-            self.message_history.append({
-                "role": "user",
-                "content": message,
-                "timestamp": self.last_activity.isoformat()
-            })
-            
+            self.message_history.append(
+                {
+                    "role": "user",
+                    "content": message,
+                    "timestamp": self.last_activity.isoformat(),
+                }
+            )
+
             # Process through LLM
             if not self.llm:
                 return "Error: Agent not initialized"
-                
+
             response = await self.llm.generate_str(message=message)
-            
+
             # Add response to history
-            self.message_history.append({
-                "role": "assistant",
-                "content": response,
-                "timestamp": datetime.now().isoformat()
-            })
-            
+            self.message_history.append(
+                {
+                    "role": "assistant",
+                    "content": response,
+                    "timestamp": datetime.now().isoformat(),
+                }
+            )
+
             return response
-            
+
         except Exception as e:
             error_msg = f"Error processing message: {str(e)}"
-            self.message_history.append({
-                "role": "error",
-                "content": error_msg,
-                "timestamp": datetime.now().isoformat()
-            })
+            self.message_history.append(
+                {
+                    "role": "error",
+                    "content": error_msg,
+                    "timestamp": datetime.now().isoformat(),
+                }
+            )
             return error_msg
-    
+
     async def cleanup(self):
         """Clean up the session resources."""
         try:
@@ -113,28 +119,28 @@ class UserSession:
 
 class SessionManager:
     """Manages user sessions for the WebSocket server."""
-    
+
     def __init__(self):
         self.sessions: Dict[str, UserSession] = {}
         self.cleanup_interval = 3600  # Clean up inactive sessions every hour
         self.max_inactive_time = 7200  # Remove sessions inactive for 2 hours
-        
+
     async def initialize(self):
         """Initialize the session manager."""
         # Start cleanup task
         asyncio.create_task(self._cleanup_task())
-        
+
     async def get_or_create_session(self, user_id: str) -> UserSession:
         """Get existing session or create a new one for the user."""
         if user_id in self.sessions:
             session = self.sessions[user_id]
             session.last_activity = datetime.now()
             return session
-        
+
         # Create new session
         session_id = str(uuid.uuid4())
         session = UserSession(user_id, session_id)
-        
+
         try:
             await session.initialize()
             self.sessions[user_id] = session
@@ -142,57 +148,59 @@ class SessionManager:
         except Exception as e:
             await session.cleanup()
             raise Exception(f"Failed to create session for user {user_id}: {str(e)}")
-    
+
     async def cleanup_session(self, user_id: str):
         """Clean up a specific user session."""
         if user_id in self.sessions:
             session = self.sessions[user_id]
             await session.cleanup()
             del self.sessions[user_id]
-    
+
     async def cleanup(self):
         """Clean up all sessions."""
         cleanup_tasks = []
         for user_id, session in self.sessions.items():
             cleanup_tasks.append(session.cleanup())
-        
+
         if cleanup_tasks:
             await asyncio.gather(*cleanup_tasks, return_exceptions=True)
-        
+
         self.sessions.clear()
-    
+
     async def _cleanup_task(self):
         """Background task to clean up inactive sessions."""
         while True:
             try:
                 await asyncio.sleep(self.cleanup_interval)
-                
+
                 current_time = datetime.now()
                 inactive_users = []
-                
+
                 for user_id, session in self.sessions.items():
-                    time_since_activity = (current_time - session.last_activity).total_seconds()
+                    time_since_activity = (
+                        current_time - session.last_activity
+                    ).total_seconds()
                     if time_since_activity > self.max_inactive_time:
                         inactive_users.append(user_id)
-                
+
                 # Clean up inactive sessions
                 for user_id in inactive_users:
                     print(f"Cleaning up inactive session for user: {user_id}")
                     await self.cleanup_session(user_id)
-                    
+
             except Exception as e:
                 print(f"Error in cleanup task: {e}")
-    
+
     def get_session_info(self, user_id: str) -> Optional[dict]:
         """Get session information for a user."""
         if user_id not in self.sessions:
             return None
-            
+
         session = self.sessions[user_id]
         return {
             "user_id": session.user_id,
             "session_id": session.session_id,
             "created_at": session.created_at.isoformat(),
             "last_activity": session.last_activity.isoformat(),
-            "message_count": len(session.message_history)
+            "message_count": len(session.message_history),
         }

--- a/examples/usecases/fastapi_websocket/session_manager.py
+++ b/examples/usecases/fastapi_websocket/session_manager.py
@@ -1,0 +1,198 @@
+import asyncio
+import os
+import uuid
+from typing import Dict, Optional
+from datetime import datetime
+
+from mcp_agent.app import MCPApp
+from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+
+class UserSession:
+    """Represents a user session with MCP agent integration."""
+    
+    def __init__(self, user_id: str, session_id: str):
+        self.user_id = user_id
+        self.session_id = session_id
+        self.created_at = datetime.now()
+        self.last_activity = datetime.now()
+        self.message_history = []
+        
+        # MCP agent components
+        self.mcp_app: Optional[MCPApp] = None
+        self.agent_app = None
+        self.agent: Optional[Agent] = None
+        self.llm = None
+        
+    async def initialize(self):
+        """Initialize the MCP agent for this session."""
+        try:
+            # Create MCP app for this session
+            self.mcp_app = MCPApp(name=f"mcp_websocket_session_{self.user_id}")
+            
+            # Start the MCP app
+            self.agent_app = await self.mcp_app.run().__aenter__()
+            
+            # Get context and logger
+            context = self.agent_app.context
+            logger = self.agent_app.logger
+            
+            # Add current directory to filesystem server args
+            context.config.mcp.servers["filesystem"].args.extend([os.getcwd()])
+            
+            # Create agent with access to filesystem and fetch servers
+            self.agent = Agent(
+                name=f"websocket_agent_{self.user_id}",
+                instruction=f"""You are an AI assistant for user {self.user_id} with access to filesystem and web resources.
+                You can help with file operations, web searches, and general assistance.
+                Always be helpful, accurate, and concise in your responses.""",
+                server_names=["fetch", "filesystem"],
+            )
+            
+            # Initialize the agent
+            await self.agent.__aenter__()
+            
+            # Attach LLM to the agent
+            self.llm = await self.agent.attach_llm(OpenAIAugmentedLLM)
+            
+            logger.info(f"Session initialized for user {self.user_id}")
+            
+        except Exception as e:
+            if self.agent_app:
+                await self.agent_app.__aexit__(None, None, None)
+            raise e
+    
+    async def process_message(self, message: str) -> str:
+        """Process a user message through the MCP agent."""
+        try:
+            # Update last activity
+            self.last_activity = datetime.now()
+            
+            # Add to message history
+            self.message_history.append({
+                "role": "user",
+                "content": message,
+                "timestamp": self.last_activity.isoformat()
+            })
+            
+            # Process through LLM
+            if not self.llm:
+                return "Error: Agent not initialized"
+                
+            response = await self.llm.generate_str(message=message)
+            
+            # Add response to history
+            self.message_history.append({
+                "role": "assistant",
+                "content": response,
+                "timestamp": datetime.now().isoformat()
+            })
+            
+            return response
+            
+        except Exception as e:
+            error_msg = f"Error processing message: {str(e)}"
+            self.message_history.append({
+                "role": "error",
+                "content": error_msg,
+                "timestamp": datetime.now().isoformat()
+            })
+            return error_msg
+    
+    async def cleanup(self):
+        """Clean up the session resources."""
+        try:
+            if self.agent:
+                await self.agent.__aexit__(None, None, None)
+            if self.agent_app:
+                await self.agent_app.__aexit__(None, None, None)
+        except Exception as e:
+            print(f"Error during session cleanup for user {self.user_id}: {e}")
+
+
+class SessionManager:
+    """Manages user sessions for the WebSocket server."""
+    
+    def __init__(self):
+        self.sessions: Dict[str, UserSession] = {}
+        self.cleanup_interval = 3600  # Clean up inactive sessions every hour
+        self.max_inactive_time = 7200  # Remove sessions inactive for 2 hours
+        
+    async def initialize(self):
+        """Initialize the session manager."""
+        # Start cleanup task
+        asyncio.create_task(self._cleanup_task())
+        
+    async def get_or_create_session(self, user_id: str) -> UserSession:
+        """Get existing session or create a new one for the user."""
+        if user_id in self.sessions:
+            session = self.sessions[user_id]
+            session.last_activity = datetime.now()
+            return session
+        
+        # Create new session
+        session_id = str(uuid.uuid4())
+        session = UserSession(user_id, session_id)
+        
+        try:
+            await session.initialize()
+            self.sessions[user_id] = session
+            return session
+        except Exception as e:
+            await session.cleanup()
+            raise Exception(f"Failed to create session for user {user_id}: {str(e)}")
+    
+    async def cleanup_session(self, user_id: str):
+        """Clean up a specific user session."""
+        if user_id in self.sessions:
+            session = self.sessions[user_id]
+            await session.cleanup()
+            del self.sessions[user_id]
+    
+    async def cleanup(self):
+        """Clean up all sessions."""
+        cleanup_tasks = []
+        for user_id, session in self.sessions.items():
+            cleanup_tasks.append(session.cleanup())
+        
+        if cleanup_tasks:
+            await asyncio.gather(*cleanup_tasks, return_exceptions=True)
+        
+        self.sessions.clear()
+    
+    async def _cleanup_task(self):
+        """Background task to clean up inactive sessions."""
+        while True:
+            try:
+                await asyncio.sleep(self.cleanup_interval)
+                
+                current_time = datetime.now()
+                inactive_users = []
+                
+                for user_id, session in self.sessions.items():
+                    time_since_activity = (current_time - session.last_activity).total_seconds()
+                    if time_since_activity > self.max_inactive_time:
+                        inactive_users.append(user_id)
+                
+                # Clean up inactive sessions
+                for user_id in inactive_users:
+                    print(f"Cleaning up inactive session for user: {user_id}")
+                    await self.cleanup_session(user_id)
+                    
+            except Exception as e:
+                print(f"Error in cleanup task: {e}")
+    
+    def get_session_info(self, user_id: str) -> Optional[dict]:
+        """Get session information for a user."""
+        if user_id not in self.sessions:
+            return None
+            
+        session = self.sessions[user_id]
+        return {
+            "user_id": session.user_id,
+            "session_id": session.session_id,
+            "created_at": session.created_at.isoformat(),
+            "last_activity": session.last_activity.isoformat(),
+            "message_count": len(session.message_history)
+        }

--- a/examples/usecases/fastapi_websocket/websocket_client_async.py
+++ b/examples/usecases/fastapi_websocket/websocket_client_async.py
@@ -19,7 +19,7 @@ except ImportError:
 
 class AsyncWebSocketClient:
     """Async WebSocket client with non-blocking input."""
-    
+
     def __init__(self, user_id: str, host: str = "localhost", port: int = 8000):
         self.user_id = user_id
         self.host = host
@@ -27,7 +27,7 @@ class AsyncWebSocketClient:
         self.uri = f"ws://{host}:{port}/ws/{user_id}"
         self.websocket = None
         self.running = False
-        
+
     async def connect(self):
         """Connect to the WebSocket server."""
         try:
@@ -37,100 +37,100 @@ class AsyncWebSocketClient:
         except Exception as e:
             print(f"❌ Failed to connect: {e}")
             return False
-    
+
     async def disconnect(self):
         """Disconnect from the WebSocket server."""
         if self.websocket:
             await self.websocket.close()
             print("👋 Disconnected from WebSocket server")
-    
+
     async def send_message(self, message: str):
         """Send a message to the server."""
         if not self.websocket:
             print("❌ Not connected to server")
             return
-        
+
         try:
             await self.websocket.send(json.dumps({"message": message}))
             print(f"📤 Sent: {message}")
         except Exception as e:
             print(f"❌ Error sending message: {e}")
-    
+
     async def listen_for_messages(self):
         """Listen for incoming messages from the server."""
         while self.running and self.websocket:
             try:
                 response = await self.websocket.recv()
                 data = json.loads(response)
-                
+
                 timestamp = datetime.now().strftime("%H:%M:%S")
                 if "error" in data:
                     print(f"\n🔴 [{timestamp}] Error: {data['error']}")
                 else:
                     print(f"\n🤖 [{timestamp}] AI: {data.get('message', 'No message')}")
-                
+
                 # Re-prompt for user input
                 print("💬 You: ", end="", flush=True)
-                
+
             except websockets.exceptions.ConnectionClosed:
                 print("\n🔌 Connection closed by server")
                 break
             except Exception as e:
                 print(f"\n❌ Error in message listener: {e}")
                 break
-    
+
     async def handle_user_input(self):
         """Handle user input asynchronously."""
         print("💬 You: ", end="", flush=True)
-        
+
         while self.running:
             try:
                 user_input = await aioconsole.ainput("")
                 user_input = user_input.strip()
-                
-                if user_input.lower() in ['quit', 'exit']:
+
+                if user_input.lower() in ["quit", "exit"]:
                     print("👋 Goodbye!")
                     self.running = False
                     break
-                
-                if user_input.lower() == 'help':
+
+                if user_input.lower() == "help":
                     self.show_help()
                     print("💬 You: ", end="", flush=True)
                     continue
-                
+
                 if user_input:
                     await self.send_message(user_input)
-                
+
                 print("💬 You: ", end="", flush=True)
-                
+
             except (EOFError, KeyboardInterrupt):
                 print("\n🛑 Interrupted by user")
                 self.running = False
                 break
-    
+
     async def interactive_chat(self):
         """Run an interactive chat session."""
         if not await self.connect():
             return
-        
-        print(f"\n🚀 Starting interactive chat session")
-        print(f"💡 Type 'quit' or 'exit' to disconnect")
-        print(f"💡 Type 'help' for available commands")
+
+        print("\n🚀 Starting interactive chat session")
+        print("💡 Type 'quit' or 'exit' to disconnect")
+        print("💡 Type 'help' for available commands")
         print("=" * 50)
-        
+
         self.running = True
-        
+
         # Start both tasks concurrently
         try:
             await asyncio.gather(
                 self.listen_for_messages(),
                 self.handle_user_input(),
-                return_exceptions=True
+                return_exceptions=True,
             )
         finally:
             self.running = False
             await self.disconnect()
-    
+
     def show_help(self):
         """Show available commands."""
         print("\n📋 Available commands:")
@@ -149,10 +149,10 @@ async def main():
     """Main function to run the WebSocket client."""
     # Get user ID from command line or use default
     user_id = sys.argv[1] if len(sys.argv) > 1 else "test_user"
-    
+
     # Create client
     client = AsyncWebSocketClient(user_id)
-    
+
     # Run interactive chat
     await client.interactive_chat()
 

--- a/examples/usecases/fastapi_websocket/websocket_client_async.py
+++ b/examples/usecases/fastapi_websocket/websocket_client_async.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Improved WebSocket client using aioconsole for non-blocking input.
+Install with: pip install aioconsole
+"""
+
+import asyncio
+import json
+import sys
+import websockets
+from datetime import datetime
+
+try:
+    import aioconsole
+except ImportError:
+    print("❌ aioconsole not found. Install with: pip install aioconsole")
+    sys.exit(1)
+
+
+class AsyncWebSocketClient:
+    """Async WebSocket client with non-blocking input."""
+    
+    def __init__(self, user_id: str, host: str = "localhost", port: int = 8000):
+        self.user_id = user_id
+        self.host = host
+        self.port = port
+        self.uri = f"ws://{host}:{port}/ws/{user_id}"
+        self.websocket = None
+        self.running = False
+        
+    async def connect(self):
+        """Connect to the WebSocket server."""
+        try:
+            self.websocket = await websockets.connect(self.uri)
+            print(f"✅ Connected to WebSocket server as user: {self.user_id}")
+            return True
+        except Exception as e:
+            print(f"❌ Failed to connect: {e}")
+            return False
+    
+    async def disconnect(self):
+        """Disconnect from the WebSocket server."""
+        if self.websocket:
+            await self.websocket.close()
+            print("👋 Disconnected from WebSocket server")
+    
+    async def send_message(self, message: str):
+        """Send a message to the server."""
+        if not self.websocket:
+            print("❌ Not connected to server")
+            return
+        
+        try:
+            await self.websocket.send(json.dumps({"message": message}))
+            print(f"📤 Sent: {message}")
+        except Exception as e:
+            print(f"❌ Error sending message: {e}")
+    
+    async def listen_for_messages(self):
+        """Listen for incoming messages from the server."""
+        while self.running and self.websocket:
+            try:
+                response = await self.websocket.recv()
+                data = json.loads(response)
+                
+                timestamp = datetime.now().strftime("%H:%M:%S")
+                if "error" in data:
+                    print(f"\n🔴 [{timestamp}] Error: {data['error']}")
+                else:
+                    print(f"\n🤖 [{timestamp}] AI: {data.get('message', 'No message')}")
+                
+                # Re-prompt for user input
+                print("💬 You: ", end="", flush=True)
+                
+            except websockets.exceptions.ConnectionClosed:
+                print("\n🔌 Connection closed by server")
+                break
+            except Exception as e:
+                print(f"\n❌ Error in message listener: {e}")
+                break
+    
+    async def handle_user_input(self):
+        """Handle user input asynchronously."""
+        print("💬 You: ", end="", flush=True)
+        
+        while self.running:
+            try:
+                user_input = await aioconsole.ainput("")
+                user_input = user_input.strip()
+                
+                if user_input.lower() in ['quit', 'exit']:
+                    print("👋 Goodbye!")
+                    self.running = False
+                    break
+                
+                if user_input.lower() == 'help':
+                    self.show_help()
+                    print("💬 You: ", end="", flush=True)
+                    continue
+                
+                if user_input:
+                    await self.send_message(user_input)
+                
+                print("💬 You: ", end="", flush=True)
+                
+            except (EOFError, KeyboardInterrupt):
+                print("\n🛑 Interrupted by user")
+                self.running = False
+                break
+    
+    async def interactive_chat(self):
+        """Run an interactive chat session."""
+        if not await self.connect():
+            return
+        
+        print(f"\n🚀 Starting interactive chat session")
+        print(f"💡 Type 'quit' or 'exit' to disconnect")
+        print(f"💡 Type 'help' for available commands")
+        print("=" * 50)
+        
+        self.running = True
+        
+        # Start both tasks concurrently
+        try:
+            await asyncio.gather(
+                self.listen_for_messages(),
+                self.handle_user_input(),
+                return_exceptions=True
+            )
+        finally:
+            self.running = False
+            await self.disconnect()
+    
+    def show_help(self):
+        """Show available commands."""
+        print("\n📋 Available commands:")
+        print("  help          - Show this help message")
+        print("  quit/exit     - Disconnect and exit")
+        print("  Ctrl+C        - Interrupt and exit")
+        print("\n💡 Example messages to try:")
+        print("  - Hello, who are you?")
+        print("  - List the files in the current directory")
+        print("  - Create a file called test.txt with 'Hello World'")
+        print("  - Get the content from https://httpbin.org/json")
+        print("  - What's the current time?")
+
+
+async def main():
+    """Main function to run the WebSocket client."""
+    # Get user ID from command line or use default
+    user_id = sys.argv[1] if len(sys.argv) > 1 else "test_user"
+    
+    # Create client
+    client = AsyncWebSocketClient(user_id)
+    
+    # Run interactive chat
+    await client.interactive_chat()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\n👋 Goodbye!")
+    except Exception as e:
+        print(f"❌ Unexpected error: {e}")
+        sys.exit(1)


### PR DESCRIPTION
Add an example for #312 to showcase how to use mcp-agent with FastAPI and websocket.

<img width="1728" height="623" alt="Screenshot 2025-07-16 at 12 41 03 AM" src="https://github.com/user-attachments/assets/5c4abaaf-18fe-40b7-be0e-537e331826fd" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a FastAPI WebSocket server supporting real-time multi-user chat with individual user sessions and session management.
  * Added an interactive HTML test page and a Python-based asynchronous WebSocket client for testing and usage.
  * Provided configuration and example secrets files for agent setup, including integration with OpenAI and Anthropic.
  * Included endpoints for health checks and listing active sessions.

* **Documentation**
  * Added a comprehensive README detailing setup, usage, configuration, error handling, development, and troubleshooting instructions.

* **Chores**
  * Added a requirements file specifying all necessary dependencies for running the example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->