### PR TITLE
Suppress warnings due to generic RequestParams objects causing type mismatches

### DIFF
--- a/src/mcp_agent/mcp/mcp_agent_client_session.py
+++ b/src/mcp_agent/mcp/mcp_agent_client_session.py
@@ -210,7 +210,8 @@ class MCPAgentClientSession(ClientSession, ContextDependent):
                     metadata,
                     progress_callback,
                 )
-                res_data = result.model_dump()
+                # ignore warnings due to generic RequestParams causing type mismatches
+                res_data = result.model_dump(warnings=False)
                 logger.debug("send_request: response=", data=res_data)
 
                 if self.context.tracing_enabled:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed unnecessary warning messages in response data logging, resulting in a cleaner log output for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->