### PR TITLE
Add customizable overrides for Orchestrator instructions and prompt templates

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm.py
@@ -520,7 +520,7 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol[MessageParamT, Message
         return str(message)
 
     def _log_chat_progress(
-        self, chat_turn: Optional[int] = None, model: Optional[str] = None
+        self, chat_turn: Optional[int] = None, model: str | None = None
     ):
         """Log a chat progress event"""
         data = {
@@ -531,7 +531,7 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol[MessageParamT, Message
         }
         self.logger.debug("Chat in progress", data=data)
 
-    def _log_chat_finished(self, model: Optional[str] = None):
+    def _log_chat_finished(self, model: str | None = None):
         """Log a chat finished event"""
         data = {"progress_action": "Finished", "model": model, "agent_name": self.name}
         self.logger.debug("Chat finished", data=data)

--- a/src/mcp_agent/workflows/orchestrator/orchestrator.py
+++ b/src/mcp_agent/workflows/orchestrator/orchestrator.py
@@ -90,40 +90,26 @@ class GetSynthesizePlanPrompt(Protocol):
 class OrchestratorOverrides:
     """Configuration overrides for Orchestrator behavior and prompts"""
 
-    """
-    Override the main orchestrator LLM's system instruction
-    """
     orchestrator_instruction: str | None = None
+    """Override the main orchestrator LLM's system instruction"""
 
-    """
-    Override the planner agent's instruction (used to break down tasks into steps)
-    """
     planner_instruction: str | None = None
+    """Override the planner agent's instruction (used to break down tasks into steps)"""
 
-    """
-    Override the synthesizer agent's instruction (used to combine results into final output)
-    """
     synthesizer_instruction: str | None = None
+    """Override the synthesizer agent's instruction (used to combine results into final output)"""
 
-    """
-    Get prompt to generate the full plan of action
-    """
     get_full_plan_prompt: GetFullPlanPrompt | None = None
+    """Get prompt to generate the full plan of action"""
 
-    """
-    Get prompt to generate the next step of action
-    """
     get_iterative_plan_prompt: GetIterativePlanPrompt | None = None
+    """Get prompt to generate the next step of action"""
 
-    """
-    Get prompt to specify as system instruction for a subtask in the plan.
-    """
     get_task_prompt: GetTaskPrompt | None = None
+    """Get prompt to specify as system instruction for a subtask in the plan"""
 
-    """
-    Get prompt to synthesize the orchestration of the workflow into a final response.
-    """
     get_synthesize_plan_prompt: GetSynthesizePlanPrompt | None = None
+    """Get prompt to synthesize the orchestration of the workflow into a final response"""
 
 
 class Orchestrator(AugmentedLLM[MessageParamT, MessageT]):

--- a/src/mcp_agent/workflows/orchestrator/orchestrator.py
+++ b/src/mcp_agent/workflows/orchestrator/orchestrator.py
@@ -649,7 +649,7 @@ class Orchestrator(AugmentedLLM[MessageParamT, MessageT]):
         prompt: str
         if self.overrides.iterative_plan_prompt_template:
             prompt = self.overrides.iterative_plan_prompt_template(
-                objective=objective, plan_result=plan_result, agents=self.agents
+                objective=objective, plan_result=plan_result, agents=agents
             )
         else:
             prompt = ITERATIVE_PLAN_PROMPT_TEMPLATE.format(

--- a/src/mcp_agent/workflows/orchestrator/orchestrator.py
+++ b/src/mcp_agent/workflows/orchestrator/orchestrator.py
@@ -440,11 +440,9 @@ class Orchestrator(AugmentedLLM[MessageParamT, MessageT]):
 
                     # Synthesize final result into a single message
                     synthesis_prompt: str
-                    if self.overrides.synthesize_plan_prompt_template:
-                        synthesis_prompt = (
-                            self.overrides.synthesize_plan_prompt_template(
-                                plan_result=plan_result
-                            )
+                    if self.overrides.get_synthesize_plan_prompt:
+                        synthesis_prompt = self.overrides.get_synthesize_plan_prompt(
+                            plan_result=plan_result
                         )
                     else:
                         synthesis_prompt = SYNTHESIZE_PLAN_PROMPT_TEMPLATE.format(
@@ -539,8 +537,8 @@ class Orchestrator(AugmentedLLM[MessageParamT, MessageT]):
                     llm = await ctx_agent.attach_llm(self.llm_factory)
 
                 task_description: str
-                if self.overrides.task_prompt_template:
-                    task_description = self.overrides.task_prompt_template(
+                if self.overrides.get_task_prompt:
+                    task_description = self.overrides.get_task_prompt(
                         objective=previous_result.objective,
                         task=task.description,
                         context=context,
@@ -612,8 +610,8 @@ class Orchestrator(AugmentedLLM[MessageParamT, MessageT]):
         )
 
         prompt: str
-        if self.overrides.full_plan_prompt_template:
-            prompt = self.overrides.full_plan_prompt_template(
+        if self.overrides.get_full_plan_prompt:
+            prompt = self.overrides.get_full_plan_prompt(
                 objective=objective, plan_result=plan_result, agents=agents
             )
         else:
@@ -647,8 +645,8 @@ class Orchestrator(AugmentedLLM[MessageParamT, MessageT]):
         )
 
         prompt: str
-        if self.overrides.iterative_plan_prompt_template:
-            prompt = self.overrides.iterative_plan_prompt_template(
+        if self.overrides.get_iterative_plan_prompt:
+            prompt = self.overrides.get_iterative_plan_prompt(
                 objective=objective, plan_result=plan_result, agents=agents
             )
         else:

--- a/src/mcp_agent/workflows/orchestrator/orchestrator.py
+++ b/src/mcp_agent/workflows/orchestrator/orchestrator.py
@@ -106,24 +106,24 @@ class OrchestratorOverrides:
     synthesizer_instruction: str | None = None
 
     """
-    Override FULL_PLAN_PROMPT_TEMPLATE
+    Get prompt to generate the full plan of action
     """
-    full_plan_prompt_template: GetFullPlanPrompt | None = None
+    get_full_plan_prompt: GetFullPlanPrompt | None = None
 
     """
-    Override ITERATIVE_PLAN_PROMPT_TEMPLATE
+    Get prompt to generate the next step of action
     """
-    iterative_plan_prompt_template: GetIterativePlanPrompt | None = None
+    get_iterative_plan_prompt: GetIterativePlanPrompt | None = None
 
     """
-    Override TASK_PROMPT_TEMPLATE
+    Get prompt to specify as system instruction for a subtask in the plan.
     """
-    task_prompt_template: GetTaskPrompt | None = None
+    get_task_prompt: GetTaskPrompt | None = None
 
     """
-    Override SYNTHESIZE_PLAN_PROMPT_TEMPLATE
+    Get prompt to synthesize the orchestration of the workflow into a final response.
     """
-    synthesize_plan_prompt_template: GetSynthesizePlanPrompt | None = None
+    get_synthesize_plan_prompt: GetSynthesizePlanPrompt | None = None
 
 
 class Orchestrator(AugmentedLLM[MessageParamT, MessageT]):

--- a/src/mcp_agent/workflows/orchestrator/orchestrator.py
+++ b/src/mcp_agent/workflows/orchestrator/orchestrator.py
@@ -614,7 +614,7 @@ class Orchestrator(AugmentedLLM[MessageParamT, MessageT]):
         prompt: str
         if self.overrides.full_plan_prompt_template:
             prompt = self.overrides.full_plan_prompt_template(
-                objective=objective, plan_result=plan_result, agents=self.agents
+                objective=objective, plan_result=plan_result, agents=agents
             )
         else:
             prompt = FULL_PLAN_PROMPT_TEMPLATE.format(

--- a/src/mcp_agent/workflows/orchestrator/orchestrator.py
+++ b/src/mcp_agent/workflows/orchestrator/orchestrator.py
@@ -428,7 +428,7 @@ class Orchestrator(AugmentedLLM[MessageParamT, MessageT]):
                 agent = self.agents.get(task.agent)
                 if not agent:
                     # TODO: saqadri - should we fail the entire workflow in this case?
-                    raise ValueError(f"No agent found matching {task.agent}")
+                    raise ValueError(f"The planner created a task to \"{task.description}\" but there isn't an agent suitable for the task, consider adding an agent.")
                 elif isinstance(agent, AugmentedLLM):
                     llm = agent
                 else:

--- a/src/mcp_agent/workflows/orchestrator/orchestrator_prompts.py
+++ b/src/mcp_agent/workflows/orchestrator/orchestrator_prompts.py
@@ -35,7 +35,7 @@ Steps are sequential, but each Step can have parallel subtasks.
 For each Step, specify a description of the step and independent subtasks that can run in parallel.
 For each subtask specify:
     1. Clear description of the task that an LLM can execute  
-    2. Name of 1 Agent OR List of MCP server names to use for the task
+    2. Name of 1 Agent (ONLY using the available agents specified) OR List of MCP server names to use for the task
     
 Return your response in the following JSON structure:
     {{
@@ -82,7 +82,7 @@ Agents:
 Generate the next step, by specifying a description of the step and independent subtasks that can run in parallel:
 For each subtask specify:
     1. Clear description of the task that an LLM can execute  
-    2. Name of 1 Agent OR List of MCP server names to use for the task
+    2. Name of 1 Agent (ONLY using the available agents specified) OR List of MCP server names to use for the task
 
 Return your response in the following JSON structure:
     {{

--- a/tests/workflows/orchestrator/test_orchestrator_overrides.py
+++ b/tests/workflows/orchestrator/test_orchestrator_overrides.py
@@ -1,0 +1,554 @@
+import pytest
+from unittest.mock import MagicMock
+
+from mcp_agent.workflows.orchestrator.orchestrator import (
+    Orchestrator,
+    OrchestratorOverrides,
+)
+from mcp_agent.workflows.orchestrator.orchestrator_models import (
+    PlanResult,
+)
+
+
+class TestOrchestratorOverrides:
+    """Tests for OrchestratorOverrides dataclass"""
+
+    def test_init_with_defaults(self):
+        """Test that OrchestratorOverrides can be initialized with default values"""
+        overrides = OrchestratorOverrides()
+
+        assert overrides.orchestrator_instruction is None
+        assert overrides.planner_instruction is None
+        assert overrides.synthesizer_instruction is None
+        assert overrides.get_full_plan_prompt is None
+        assert overrides.get_iterative_plan_prompt is None
+        assert overrides.get_task_prompt is None
+        assert overrides.get_synthesize_plan_prompt is None
+
+    def test_init_with_all_overrides(self):
+        """Test that OrchestratorOverrides can be initialized with all overrides"""
+        custom_orchestrator_instruction = "Custom orchestrator instruction"
+        custom_planner_instruction = "Custom planner instruction"
+        custom_synthesizer_instruction = "Custom synthesizer instruction"
+
+        def custom_get_full_plan_prompt(objective, plan_result, agents):
+            agent_count = len(agents) if agents else 0
+            status = (
+                "complete" if plan_result and plan_result.is_complete else "incomplete"
+            )
+            return f"Custom full plan prompt for {objective} (agents: {agent_count}, status: {status})"
+
+        def custom_get_iterative_plan_prompt(objective, plan_result, agents):
+            agent_count = len(agents) if agents else 0
+            steps_completed = len(plan_result.step_results) if plan_result else 0
+            return f"Custom iterative plan prompt for {objective} (agents: {agent_count}, steps done: {steps_completed})"
+
+        def custom_get_task_prompt(objective, task, context):
+            context_length = len(context) if context else 0
+            return f"Custom task prompt for {task} (objective: {objective}, context chars: {context_length})"
+
+        def custom_get_synthesize_plan_prompt(plan_result):
+            steps_count = len(plan_result.step_results) if plan_result else 0
+            return f"Custom synthesize plan prompt for {plan_result.objective} ({steps_count} steps completed)"
+
+        overrides = OrchestratorOverrides(
+            orchestrator_instruction=custom_orchestrator_instruction,
+            planner_instruction=custom_planner_instruction,
+            synthesizer_instruction=custom_synthesizer_instruction,
+            get_full_plan_prompt=custom_get_full_plan_prompt,
+            get_iterative_plan_prompt=custom_get_iterative_plan_prompt,
+            get_task_prompt=custom_get_task_prompt,
+            get_synthesize_plan_prompt=custom_get_synthesize_plan_prompt,
+        )
+
+        assert overrides.orchestrator_instruction == custom_orchestrator_instruction
+        assert overrides.planner_instruction == custom_planner_instruction
+        assert overrides.synthesizer_instruction == custom_synthesizer_instruction
+        assert overrides.get_full_plan_prompt == custom_get_full_plan_prompt
+        assert overrides.get_iterative_plan_prompt == custom_get_iterative_plan_prompt
+        assert overrides.get_task_prompt == custom_get_task_prompt
+        assert overrides.get_synthesize_plan_prompt == custom_get_synthesize_plan_prompt
+
+        # Test that all custom functions work correctly with all their parameters
+        test_plan_result = PlanResult(objective="test obj", step_results=[])
+        test_agents = ["agent1", "agent2"]
+
+        full_plan_result = custom_get_full_plan_prompt(
+            "test objective", test_plan_result, test_agents
+        )
+        assert (
+            "Custom full plan prompt for test objective (agents: 2, status: incomplete)"
+            == full_plan_result
+        )
+
+        iterative_plan_result = custom_get_iterative_plan_prompt(
+            "test objective", test_plan_result, test_agents
+        )
+        assert (
+            "Custom iterative plan prompt for test objective (agents: 2, steps done: 0)"
+            == iterative_plan_result
+        )
+
+        task_result = custom_get_task_prompt(
+            "test objective", "test task", "context data"
+        )
+        assert (
+            "Custom task prompt for test task (objective: test objective, context chars: 12)"
+            == task_result
+        )
+
+        synthesize_result = custom_get_synthesize_plan_prompt(test_plan_result)
+        assert (
+            "Custom synthesize plan prompt for test obj (0 steps completed)"
+            == synthesize_result
+        )
+
+
+class TestOrchestratorWithOverrides:
+    """Tests for Orchestrator functionality with overrides applied"""
+
+    def test_orchestrator_with_custom_orchestrator_instruction(
+        self, mock_llm_factory, mock_context
+    ):
+        """Test that Orchestrator uses custom orchestrator instruction when provided"""
+        custom_instruction = "Custom orchestrator instruction for testing"
+        overrides = OrchestratorOverrides(orchestrator_instruction=custom_instruction)
+
+        orchestrator = Orchestrator(
+            llm_factory=mock_llm_factory, context=mock_context, overrides=overrides
+        )
+
+        assert orchestrator.agent.instruction == custom_instruction
+
+    def test_orchestrator_with_custom_planner_instruction(
+        self, mock_llm_factory, mock_context
+    ):
+        """Test that Orchestrator uses custom planner instruction when provided"""
+        custom_instruction = "Custom planner instruction for testing"
+        overrides = OrchestratorOverrides(planner_instruction=custom_instruction)
+
+        # Create a mock LLM factory that tracks calls
+        mock_factory = MagicMock(side_effect=mock_llm_factory)
+
+        # Create orchestrator to trigger planner creation with custom instruction
+        _ = Orchestrator(
+            llm_factory=mock_factory, context=mock_context, overrides=overrides
+        )
+
+        # The planner should be created with the custom instruction
+        # We can verify this by checking the agent passed to the llm_factory
+        mock_factory.assert_called()
+        # Get the planner creation call
+        planner_agent_calls = [
+            call
+            for call in mock_factory.call_args_list
+            if call[1]["agent"].name == "LLM Orchestration Planner"
+        ]
+        assert len(planner_agent_calls) > 0
+        planner_agent = planner_agent_calls[0][1]["agent"]
+        assert custom_instruction.strip() in planner_agent.instruction
+
+    def test_orchestrator_with_custom_synthesizer_instruction(
+        self, mock_llm_factory, mock_context
+    ):
+        """Test that Orchestrator uses custom synthesizer instruction when provided"""
+        custom_instruction = "Custom synthesizer instruction for testing"
+        overrides = OrchestratorOverrides(synthesizer_instruction=custom_instruction)
+
+        # Create a mock LLM factory that tracks calls
+        mock_factory = MagicMock(side_effect=mock_llm_factory)
+
+        # Create orchestrator to trigger synthesizer creation with custom instruction
+        _ = Orchestrator(
+            llm_factory=mock_factory, context=mock_context, overrides=overrides
+        )
+
+        # The synthesizer should be created with the custom instruction
+        # We can verify this by checking the agent passed to the llm_factory
+        mock_factory.assert_called()
+        # Get the synthesizer creation call
+        synthesizer_agent_calls = [
+            call
+            for call in mock_factory.call_args_list
+            if call[1]["agent"].name == "LLM Orchestration Synthesizer"
+        ]
+        assert len(synthesizer_agent_calls) > 0
+        synthesizer_agent = synthesizer_agent_calls[0][1]["agent"]
+        assert synthesizer_agent.instruction == custom_instruction
+
+    def test_orchestrator_with_custom_full_plan_prompt(
+        self, mock_llm_factory, mock_agents, mock_context
+    ):
+        """Test that Orchestrator stores custom full plan prompt correctly"""
+
+        def custom_get_full_plan_prompt(objective, plan_result, agents):
+            agent_count = len(agents) if agents else 0
+            status = (
+                "complete" if plan_result and plan_result.is_complete else "incomplete"
+            )
+            return f"CUSTOM FULL PLAN: {objective} (agents: {agent_count}, status: {status})"
+
+        overrides = OrchestratorOverrides(
+            get_full_plan_prompt=custom_get_full_plan_prompt
+        )
+
+        orchestrator = Orchestrator(
+            llm_factory=mock_llm_factory,
+            available_agents=mock_agents,
+            context=mock_context,
+            overrides=overrides,
+        )
+
+        # Verify that the override was properly stored
+        assert (
+            orchestrator.overrides.get_full_plan_prompt == custom_get_full_plan_prompt
+        )
+
+        # Test that the custom function works correctly with all parameters
+        test_plan_result = PlanResult(objective="test obj", step_results=[])
+        test_prompt = orchestrator.overrides.get_full_plan_prompt(
+            objective="test objective",
+            plan_result=test_plan_result,
+            agents=["agent1", "agent2"],
+        )
+        assert (
+            test_prompt
+            == "CUSTOM FULL PLAN: test objective (agents: 2, status: incomplete)"
+        )
+
+    def test_orchestrator_with_custom_iterative_plan_prompt(
+        self, mock_llm_factory, mock_agents, mock_context
+    ):
+        """Test that Orchestrator stores custom iterative plan prompt correctly"""
+
+        def custom_get_iterative_plan_prompt(objective, plan_result, agents):
+            agent_count = len(agents) if agents else 0
+            steps_completed = len(plan_result.step_results) if plan_result else 0
+            return f"CUSTOM ITERATIVE PLAN: {objective} (agents: {agent_count}, steps done: {steps_completed})"
+
+        overrides = OrchestratorOverrides(
+            get_iterative_plan_prompt=custom_get_iterative_plan_prompt
+        )
+
+        orchestrator = Orchestrator(
+            llm_factory=mock_llm_factory,
+            available_agents=mock_agents,
+            context=mock_context,
+            overrides=overrides,
+        )
+
+        # Verify that the override was properly stored
+        assert (
+            orchestrator.overrides.get_iterative_plan_prompt
+            == custom_get_iterative_plan_prompt
+        )
+
+        # Test that the custom function works correctly with all parameters
+        test_plan_result = PlanResult(objective="test obj", step_results=[])
+        test_prompt = orchestrator.overrides.get_iterative_plan_prompt(
+            objective="test objective",
+            plan_result=test_plan_result,
+            agents=["agent1", "agent2"],
+        )
+        assert (
+            test_prompt
+            == "CUSTOM ITERATIVE PLAN: test objective (agents: 2, steps done: 0)"
+        )
+
+    def test_orchestrator_with_custom_task_prompt(self, mock_llm_factory, mock_context):
+        """Test that Orchestrator properly stores custom task prompt template"""
+
+        def custom_get_task_prompt(objective, task, context):
+            context_length = len(context) if context else 0
+            return f"CUSTOM TASK: {task} (objective: {objective}, context chars: {context_length})"
+
+        overrides = OrchestratorOverrides(get_task_prompt=custom_get_task_prompt)
+
+        orchestrator = Orchestrator(
+            llm_factory=mock_llm_factory,
+            context=mock_context,
+            overrides=overrides,
+        )
+
+        # Verify that the override was properly stored
+        assert orchestrator.overrides.get_task_prompt == custom_get_task_prompt
+
+        # Test that the custom template function works correctly with all parameters
+        test_prompt = orchestrator.overrides.get_task_prompt(
+            objective="test objective", task="test task", context="context data"
+        )
+        assert (
+            test_prompt
+            == "CUSTOM TASK: test task (objective: test objective, context chars: 12)"
+        )
+
+    def test_orchestrator_with_custom_synthesize_plan_prompt(
+        self, mock_llm_factory, mock_agents, mock_context
+    ):
+        """Test that Orchestrator stores custom synthesize plan prompt correctly"""
+
+        def custom_get_synthesize_plan_prompt(plan_result):
+            steps_count = len(plan_result.step_results) if plan_result else 0
+            return f"CUSTOM SYNTHESIZE: {plan_result.objective} ({steps_count} steps completed)"
+
+        overrides = OrchestratorOverrides(
+            get_synthesize_plan_prompt=custom_get_synthesize_plan_prompt
+        )
+
+        orchestrator = Orchestrator(
+            llm_factory=mock_llm_factory,
+            available_agents=mock_agents,
+            context=mock_context,
+            overrides=overrides,
+        )
+
+        # Verify that the override was properly stored
+        assert (
+            orchestrator.overrides.get_synthesize_plan_prompt
+            == custom_get_synthesize_plan_prompt
+        )
+
+        # Test that the custom function works correctly with all parameters
+        plan_result = PlanResult(objective="test objective", step_results=[])
+        test_prompt = orchestrator.overrides.get_synthesize_plan_prompt(plan_result)
+        assert test_prompt == "CUSTOM SYNTHESIZE: test objective (0 steps completed)"
+
+    def test_orchestrator_with_no_overrides_uses_defaults(
+        self, mock_llm_factory, mock_context
+    ):
+        """Test that Orchestrator uses default values when no overrides are provided"""
+        # Create a mock LLM factory that tracks calls
+        mock_factory = MagicMock(side_effect=mock_llm_factory)
+
+        orchestrator = Orchestrator(llm_factory=mock_factory, context=mock_context)
+
+        # Check that default orchestrator instruction is used
+        assert (
+            orchestrator.agent.instruction is not None
+            and len(orchestrator.agent.instruction) > 0
+        )
+
+        # Check that the overrides object is created with defaults (all None)
+        assert orchestrator.overrides is not None
+        assert orchestrator.overrides.orchestrator_instruction is None
+        assert orchestrator.overrides.planner_instruction is None
+        assert orchestrator.overrides.synthesizer_instruction is None
+        assert orchestrator.overrides.get_full_plan_prompt is None
+        assert orchestrator.overrides.get_iterative_plan_prompt is None
+        assert orchestrator.overrides.get_task_prompt is None
+        assert orchestrator.overrides.get_synthesize_plan_prompt is None
+
+        # Verify that the planner was created with the default instruction
+        planner_agent_calls = [
+            call
+            for call in mock_factory.call_args_list
+            if call[1]["agent"].name == "LLM Orchestration Planner"
+        ]
+        assert len(planner_agent_calls) > 0
+        planner_agent = planner_agent_calls[0][1]["agent"]
+        assert len(planner_agent.instruction) > 0
+
+        # Verify that the synthesizer was created with the default instruction
+        synthesizer_agent_calls = [
+            call
+            for call in mock_factory.call_args_list
+            if call[1]["agent"].name == "LLM Orchestration Synthesizer"
+        ]
+        assert synthesizer_agent_calls is not None and len(synthesizer_agent_calls) > 0
+        synthesizer_agent = synthesizer_agent_calls[0][1]["agent"]
+        assert (
+            synthesizer_agent.instruction is not None
+            and len(synthesizer_agent.instruction) > 0
+        )
+
+    def test_orchestrator_with_partial_overrides(self, mock_llm_factory, mock_context):
+        """Test that Orchestrator works correctly with partial overrides"""
+        custom_orchestrator_instruction = "Custom orchestrator instruction"
+        overrides = OrchestratorOverrides(
+            orchestrator_instruction=custom_orchestrator_instruction,
+            # Leave other overrides as None to test partial override behavior
+        )
+
+        orchestrator = Orchestrator(
+            llm_factory=mock_llm_factory, context=mock_context, overrides=overrides
+        )
+
+        # Check that the custom orchestrator instruction is used
+        assert orchestrator.agent.instruction == custom_orchestrator_instruction
+
+        # Check that other overrides remain None (should use defaults)
+        assert orchestrator.overrides.planner_instruction is None
+        assert orchestrator.overrides.synthesizer_instruction is None
+        assert orchestrator.overrides.get_full_plan_prompt is None
+
+
+class TestOrchestratorOverrideProtocols:
+    """Tests for the protocol classes used in orchestrator overrides"""
+
+    def test_custom_full_plan_prompt_function(self):
+        """Test that custom full plan prompt function works correctly with all parameters"""
+
+        def custom_full_plan_prompt(objective: str, plan_result, agents):
+            agent_count = len(agents) if agents else 0
+            status = (
+                "complete" if plan_result and plan_result.is_complete else "incomplete"
+            )
+            return f"Custom prompt for {objective} (agents: {agent_count}, status: {status})"
+
+        test_plan_result = PlanResult(objective="test obj", step_results=[])
+        result = custom_full_plan_prompt(
+            "test objective", test_plan_result, ["agent1", "agent2"]
+        )
+        assert (
+            result == "Custom prompt for test objective (agents: 2, status: incomplete)"
+        )
+
+    def test_custom_iterative_plan_prompt_function(self):
+        """Test that custom iterative plan prompt function works correctly with all parameters"""
+
+        def custom_iterative_plan_prompt(objective: str, plan_result, agents):
+            agent_count = len(agents) if agents else 0
+            steps_completed = len(plan_result.step_results) if plan_result else 0
+            return f"Custom iterative prompt for {objective} (agents: {agent_count}, steps done: {steps_completed})"
+
+        test_plan_result = PlanResult(objective="test obj", step_results=[])
+        result = custom_iterative_plan_prompt(
+            "test objective", test_plan_result, ["agent1"]
+        )
+        assert (
+            result
+            == "Custom iterative prompt for test objective (agents: 1, steps done: 0)"
+        )
+
+    def test_custom_task_prompt_function(self):
+        """Test that custom task prompt function works correctly with all parameters"""
+
+        def custom_task_prompt(objective: str, task: str, context: str):
+            context_length = len(context) if context else 0
+            return f"Custom task prompt for {task} (objective: {objective}, context chars: {context_length})"
+
+        result = custom_task_prompt("test objective", "test task", "context data")
+        assert (
+            result
+            == "Custom task prompt for test task (objective: test objective, context chars: 12)"
+        )
+
+    def test_custom_synthesize_plan_prompt_function(self):
+        """Test that custom synthesize plan prompt function works correctly with all parameters"""
+
+        def custom_synthesize_plan_prompt(plan_result):
+            steps_count = len(plan_result.step_results) if plan_result else 0
+            return f"Custom synthesize prompt for {plan_result.objective} ({steps_count} steps completed)"
+
+        plan_result = PlanResult(objective="test objective", step_results=[])
+        result = custom_synthesize_plan_prompt(plan_result)
+        assert (
+            result == "Custom synthesize prompt for test objective (0 steps completed)"
+        )
+
+
+class TestOrchestratorOverridesIntegration:
+    """Integration tests for orchestrator overrides with complex scenarios"""
+
+    def test_orchestrator_overrides_end_to_end(
+        self, mock_llm_factory, mock_agents, mock_context
+    ):
+        """Test that all overrides are stored correctly together"""
+        custom_orchestrator_instruction = "Custom orchestrator for E2E test"
+        custom_planner_instruction = "Custom planner for E2E test"
+        custom_synthesizer_instruction = "Custom synthesizer for E2E test"
+
+        def custom_get_full_plan_prompt(objective, plan_result, agents):
+            agent_count = len(agents) if agents else 0
+            status = (
+                "complete" if plan_result and plan_result.is_complete else "incomplete"
+            )
+            return (
+                f"E2E FULL PLAN: {objective} (agents: {agent_count}, status: {status})"
+            )
+
+        def custom_get_task_prompt(objective, task, context):
+            context_length = len(context) if context else 0
+            return f"E2E TASK: {task} (objective: {objective}, context chars: {context_length})"
+
+        def custom_get_synthesize_plan_prompt(plan_result):
+            steps_count = len(plan_result.step_results) if plan_result else 0
+            return f"E2E SYNTHESIZE: {plan_result.objective} ({steps_count} steps completed)"
+
+        overrides = OrchestratorOverrides(
+            orchestrator_instruction=custom_orchestrator_instruction,
+            planner_instruction=custom_planner_instruction,
+            synthesizer_instruction=custom_synthesizer_instruction,
+            get_full_plan_prompt=custom_get_full_plan_prompt,
+            get_task_prompt=custom_get_task_prompt,
+            get_synthesize_plan_prompt=custom_get_synthesize_plan_prompt,
+        )
+
+        orchestrator = Orchestrator(
+            llm_factory=mock_llm_factory,
+            available_agents=mock_agents,
+            context=mock_context,
+            overrides=overrides,
+        )
+
+        # Verify that all custom instructions were applied
+        assert orchestrator.agent.instruction == custom_orchestrator_instruction
+
+        # Verify that all overrides were stored correctly
+        assert (
+            orchestrator.overrides.orchestrator_instruction
+            == custom_orchestrator_instruction
+        )
+        assert orchestrator.overrides.planner_instruction == custom_planner_instruction
+        assert (
+            orchestrator.overrides.synthesizer_instruction
+            == custom_synthesizer_instruction
+        )
+        assert (
+            orchestrator.overrides.get_full_plan_prompt == custom_get_full_plan_prompt
+        )
+        assert orchestrator.overrides.get_task_prompt == custom_get_task_prompt
+        assert (
+            orchestrator.overrides.get_synthesize_plan_prompt
+            == custom_get_synthesize_plan_prompt
+        )
+
+        # Test that all custom functions work correctly with all parameters
+        test_plan_result = PlanResult(objective="test obj", step_results=[])
+
+        full_plan_result = custom_get_full_plan_prompt(
+            "test", test_plan_result, ["agent1", "agent2"]
+        )
+        assert full_plan_result == "E2E FULL PLAN: test (agents: 2, status: incomplete)"
+
+        task_result = custom_get_task_prompt("test obj", "test task", "context data")
+        assert (
+            task_result
+            == "E2E TASK: test task (objective: test obj, context chars: 12)"
+        )
+
+        synthesize_result = custom_get_synthesize_plan_prompt(test_plan_result)
+        assert synthesize_result == "E2E SYNTHESIZE: test obj (0 steps completed)"
+
+    def test_orchestrator_override_error_handling(self, mock_llm_factory, mock_context):
+        """Test that orchestrator can store override functions that might error"""
+
+        def faulty_get_full_plan_prompt(objective, plan_result, agents):
+            raise ValueError("Custom prompt error")
+
+        overrides = OrchestratorOverrides(
+            get_full_plan_prompt=faulty_get_full_plan_prompt
+        )
+
+        orchestrator = Orchestrator(
+            llm_factory=mock_llm_factory, context=mock_context, overrides=overrides
+        )
+
+        # Verify that the override was stored (even though it's faulty)
+        assert (
+            orchestrator.overrides.get_full_plan_prompt == faulty_get_full_plan_prompt
+        )
+
+        # The error should occur when the function is called
+        with pytest.raises(ValueError, match="Custom prompt error"):
+            orchestrator.overrides.get_full_plan_prompt("test", None, [])


### PR DESCRIPTION
  Summary

  - Add OrchestratorOverrides dataclass to allow customization of all orchestrator
  instructions and prompt templates
  - Enable users to override planner, synthesizer, and orchestrator agent instructions
  without creating custom agents
  - Make all prompt templates customizable (FULL_PLAN_PROMPT_TEMPLATE,
  ITERATIVE_PLAN_PROMPT_TEMPLATE, etc.)

  Changes

  - New OrchestratorOverrides dataclass: Contains optional overrides for all orchestrator
   behavior
    - Agent instructions: orchestrator_instruction, planner_instruction,
  synthesizer_instruction
    - Prompt templates: full_plan_prompt_template, iterative_plan_prompt_template,
  task_prompt_template, synthesize_plan_prompt_template, synthesize_step_prompt_template
  - Updated Orchestrator constructor: Accepts optional overrides parameter
  - Implementation: All instructions and prompt templates now use override values when
  provided, falling back to defaults

  Usage

```
  overrides = OrchestratorOverrides(
      planner_instruction="Custom planner behavior...",
      full_plan_prompt_template="Custom template with {objective}, {plan_result}, 
  {agents}"
  )
  orchestrator = Orchestrator(llm_factory=factory, overrides=overrides)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customizing orchestrator instructions and prompt templates through new configuration options. Users can now override default instructions and prompts for various workflow steps, allowing for greater flexibility in orchestrator behavior.  
* **Chores**
  * Updated type annotations to use modern union syntax for improved code clarity.
* **Tests**
  * Introduced comprehensive tests for orchestrator overrides, verifying initialization, usage, integration, and error handling to ensure robust customization support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->