### PR TITLE
fix: system prompt should not be None when passed to anthropic.messag…

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_anthropic.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_anthropic.py
@@ -223,10 +223,12 @@ class AnthropicAugmentedLLM(AugmentedLLM[MessageParam, Message]):
                     "model": model,
                     "max_tokens": params.maxTokens,
                     "messages": messages,
-                    "system": self.instruction or params.systemPrompt,
                     "stop_sequences": params.stopSequences or [],
                     "tools": available_tools,
                 }
+
+                if system := (self.instruction or params.systemPrompt):
+                    arguments["system"] = system
 
                 if params.metadata:
                     arguments = {**arguments, **params.metadata}


### PR DESCRIPTION
…es.create

Fix Bad Request Error when system prompt is None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the system prompt so it is only included when set, preventing unintended values from being sent.

* **Tests**
  * Added tests to verify correct behavior and precedence of the system prompt in API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->