### PR TITLE
[ez] Regenerate Schema

### DIFF
--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -4,64 +4,6 @@
       "additionalProperties": true,
       "description": "Settings for using Anthropic models in the MCP Agent application.",
       "properties": {
-        "api_key": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Api Key"
-        },
-        "default_model": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Default Model"
-        },
-        "provider": {
-          "default": "anthropic",
-          "title": "Bedrock",
-          "type": "string",
-          "enum": [
-            "anthropic",
-            "bedrock",
-            "vertexai"
-          ]
-        },
-        "project": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Project"
-        },
-        "location": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Location"
-        },
         "aws_access_key_id": {
           "anyOf": [
             {
@@ -121,6 +63,64 @@
           ],
           "default": null,
           "title": "Profile"
+        },
+        "project": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Project"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "api_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Api Key"
+        },
+        "default_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Default Model"
+        },
+        "provider": {
+          "default": "anthropic",
+          "enum": [
+            "anthropic",
+            "bedrock",
+            "vertexai"
+          ],
+          "title": "Provider",
+          "type": "string"
         }
       },
       "title": "AnthropicSettings",
@@ -236,38 +236,6 @@
         }
       },
       "title": "BedrockSettings",
-      "type": "object"
-    },
-    "VertexAISettings": {
-      "additionalProperties": true,
-      "description": "Settings for using VertexAI models in the MCP Agent application",
-      "properties": {
-        "project": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Project"
-        },
-        "location": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Location"
-        }
-      },
-      "title": "VertexAISettings",
       "type": "object"
     },
     "CohereSettings": {
@@ -883,6 +851,18 @@
           "default": null,
           "description": "OTLP settings for OpenTelemetry tracing. Required if using otlp exporter."
         },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
         "path_settings": {
           "anyOf": [
             {
@@ -1152,6 +1132,7 @@
         "service_version": null,
         "sample_rate": 1.0,
         "otlp_settings": null,
+        "path": null,
         "path_settings": null
       },
       "description": "OpenTelemetry logging settings for the MCP Agent application"


### PR DESCRIPTION
## Description

Generate the schema to match the latest state. Includes the following changes:
- Anthropic settings includes Bedrock and VertexAI settings (https://github.com/lastmile-ai/mcp-agent/commit/1cd9fca850b78dc22b0d0205251bb2255c330ff0)
- Trace Settings support path override (https://github.com/lastmile-ai/mcp-agent/commit/2e7ad069df98c46e0ed9a6f2d3d8255d95f013e7)

## Testing
```bash
make tests
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional "path" setting to OpenTelemetry configuration.

* **Refactor**
  * Reorganized and renamed configuration options for Anthropic settings to focus on AWS credential fields.
  * Updated provider options to include "anthropic", "bedrock", and "vertexai" with a default of "anthropic".
  * Removed VertexAI settings from the configuration schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->