### PR TITLE
Add watch mode for TokenCounter

### DIFF
--- a/examples/mcp_agent_server/asyncio/basic_agent_server.py
+++ b/examples/mcp_agent_server/asyncio/basic_agent_server.py
@@ -10,6 +10,7 @@ This example demonstrates three approaches to creating agents and workflows:
 import asyncio
 import os
 import logging
+from typing import Dict, Any
 
 from mcp_agent.app import MCPApp
 from mcp_agent.server.app_server import create_mcp_server_for_app
@@ -20,6 +21,7 @@ from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLL
 from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
 from mcp_agent.workflows.parallel.parallel_llm import ParallelLLM
 from mcp_agent.executor.workflow import Workflow, WorkflowResult
+from mcp_agent.tracing.token_counter import TokenNode
 
 # Initialize logging
 logging.basicConfig(level=logging.INFO)
@@ -182,6 +184,124 @@ async def main():
 
         # Create the MCP server that exposes both workflows and agent configurations
         mcp_server = create_mcp_server_for_app(agent_app)
+
+        # Add custom tool to get token usage for a workflow
+        @mcp_server.tool(
+            name="get_token_usage",
+            structured_output=True,
+            description="""
+            Get detailed token usage information for a specific workflow run.
+            
+            This provides a comprehensive breakdown of token usage including:
+            - Total tokens used across all LLM calls within the workflow
+            - Breakdown by model provider and specific models
+            - Hierarchical usage tree showing usage at each level (workflow -> agent -> llm)
+            - Total cost estimate based on model pricing
+            
+            Args:
+                workflow_id: Optional workflow ID (if multiple workflows have the same name)
+                run_id: Optional ID of the workflow run to get token usage for
+                workflow_name: Optional name of the workflow (used as fallback)
+            
+            Returns:
+                Detailed token usage information for the specific workflow run
+            """,
+        )
+        async def get_workflow_token_usage(
+            workflow_id: str | None = None,
+            run_id: str | None = None,
+            workflow_name: str | None = None,
+        ) -> Dict[str, Any]:
+            """Get token usage information for a specific workflow run."""
+            if not context.token_counter:
+                return {
+                    "error": "Token counter not available",
+                    "message": "Token tracking is not enabled for this application",
+                }
+
+            # Find the specific workflow node
+            workflow_node = context.token_counter.get_workflow_node(
+                name=workflow_name, workflow_id=workflow_id, run_id=run_id
+            )
+
+            if not workflow_node:
+                return {
+                    "error": "Workflow not found",
+                    "message": f"Could not find workflow with run_id='{run_id}'",
+                }
+
+            # Get the aggregated usage for this workflow
+            workflow_usage = workflow_node.aggregate_usage()
+
+            # Calculate cost for this workflow
+            workflow_cost = context.token_counter._calculate_node_cost(workflow_node)
+
+            # Build the response
+            result = {
+                "workflow": {
+                    "name": workflow_node.name,
+                    "run_id": workflow_node.metadata.get("run_id"),
+                    "workflow_id": workflow_node.metadata.get("workflow_id"),
+                },
+                "usage": {
+                    "input_tokens": workflow_usage.input_tokens,
+                    "output_tokens": workflow_usage.output_tokens,
+                    "total_tokens": workflow_usage.total_tokens,
+                },
+                "cost": round(workflow_cost, 4),
+                "model_breakdown": {},
+                "usage_tree": workflow_node.to_dict(),
+            }
+
+            # Get model breakdown for this workflow
+            model_usage = {}
+
+            def collect_model_usage(node: TokenNode):
+                """Recursively collect model usage from a node tree"""
+                if node.usage.model_name:
+                    model_name = node.usage.model_name
+                    provider = (
+                        node.usage.model_info.provider
+                        if node.usage.model_info
+                        else None
+                    )
+
+                    # Use tuple as key to handle same model from different providers
+                    model_key = (model_name, provider)
+
+                    if model_key not in model_usage:
+                        model_usage[model_key] = {
+                            "model_name": model_name,
+                            "provider": provider,
+                            "input_tokens": 0,
+                            "output_tokens": 0,
+                            "total_tokens": 0,
+                        }
+
+                    model_usage[model_key]["input_tokens"] += node.usage.input_tokens
+                    model_usage[model_key]["output_tokens"] += node.usage.output_tokens
+                    model_usage[model_key]["total_tokens"] += node.usage.total_tokens
+
+                for child in node.children:
+                    collect_model_usage(child)
+
+            collect_model_usage(workflow_node)
+
+            # Calculate costs for each model and format for output
+            for (model_name, provider), usage in model_usage.items():
+                cost = context.token_counter.calculate_cost(
+                    model_name, usage["input_tokens"], usage["output_tokens"], provider
+                )
+
+                # Create display key with provider info if available
+                display_key = f"{model_name} ({provider})" if provider else model_name
+
+                result["model_breakdown"][display_key] = {
+                    **usage,
+                    "cost": round(cost, 4),
+                }
+
+            return result
 
         # Run the server
         await mcp_server.run_stdio_async()

--- a/examples/mcp_agent_server/asyncio/client.py
+++ b/examples/mcp_agent_server/asyncio/client.py
@@ -7,6 +7,8 @@ from mcp_agent.config import MCPServerSettings
 from mcp_agent.executor.workflow import WorkflowExecution
 from mcp_agent.mcp.gen_client import gen_client
 
+from rich import print
+
 
 async def main():
     # Create MCPApp to get the server registry
@@ -122,6 +124,24 @@ async def main():
                 #     "workflows-cancel",
                 #     arguments={"workflow_id": "BasicAgentWorkflow", "run_id": run_id},
                 # )
+
+            # Get the token usage summary
+            logger.info("Fetching token usage summary...")
+            token_usage_result = await server.call_tool(
+                "get_token_usage",
+                arguments={
+                    "run_id": run_id,
+                    "workflow_id": execution.workflow_id,
+                },
+            )
+
+            logger.info(
+                "Token usage summary:",
+                data=_tool_result_to_json(token_usage_result) or token_usage_result,
+            )
+
+            # Display the token usage summary
+            print(token_usage_result.structuredContent)
 
 
 def _tool_result_to_json(tool_result: CallToolResult):

--- a/src/mcp_agent/human_input/handler.py
+++ b/src/mcp_agent/human_input/handler.py
@@ -67,7 +67,12 @@ def _create_panel(request: HumanInputRequest) -> Panel:
 
 async def console_input_callback(request: HumanInputRequest) -> HumanInputResponse:
     """Entry point: handle both simple and schema-based input."""
-    with progress_display.paused():
+    # Use context manager if progress_display exists, otherwise just run the code
+    if progress_display and hasattr(progress_display, "paused"):
+        with progress_display.paused():
+            console.print(_create_panel(request))
+            response = await _handle_simple_input(request)
+    else:
         console.print(_create_panel(request))
         response = await _handle_simple_input(request)
     return HumanInputResponse(request_id=request.request_id, response=response)

--- a/src/mcp_agent/logging/listeners.py
+++ b/src/mcp_agent/logging/listeners.py
@@ -113,27 +113,30 @@ class ProgressListener(LifecycleAwareListener):
     FilteredListener, we get events before any filtering occurs.
     """
 
-    def __init__(self, display=None):
+    def __init__(self, display=None, token_counter=None):
         """Initialize the progress listener.
         Args:
-            display: Optional display handler. If None, the shared progress_display will be used.
+            display: Optional display handler. If None, the shared progress_display will be used if available.
         """
-        from mcp_agent.logging.progress_display import progress_display
+        self.display = display
+        if self.display is None:
+            from mcp_agent.logging.progress_display import create_progress_display
 
-        self.display = display or progress_display
+            self.display = create_progress_display(token_counter=token_counter)
 
     async def start(self):
         """Start the progress display."""
-        self.display.start()
+        if self.display:
+            self.display.start()
 
     async def stop(self):
         """Stop the progress display."""
-        self.display.stop()
+        if self.display:
+            self.display.stop()
 
     async def handle_event(self, event: Event):
         """Process an incoming event and display progress if relevant."""
-
-        if event.data:
+        if self.display and event.data:
             progress_event = convert_log_event(event)
             if progress_event:
                 self.display.update(progress_event)

--- a/src/mcp_agent/logging/logger.py
+++ b/src/mcp_agent/logging/logger.py
@@ -244,7 +244,10 @@ class LoggingConfig:
 
         # Only add progress listener if enabled in settings
         if "progress" not in bus.listeners and kwargs.get("progress_display", True):
-            bus.add_listener("progress", ProgressListener())
+            bus.add_listener(
+                "progress",
+                ProgressListener(token_counter=kwargs.get("token_counter", None)),
+            )
 
         if "batching" not in bus.listeners:
             bus.add_listener(

--- a/src/mcp_agent/logging/progress_display.py
+++ b/src/mcp_agent/logging/progress_display.py
@@ -1,10 +1,32 @@
 """
 Centralized progress display configuration for MCP Agent.
-Provides a shared progress display instance for consistent progress handling.
+Provides optional shared progress display instance for consistent progress handling.
 """
 
+from typing import Optional
 from mcp_agent.console import console
 from mcp_agent.logging.rich_progress import RichProgressDisplay
 
-# Main progress display instance - shared across the application
-progress_display = RichProgressDisplay(console)
+# Main progress display instance - can be created when needed
+progress_display: Optional[RichProgressDisplay] = None
+
+
+def get_progress_display(token_counter=None) -> RichProgressDisplay:
+    """Get or create the shared progress display instance.
+
+    Args:
+        token_counter: Optional TokenCounter instance for token tracking
+    """
+    global progress_display
+    if progress_display is None:
+        progress_display = RichProgressDisplay(console, token_counter)
+    return progress_display
+
+
+def create_progress_display(token_counter=None) -> RichProgressDisplay:
+    """Create a new progress display instance.
+
+    Args:
+        token_counter: Optional TokenCounter instance for token tracking
+    """
+    return RichProgressDisplay(console, token_counter)

--- a/src/mcp_agent/logging/rich_progress.py
+++ b/src/mcp_agent/logging/rich_progress.py
@@ -10,12 +10,22 @@ from contextlib import contextmanager
 
 
 class RichProgressDisplay:
-    """Rich-based display for progress events."""
+    """Rich-based display for progress events with optional token tracking."""
 
-    def __init__(self, console: Optional[Console] = None):
-        """Initialize the progress display."""
+    def __init__(self, console: Optional[Console] = None, token_counter=None):
+        """Initialize the progress display.
+
+        Args:
+            console: Rich console to use
+            token_counter: Optional TokenCounter instance for token tracking
+        """
         self.console = console or default_console
         self._taskmap = {}
+        self._token_counter = token_counter
+        self._token_task_id = None
+        self._token_watch_id = None
+
+        # Create progress display
         self._progress = Progress(
             SpinnerColumn(spinner_name="simpleDotsScrolling"),
             TextColumn(
@@ -29,19 +39,78 @@ class RichProgressDisplay:
         self._paused = False
 
     def start(self):
-        """start"""
-
+        """Start the progress display and optionally token tracking."""
         self._progress.start()
 
+        # Always add a token tracking row if token counter is available
+        if self._token_counter:
+            self._start_token_tracking()
+
     def stop(self):
-        """stop"""
+        """Stop the progress display and token tracking."""
+        # Stop token tracking if active
+        if self._token_watch_id and self._token_counter:
+            self._token_counter.unwatch(self._token_watch_id)
+            self._token_watch_id = None
+
         self._progress.stop()
+
+    def _start_token_tracking(self):
+        """Start tracking token usage."""
+        # Add a task for token display
+        self._token_task_id = self._progress.add_task(
+            "",  # description (empty for consistency)
+            target="usage",
+            details="",
+            total=None,
+        )
+
+        # Set initial description with token data
+        self._progress.update(
+            self._token_task_id,
+            description="[bold cyan]Tokens      ",
+            details="0 tokens | $0.0000",
+        )
+
+        # Try to register watch immediately, but don't fail if root doesn't exist yet
+        self._try_register_watch()
+
+    def _try_register_watch(self):
+        """Try to register the token watch if root node exists."""
+        if self._token_watch_id or not self._token_counter:
+            return  # Already registered or no counter
+
+        # Check if root node exists now
+        if hasattr(self._token_counter, "_root") and self._token_counter._root:
+            self._token_watch_id = self._token_counter.watch(
+                callback=self._on_token_update,
+                node=self._token_counter._root,
+                threshold=1,
+                throttle_ms=100,
+            )
+
+            # Get initial summary and update display
+            initial_summary = self._token_counter.get_summary()
+            if initial_summary.usage.total_tokens > 0:
+                self._progress.update(
+                    self._token_task_id,
+                    description="[bold cyan]Tokens      ",
+                    details=f"{initial_summary.usage.total_tokens:,} tokens | ${initial_summary.cost:.4f}",
+                )
+
+    async def _on_token_update(self, node, usage):
+        """Handle token usage updates."""
+        summary = self._token_counter.get_summary()
+        self._progress.update(
+            self._token_task_id,
+            description="[bold cyan]Tokens      ",
+            details=f"{summary.usage.total_tokens:,} tokens | ${summary.cost:.4f}",
+        )
 
     def pause(self):
         """Pause the progress display."""
         if not self._paused:
             self._paused = True
-
             for task in self._progress.tasks:
                 task.visible = False
             self._progress.stop()
@@ -83,6 +152,14 @@ class RichProgressDisplay:
 
     def update(self, event: ProgressEvent) -> None:
         """Update the progress display with a new event."""
+        # Try to register token watch if we haven't yet
+        if (
+            self._token_counter
+            and self._token_task_id is not None
+            and not self._token_watch_id
+        ):
+            self._try_register_watch()
+
         task_name = event.agent_name or "default"
 
         # Create new task if needed
@@ -90,7 +167,7 @@ class RichProgressDisplay:
             task_id = self._progress.add_task(
                 "",
                 total=None,
-                target=f"{event.target or task_name}",  # Use task_name as fallback for target
+                target=f"{event.target or task_name}",
                 details=f"{event.agent_name or ''}",
             )
             self._taskmap[task_name] = task_id
@@ -101,7 +178,7 @@ class RichProgressDisplay:
         self._progress.update(
             task_id,
             description=f"[{self._get_action_style(event.action)}]{event.action.value:<15}",
-            target=event.target or task_name,  # Use task_name as fallback for target
+            target=event.target or task_name,
             details=event.details or "",
             task_name=task_name,
         )
@@ -120,7 +197,8 @@ class RichProgressDisplay:
                 details=f" / Elapsed Time {time.strftime('%H:%M:%S', time.gmtime(self._progress.tasks[task_id].elapsed))}",
             )
             for task in self._progress.tasks:
-                if task.id != task_id:
+                # Never hide the token display task
+                if task.id != task_id and task.id != self._token_task_id:
                     task.visible = False
         elif event.action == ProgressAction.FATAL_ERROR:
             self._progress.update(
@@ -130,7 +208,8 @@ class RichProgressDisplay:
                 details=f" / {event.details}",
             )
             for task in self._progress.tasks:
-                if task.id != task_id:
+                # Never hide the token display task
+                if task.id != task_id and task.id != self._token_task_id:
                     task.visible = False
         else:
             self._progress.reset(task_id)

--- a/src/mcp_agent/logging/rich_token_display.py
+++ b/src/mcp_agent/logging/rich_token_display.py
@@ -1,0 +1,226 @@
+"""Rich-based live token usage display for MCP Agent."""
+
+from typing import Dict, Optional, Tuple
+from rich.console import Console
+from rich.live import Live
+from rich.table import Table
+from rich.layout import Layout
+from rich.panel import Panel
+from rich.text import Text
+from rich.align import Align
+from threading import Lock
+from datetime import datetime, timedelta
+
+from mcp_agent.console import console as default_console
+from mcp_agent.tracing.token_counter import TokenNode, TokenUsage, TokenCounter
+
+
+class RichTokenDisplay:
+    """Rich-based live display for token usage tracking."""
+
+    def __init__(
+        self,
+        token_counter: TokenCounter,
+        console: Optional[Console] = None,
+        update_interval: float = 0.5,
+    ):
+        """Initialize the token display.
+
+        Args:
+            token_counter: The TokenCounter instance to monitor
+            console: Rich console to use (defaults to mcp_agent console)
+            update_interval: How often to update the display in seconds
+        """
+        self.console = console or default_console
+        self.token_counter = token_counter
+        self.update_interval = update_interval
+        self._lock = Lock()
+        self._node_data: Dict[str, Tuple[TokenNode, TokenUsage, datetime]] = {}
+        self._total_cost = 0.0
+        self._last_update = datetime.now()
+        self._watch_ids = []
+        self._live = None
+        self._running = False
+
+    def _format_tokens(self, tokens: int) -> str:
+        """Format token count with thousands separator."""
+        return f"{tokens:,}"
+
+    def _format_cost(self, cost: float) -> str:
+        """Format cost in USD."""
+        if cost < 0.01:
+            return f"${cost:.4f}"
+        elif cost < 1.0:
+            return f"${cost:.3f}"
+        else:
+            return f"${cost:.2f}"
+
+    def _format_rate(self, tokens: int, elapsed: timedelta) -> str:
+        """Format tokens per second rate."""
+        seconds = elapsed.total_seconds()
+        if seconds > 0:
+            rate = tokens / seconds
+            return f"{rate:.1f} tok/s"
+        return "- tok/s"
+
+    def _create_display(self) -> Layout:
+        """Create the Rich layout for display."""
+        layout = Layout()
+
+        # Create header
+        header = Panel(
+            Align.center(
+                Text("🔍 Live Token Usage Monitor", style="bold white on blue"),
+                vertical="middle",
+            ),
+            height=3,
+            border_style="blue",
+        )
+
+        # Create main table
+        table = Table(
+            title="Token Usage by Node",
+            title_style="bold cyan",
+            show_header=True,
+            header_style="bold magenta",
+            show_lines=True,
+            expand=True,
+        )
+
+        table.add_column("Node", style="cyan", width=20)
+        table.add_column("Type", style="yellow", width=10)
+        table.add_column("Input", style="green", justify="right", width=12)
+        table.add_column("Output", style="green", justify="right", width=12)
+        table.add_column("Total", style="bold green", justify="right", width=12)
+        table.add_column("Cost", style="bold yellow", justify="right", width=10)
+        table.add_column("Rate", style="blue", justify="right", width=12)
+        table.add_column("Last Update", style="dim", width=15)
+
+        # Add rows for each tracked node
+        with self._lock:
+            sorted_nodes = sorted(
+                self._node_data.items(),
+                key=lambda x: x[1][1].total_tokens,
+                reverse=True,
+            )
+
+            for node_key, (node, usage, last_update) in sorted_nodes:
+                elapsed = datetime.now() - last_update
+                cost = self.token_counter.get_node_cost(node.name, node.node_type)
+
+                table.add_row(
+                    node.name[:20],
+                    node.node_type,
+                    self._format_tokens(usage.input_tokens),
+                    self._format_tokens(usage.output_tokens),
+                    self._format_tokens(usage.total_tokens),
+                    self._format_cost(cost),
+                    self._format_rate(usage.total_tokens, elapsed),
+                    f"{elapsed.total_seconds():.1f}s ago",
+                )
+
+        # Create summary panel
+        summary_data = self.token_counter.get_summary()
+        summary_text = Text()
+        summary_text.append("Total Tokens: ", style="bold")
+        summary_text.append(f"{self._format_tokens(summary_data.usage.total_tokens)}\n")
+        summary_text.append("Total Cost: ", style="bold")
+        summary_text.append(f"{self._format_cost(summary_data.cost)}\n")
+        summary_text.append("Active Nodes: ", style="bold")
+        summary_text.append(f"{len(self._node_data)}")
+
+        summary = Panel(
+            summary_text,
+            title="Summary",
+            title_align="left",
+            border_style="green",
+            padding=(1, 2),
+        )
+
+        # Arrange layout
+        layout.split_column(
+            header,
+            Layout(table, name="table", ratio=3),
+            Layout(summary, name="summary", ratio=1),
+        )
+
+        return layout
+
+    def _on_token_update(self, node: TokenNode, usage: TokenUsage) -> None:
+        """Callback for token updates."""
+        with self._lock:
+            node_key = f"{node.name}_{node.node_type}_{id(node)}"
+            self._node_data[node_key] = (node, usage, datetime.now())
+
+            # Clean up old entries (not updated in last 30 seconds)
+            cutoff = datetime.now() - timedelta(seconds=30)
+            self._node_data = {
+                k: v for k, v in self._node_data.items() if v[2] > cutoff
+            }
+
+    def start(self) -> None:
+        """Start the live display and token watching."""
+        if self._running:
+            return
+
+        self._running = True
+
+        # Watch all node types with low threshold for frequent updates
+        watch_configs = [
+            # Watch app level for overall stats
+            {"node_type": "app", "threshold": 1},
+            # Watch workflows for intermediate tracking
+            {"node_type": "workflow", "threshold": 1},
+            # Watch agents for detailed tracking
+            {"node_type": "agent", "threshold": 1},
+            # Watch LLMs for most granular tracking
+            {"node_type": "llm", "threshold": 1},
+        ]
+
+        for config in watch_configs:
+            watch_id = self.token_counter.watch(
+                callback=self._on_token_update,
+                throttle_ms=100,  # Update at most 10 times per second
+                **config,
+            )
+            self._watch_ids.append(watch_id)
+
+        # Start live display
+        self._live = Live(
+            self._create_display(),
+            console=self.console,
+            refresh_per_second=1 / self.update_interval,
+            transient=False,
+        )
+        self._live.start()
+
+    def stop(self) -> None:
+        """Stop the live display and clean up watches."""
+        if not self._running:
+            return
+
+        self._running = False
+
+        # Remove all watches
+        for watch_id in self._watch_ids:
+            self.token_counter.unwatch(watch_id)
+        self._watch_ids.clear()
+
+        # Stop live display
+        if self._live:
+            self._live.stop()
+            self._live = None
+
+    def update(self) -> None:
+        """Manually update the display."""
+        if self._live and self._running:
+            self._live.update(self._create_display())
+
+    def __enter__(self):
+        """Context manager entry."""
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.stop()

--- a/src/mcp_agent/logging/token_progress_display.py
+++ b/src/mcp_agent/logging/token_progress_display.py
@@ -1,0 +1,138 @@
+"""Token usage progress display using Rich Progress widget."""
+
+from typing import Optional, Dict
+from rich.console import Console
+from rich.progress import Progress, TextColumn
+from mcp_agent.console import console as default_console
+from mcp_agent.tracing.token_counter import TokenNode, TokenUsage, TokenCounter
+from contextlib import contextmanager
+
+
+class TokenProgressDisplay:
+    """Rich Progress-based display for token usage."""
+
+    def __init__(self, token_counter: TokenCounter, console: Optional[Console] = None):
+        """Initialize the token progress display."""
+        self.console = console or default_console
+        self.token_counter = token_counter
+        self._taskmap: Dict[str, int] = {}
+        self._watch_ids = []
+
+        # Create progress display with custom columns
+        self._progress = Progress(
+            TextColumn("[bold cyan]Token Usage", justify="left"),
+            TextColumn("{task.fields[node_info]:<30}", style="white"),
+            TextColumn("{task.fields[tokens]:>10}", style="bold green"),
+            TextColumn("{task.fields[cost]:>10}", style="bold yellow"),
+            console=self.console,
+            transient=False,
+            refresh_per_second=10,
+        )
+        self._paused = False
+        self._total_task_id = None
+
+    def start(self):
+        """Start the progress display and register watches."""
+        self._progress.start()
+
+        # Add a task for the total
+        self._total_task_id = self._progress.add_task(
+            "", total=None, node_info="[bold]TOTAL", tokens="0", cost="$0.0000"
+        )
+
+        # Register watch on app node for aggregate totals
+        if hasattr(self.token_counter, "_root") and self.token_counter._root:
+            watch_id = self.token_counter.watch(
+                callback=self._on_token_update,
+                node=self.token_counter._root,
+                threshold=1,
+                throttle_ms=100,
+            )
+            self._watch_ids.append(watch_id)
+
+    def stop(self):
+        """Stop the progress display and unregister watches."""
+        # Unregister watches
+        for watch_id in self._watch_ids:
+            self.token_counter.unwatch(watch_id)
+        self._watch_ids.clear()
+
+        self._progress.stop()
+
+    def pause(self):
+        """Pause the progress display."""
+        if not self._paused:
+            self._paused = True
+            for task in self._progress.tasks:
+                task.visible = False
+            self._progress.stop()
+
+    def resume(self):
+        """Resume the progress display."""
+        if self._paused:
+            for task in self._progress.tasks:
+                task.visible = True
+            self._paused = False
+            self._progress.start()
+
+    @contextmanager
+    def paused(self):
+        """Context manager for temporarily pausing the display."""
+        self.pause()
+        try:
+            yield
+        finally:
+            self.resume()
+
+    def _format_tokens(self, tokens: int) -> str:
+        """Format token count with thousands separator."""
+        return f"{tokens:,}"
+
+    def _format_cost(self, cost: float) -> str:
+        """Format cost in USD."""
+        return f"${cost:.4f}"
+
+    async def _on_token_update(self, node: TokenNode, usage: TokenUsage):
+        """Handle token usage updates."""
+        # Update total
+        summary = self.token_counter.get_summary()
+        self._progress.update(
+            self._total_task_id,
+            node_info="[bold]TOTAL",
+            tokens=self._format_tokens(summary.usage.total_tokens),
+            cost=self._format_cost(summary.cost),
+        )
+
+        # Get app-level cost
+        cost = self.token_counter.get_node_cost(node.name, node.node_type)
+
+        # Create task key
+        task_key = f"{node.name}_{node.node_type}"
+
+        # Update or create task for this node
+        if task_key not in self._taskmap:
+            task_id = self._progress.add_task(
+                "",
+                total=None,
+                node_info=f"{node.name} ({node.node_type})",
+                tokens=self._format_tokens(usage.total_tokens),
+                cost=self._format_cost(cost),
+            )
+            self._taskmap[task_key] = task_id
+        else:
+            task_id = self._taskmap[task_key]
+            self._progress.update(
+                task_id,
+                node_info=f"{node.name} ({node.node_type})",
+                tokens=self._format_tokens(usage.total_tokens),
+                cost=self._format_cost(cost),
+            )
+
+    def __enter__(self):
+        """Context manager entry."""
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.stop()

--- a/src/mcp_agent/tracing/token_counter.py
+++ b/src/mcp_agent/tracing/token_counter.py
@@ -76,19 +76,26 @@ class TokenNode:
 
     def aggregate_usage(self) -> TokenUsage:
         """Recursively aggregate usage from this node and all children"""
-        total = TokenUsage(
-            input_tokens=self.usage.input_tokens,
-            output_tokens=self.usage.output_tokens,
-            total_tokens=self.usage.total_tokens,
-        )
+        try:
+            total = TokenUsage(
+                input_tokens=self.usage.input_tokens,
+                output_tokens=self.usage.output_tokens,
+                total_tokens=self.usage.total_tokens,
+            )
 
-        for child in self.children:
-            child_usage = child.aggregate_usage()
-            total.input_tokens += child_usage.input_tokens
-            total.output_tokens += child_usage.output_tokens
-            total.total_tokens += child_usage.total_tokens
+            for child in self.children:
+                try:
+                    child_usage = child.aggregate_usage()
+                    total.input_tokens += child_usage.input_tokens
+                    total.output_tokens += child_usage.output_tokens
+                    total.total_tokens += child_usage.total_tokens
+                except Exception as e:
+                    logger.error(f"Error aggregating usage for child {child.name}: {e}")
 
-        return total
+            return total
+        except Exception as e:
+            logger.error(f"Error in aggregate_usage: {e}")
+            return TokenUsage()
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for serialization"""
@@ -402,42 +409,55 @@ class TokenCounter:
         Push a new context onto the stack.
         This is called when entering a new scope (app, workflow, agent, etc).
         """
-        with self._lock:
-            node = TokenNode(name=name, node_type=node_type, metadata=metadata or {})
+        try:
+            with self._lock:
+                node = TokenNode(
+                    name=name, node_type=node_type, metadata=metadata or {}
+                )
 
-            if self._current:
-                self._current.add_child(node)
-            else:
-                # This is the root
-                self._root = node
+                if self._current:
+                    self._current.add_child(node)
+                else:
+                    # This is the root
+                    self._root = node
 
-            self._stack.append(node)
-            self._current = node
+                self._stack.append(node)
+                self._current = node
 
-            logger.debug(f"Pushed token context: {name} ({node_type})")
+                logger.debug(f"Pushed token context: {name} ({node_type})")
+        except Exception as e:
+            logger.error(f"Error in TokenCounter.push: {e}", exc_info=True)
+            # Continue execution - don't break the program
 
     def pop(self) -> Optional[TokenNode]:
         """
         Pop the current context from the stack.
         Returns the popped node with aggregated usage.
         """
-        with self._lock:
-            if not self._stack:
-                logger.warning("Attempted to pop from empty token stack")
-                return None
+        try:
+            with self._lock:
+                if not self._stack:
+                    logger.warning("Attempted to pop from empty token stack")
+                    return None
 
-            node = self._stack.pop()
-            self._current = self._stack[-1] if self._stack else None
+                node = self._stack.pop()
+                self._current = self._stack[-1] if self._stack else None
 
-            # Log aggregated usage for this node
-            usage = node.aggregate_usage()
-            logger.debug(
-                f"Popped token context: {node.name} ({node.node_type}) - "
-                f"Total: {usage.total_tokens} tokens "
-                f"(input: {usage.input_tokens}, output: {usage.output_tokens})"
-            )
+                try:
+                    # Log aggregated usage for this node
+                    usage = node.aggregate_usage()
+                    logger.debug(
+                        f"Popped token context: {node.name} ({node.node_type}) - "
+                        f"Total: {usage.total_tokens} tokens "
+                        f"(input: {usage.input_tokens}, output: {usage.output_tokens})"
+                    )
+                except Exception as e:
+                    logger.error(f"Error aggregating usage during pop: {e}")
 
-            return node
+                return node
+        except Exception as e:
+            logger.error(f"Error in TokenCounter.pop: {e}", exc_info=True)
+            return None
 
     def record_usage(
         self,
@@ -458,45 +478,68 @@ class TokenCounter:
             provider: Optional provider name to help disambiguate models
             model_info: Optional full ModelInfo object with metadata
         """
-        with self._lock:
-            if not self._current:
-                logger.warning("No current token context, creating root")
-                self.push("root", "app")
+        try:
+            # Validate inputs
+            input_tokens = int(input_tokens) if input_tokens is not None else 0
+            output_tokens = int(output_tokens) if output_tokens is not None else 0
 
-            # If we have model_name but no model_info, try to look it up
-            if model_name and not model_info:
-                model_info = self.find_model_info(model_name, provider)
+            with self._lock:
+                if not self._current:
+                    logger.warning("No current token context, creating root")
+                    try:
+                        self.push("root", "app")
+                    except Exception as e:
+                        logger.error(f"Failed to create root context: {e}")
+                        return
 
-            # Update current node's usage
-            self._current.usage.input_tokens += input_tokens
-            self._current.usage.output_tokens += output_tokens
-            self._current.usage.total_tokens += input_tokens + output_tokens
+                # If we have model_name but no model_info, try to look it up
+                if model_name and not model_info:
+                    try:
+                        model_info = self.find_model_info(model_name, provider)
+                    except Exception as e:
+                        logger.debug(f"Failed to find model info for {model_name}: {e}")
 
-            # Store model information
-            if model_name and not self._current.usage.model_name:
-                self._current.usage.model_name = model_name
-            if model_info and not self._current.usage.model_info:
-                self._current.usage.model_info = model_info
+                # Update current node's usage
+                if self._current and hasattr(self._current, "usage"):
+                    self._current.usage.input_tokens += input_tokens
+                    self._current.usage.output_tokens += output_tokens
+                    self._current.usage.total_tokens += input_tokens + output_tokens
 
-            # Track global usage by model and provider
-            if model_name:
-                # Use provider from model_info if available, otherwise use the passed provider
-                provider_key = model_info.provider if model_info else provider
-                usage_key = (model_name, provider_key)
+                    # Store model information
+                    if model_name and not self._current.usage.model_name:
+                        self._current.usage.model_name = model_name
+                    if model_info and not self._current.usage.model_info:
+                        self._current.usage.model_info = model_info
 
-                model_usage = self._usage_by_model[usage_key]
-                model_usage.input_tokens += input_tokens
-                model_usage.output_tokens += output_tokens
-                model_usage.total_tokens += input_tokens + output_tokens
-                model_usage.model_name = model_name
-                if model_info and not model_usage.model_info:
-                    model_usage.model_info = model_info
+                # Track global usage by model and provider
+                if model_name:
+                    try:
+                        # Use provider from model_info if available, otherwise use the passed provider
+                        provider_key = (
+                            model_info.provider
+                            if model_info and hasattr(model_info, "provider")
+                            else provider
+                        )
+                        usage_key = (model_name, provider_key)
 
-            logger.debug(
-                f"Recorded {input_tokens + output_tokens} tokens "
-                f"(in: {input_tokens}, out: {output_tokens}) "
-                f"for {self._current.name} using {model_name or 'unknown model'}"
-            )
+                        model_usage = self._usage_by_model[usage_key]
+                        model_usage.input_tokens += input_tokens
+                        model_usage.output_tokens += output_tokens
+                        model_usage.total_tokens += input_tokens + output_tokens
+                        model_usage.model_name = model_name
+                        if model_info and not model_usage.model_info:
+                            model_usage.model_info = model_info
+                    except Exception as e:
+                        logger.error(f"Failed to track global usage: {e}")
+
+                logger.debug(
+                    f"Recorded {input_tokens + output_tokens} tokens "
+                    f"(in: {input_tokens}, out: {output_tokens}) "
+                    f"for {getattr(self._current, 'name', 'unknown')} using {model_name or 'unknown model'}"
+                )
+        except Exception as e:
+            logger.error(f"Error in TokenCounter.record_usage: {e}", exc_info=True)
+            # Continue execution - don't break the program
 
     def calculate_cost(
         self,
@@ -506,37 +549,52 @@ class TokenCounter:
         provider: Optional[str] = None,
     ) -> float:
         """Calculate cost for given token usage"""
-        # Look up the model to get accurate cost
-        model_info = self.find_model_info(model_name, provider)
-        if model_info:
-            model_name = model_info.name
-
-        if not model_name or model_name not in self._model_costs:
-            logger.info(
-                f"Model {model_name} not found in costs, using default estimate"
+        try:
+            # Validate inputs
+            input_tokens = max(0, int(input_tokens) if input_tokens is not None else 0)
+            output_tokens = max(
+                0, int(output_tokens) if output_tokens is not None else 0
             )
+
+            # Look up the model to get accurate cost
+            try:
+                model_info = self.find_model_info(model_name, provider)
+                if model_info:
+                    model_name = model_info.name
+            except Exception as e:
+                logger.debug(f"Failed to find model info: {e}")
+
+            if not model_name or model_name not in self._model_costs:
+                logger.info(
+                    f"Model {model_name} not found in costs, using default estimate"
+                )
+                return (input_tokens + output_tokens) * 0.5 / 1_000_000
+
+            costs = self._model_costs.get(model_name, {})
+
+            input_cost_per_1m = costs.get("input_cost_per_1m")
+            output_cost_per_1m = costs.get("output_cost_per_1m")
+
+            if input_cost_per_1m is not None and output_cost_per_1m is not None:
+                input_cost = (input_tokens / 1_000_000) * input_cost_per_1m
+                output_cost = (output_tokens / 1_000_000) * output_cost_per_1m
+                total_cost = input_cost + output_cost
+                logger.debug(
+                    f"Using input/output costs: input_cost=${input_cost:.6f}, output_cost=${output_cost:.6f}, total=${total_cost:.6f}"
+                )
+                return total_cost
+            else:
+                total_tokens = input_tokens + output_tokens
+                blended_cost_per_1m = costs.get("blended_cost_per_1m", 0.5)
+                blended_cost = (total_tokens / 1_000_000) * blended_cost_per_1m
+                logger.debug(
+                    f"Using blended cost: total_tokens={total_tokens}, blended_cost_per_1m={blended_cost_per_1m}, total=${blended_cost:.6f}"
+                )
+                return blended_cost
+        except Exception as e:
+            logger.warning(f"Error in TokenCounter.calculate_cost: {e}", exc_info=True)
+            # Return a default cost estimate
             return (input_tokens + output_tokens) * 0.5 / 1_000_000
-
-        costs = self._model_costs[model_name]
-        logger.debug(f"Calculating cost for {model_name}")
-        logger.debug(f"Costs: {costs}")
-        logger.debug(f"Input tokens: {input_tokens}, Output tokens: {output_tokens}")
-
-        if costs["input_cost_per_1m"] and costs["output_cost_per_1m"]:
-            input_cost = (input_tokens / 1_000_000) * costs["input_cost_per_1m"]
-            output_cost = (output_tokens / 1_000_000) * costs["output_cost_per_1m"]
-            total_cost = input_cost + output_cost
-            logger.debug(
-                f"Using input/output costs: input_cost=${input_cost:.6f}, output_cost=${output_cost:.6f}, total=${total_cost:.6f}"
-            )
-            return total_cost
-        else:
-            total_tokens = input_tokens + output_tokens
-            blended_cost = (total_tokens / 1_000_000) * costs["blended_cost_per_1m"]
-            logger.debug(
-                f"Using blended cost: total_tokens={total_tokens}, blended_cost_per_1m={costs['blended_cost_per_1m']}, total=${blended_cost:.6f}"
-            )
-            return blended_cost
 
     def get_current_path(self) -> List[str]:
         """Get the current stack path (e.g., ['app', 'workflow', 'agent'])"""
@@ -552,75 +610,110 @@ class TokenCounter:
 
     def get_summary(self) -> TokenSummary:
         """Get summary of token usage and costs"""
-        with self._lock:
-            total_cost = 0.0
-            model_costs: Dict[str, ModelUsageSummary] = {}
+        try:
+            with self._lock:
+                total_cost = 0.0
+                model_costs: Dict[str, ModelUsageSummary] = {}
 
-            # Calculate costs per model
-            for (model_name, provider_key), usage in self._usage_by_model.items():
-                # Use the provider from the key (which came from record_usage)
-                # Fall back to model_info.provider if key's provider is None
-                provider = provider_key
-                if provider is None and usage.model_info:
-                    provider = usage.model_info.provider
+                # Calculate costs per model
+                for (model_name, provider_key), usage in self._usage_by_model.items():
+                    try:
+                        # Use the provider from the key (which came from record_usage)
+                        # Fall back to model_info.provider if key's provider is None
+                        provider = provider_key
+                        if provider is None and usage.model_info:
+                            provider = getattr(usage.model_info, "provider", None)
 
-                logger.debug(f"Calculating cost for {model_name} from {provider}")
-                logger.debug(
-                    f"Usage - input: {usage.input_tokens}, output: {usage.output_tokens}, total: {usage.total_tokens}"
-                )
+                        logger.debug(
+                            f"Calculating cost for {model_name} from {provider}"
+                        )
+                        logger.debug(
+                            f"Usage - input: {usage.input_tokens}, output: {usage.output_tokens}, total: {usage.total_tokens}"
+                        )
 
-                cost = self.calculate_cost(
-                    model_name, usage.input_tokens, usage.output_tokens, provider
-                )
+                        cost = self.calculate_cost(
+                            model_name,
+                            usage.input_tokens,
+                            usage.output_tokens,
+                            provider,
+                        )
 
-                logger.debug(f"get_summary: Calculated cost: ${cost:.6f}")
-                total_cost += cost
+                        logger.debug(f"get_summary: Calculated cost: ${cost:.6f}")
+                        total_cost += cost
 
-                # Create model info dict if available
-                model_info_dict = None
-                if usage.model_info:
-                    model_info_dict = {
-                        "provider": usage.model_info.provider,
-                        "description": usage.model_info.description,
-                        "context_window": usage.model_info.context_window,
-                        "tool_calling": usage.model_info.tool_calling,
-                        "structured_outputs": usage.model_info.structured_outputs,
-                    }
+                        # Create model info dict if available
+                        model_info_dict = None
+                        if usage.model_info:
+                            try:
+                                model_info_dict = {
+                                    "provider": getattr(
+                                        usage.model_info, "provider", None
+                                    ),
+                                    "description": getattr(
+                                        usage.model_info, "description", None
+                                    ),
+                                    "context_window": getattr(
+                                        usage.model_info, "context_window", None
+                                    ),
+                                    "tool_calling": getattr(
+                                        usage.model_info, "tool_calling", None
+                                    ),
+                                    "structured_outputs": getattr(
+                                        usage.model_info, "structured_outputs", None
+                                    ),
+                                }
+                            except Exception as e:
+                                logger.debug(f"Failed to extract model info: {e}")
 
-                model_summary = ModelUsageSummary(
-                    model_name=model_name,
-                    provider=provider,
+                        model_summary = ModelUsageSummary(
+                            model_name=model_name,
+                            provider=provider,
+                            usage=TokenUsageBase(
+                                input_tokens=usage.input_tokens,
+                                output_tokens=usage.output_tokens,
+                                total_tokens=usage.total_tokens,
+                            ),
+                            cost=cost,
+                            model_info=model_info_dict,
+                        )
+
+                        # Create a descriptive key for the summary
+                        if provider:
+                            summary_key = f"{model_name} ({provider})"
+                        else:
+                            summary_key = model_name
+
+                        model_costs[summary_key] = model_summary
+                    except Exception as e:
+                        logger.error(f"Error processing model {model_name}: {e}")
+                        continue
+
+                # Get total usage
+                total_usage = TokenUsage()
+                if self._root:
+                    try:
+                        total_usage = self._root.aggregate_usage()
+                    except Exception as e:
+                        logger.error(f"Error aggregating total usage: {e}")
+
+                return TokenSummary(
                     usage=TokenUsageBase(
-                        input_tokens=usage.input_tokens,
-                        output_tokens=usage.output_tokens,
-                        total_tokens=usage.total_tokens,
+                        input_tokens=total_usage.input_tokens,
+                        output_tokens=total_usage.output_tokens,
+                        total_tokens=total_usage.total_tokens,
                     ),
-                    cost=cost,
-                    model_info=model_info_dict,
+                    cost=total_cost,
+                    model_usage=model_costs,
+                    usage_tree=self.get_tree() if self._root else None,
                 )
-
-                # Create a descriptive key for the summary
-                if provider:
-                    summary_key = f"{model_name} ({provider})"
-                else:
-                    summary_key = model_name
-
-                model_costs[summary_key] = model_summary
-
-            # Get total usage
-            total_usage = TokenUsage()
-            if self._root:
-                total_usage = self._root.aggregate_usage()
-
+        except Exception as e:
+            logger.error(f"Error in get_summary: {e}", exc_info=True)
+            # Return empty summary on error
             return TokenSummary(
-                usage=TokenUsageBase(
-                    input_tokens=total_usage.input_tokens,
-                    output_tokens=total_usage.output_tokens,
-                    total_tokens=total_usage.total_tokens,
-                ),
-                cost=total_cost,
-                model_usage=model_costs,
-                usage_tree=self.get_tree() if self._root else None,
+                usage=TokenUsageBase(),
+                cost=0.0,
+                model_usage={},
+                usage_tree=None,
             )
 
     def reset(self) -> None:
@@ -655,17 +748,25 @@ class TokenCounter:
         self, node: TokenNode, name: str, node_type: Optional[str] = None
     ) -> Optional[TokenNode]:
         """Recursively search for a node"""
-        # Check current node
-        if node.name == name and (node_type is None or node.node_type == node_type):
-            return node
+        try:
+            # Check current node
+            if node.name == name and (node_type is None or node.node_type == node_type):
+                return node
 
-        # Search children
-        for child in node.children:
-            result = self._find_node_recursive(child, name, node_type)
-            if result:
-                return result
+            # Search children
+            for child in node.children:
+                try:
+                    result = self._find_node_recursive(child, name, node_type)
+                    if result:
+                        return result
+                except Exception as e:
+                    logger.debug(f"Error searching child node: {e}")
+                    continue
 
-        return None
+            return None
+        except Exception as e:
+            logger.error(f"Error in _find_node_recursive: {e}")
+            return None
 
     def find_nodes_by_type(self, node_type: str) -> List[TokenNode]:
         """
@@ -734,26 +835,38 @@ class TokenCounter:
 
     def _calculate_node_cost(self, node: TokenNode) -> float:
         """Calculate cost for a node and its children"""
-        total_cost = 0.0
+        try:
+            total_cost = 0.0
 
-        # If this node has direct usage with a model, calculate its cost
-        if node.usage.model_name:
-            provider = None
-            if node.usage.model_info:
-                provider = node.usage.model_info.provider
+            # If this node has direct usage with a model, calculate its cost
+            if node.usage.model_name:
+                provider = None
+                if node.usage.model_info:
+                    provider = getattr(node.usage.model_info, "provider", None)
 
-            total_cost += self.calculate_cost(
-                node.usage.model_name,
-                node.usage.input_tokens,
-                node.usage.output_tokens,
-                provider,
-            )
+                try:
+                    cost = self.calculate_cost(
+                        node.usage.model_name,
+                        node.usage.input_tokens,
+                        node.usage.output_tokens,
+                        provider,
+                    )
+                    total_cost += cost
+                except Exception as e:
+                    logger.error(f"Error calculating cost for node {node.name}: {e}")
 
-        # Add costs from children
-        for child in node.children:
-            total_cost += self._calculate_node_cost(child)
+            # Add costs from children
+            for child in node.children:
+                try:
+                    total_cost += self._calculate_node_cost(child)
+                except Exception as e:
+                    logger.error(f"Error calculating cost for child {child.name}: {e}")
+                    continue
 
-        return total_cost
+            return total_cost
+        except Exception as e:
+            logger.error(f"Error in _calculate_node_cost: {e}")
+            return 0.0
 
     def get_app_usage(self) -> Optional[TokenUsage]:
         """Get total token usage for the entire application (root node)"""

--- a/src/mcp_agent/tracing/token_tracking_decorator.py
+++ b/src/mcp_agent/tracing/token_tracking_decorator.py
@@ -9,15 +9,15 @@ T = TypeVar("T")
 
 
 def track_tokens(
-    node_type: str = "llm_call",
+    node_type: str = "llm",
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """
     Decorator to track token usage for AugmentedLLM methods.
     Automatically pushes/pops token context around method execution.
 
     Args:
-        node_type: The type of node for token tracking. Default is "llm_call".
-                  Higher-order workflows should use "workflow".
+        node_type: The type of node for token tracking. Default is "llm" for base AugmentedLLM classes.
+                  Higher-order AugmentedLLM classes should use "agent".
     """
 
     def decorator(method: Callable[..., T]) -> Callable[..., T]:

--- a/src/mcp_agent/workflows/evaluator_optimizer/evaluator_optimizer.py
+++ b/src/mcp_agent/workflows/evaluator_optimizer/evaluator_optimizer.py
@@ -155,7 +155,7 @@ class EvaluatorOptimizerLLM(AugmentedLLM[MessageParamT, MessageT]):
         # Track iteration history
         self.refinement_history = []
 
-    @track_tokens(node_type="workflow")
+    @track_tokens(node_type="agent")
     async def generate(
         self,
         message: str | MessageParamT | List[MessageParamT],

--- a/src/mcp_agent/workflows/orchestrator/orchestrator.py
+++ b/src/mcp_agent/workflows/orchestrator/orchestrator.py
@@ -210,7 +210,7 @@ class Orchestrator(AugmentedLLM[MessageParamT, MessageT]):
             maxTokens=16384,
         )
 
-    @track_tokens(node_type="workflow")
+    @track_tokens(node_type="agent")
     async def generate(
         self,
         message: str | MessageParamT | List[MessageParamT],

--- a/src/mcp_agent/workflows/parallel/parallel_llm.py
+++ b/src/mcp_agent/workflows/parallel/parallel_llm.py
@@ -99,7 +99,7 @@ class ParallelLLM(AugmentedLLM[MessageParamT, MessageT]):
             context=context,
         )
 
-    @track_tokens(node_type="workflow")
+    @track_tokens(node_type="agent")
     async def generate(
         self,
         message: str | MessageParamT | List[MessageParamT],

--- a/src/mcp_agent/workflows/swarm/swarm_anthropic.py
+++ b/src/mcp_agent/workflows/swarm/swarm_anthropic.py
@@ -13,7 +13,7 @@ class AnthropicSwarm(Swarm, AnthropicAugmentedLLM):
     using Anthropic's API as the LLM.
     """
 
-    @track_tokens(node_type="workflow")
+    @track_tokens(node_type="agent")
     async def generate(self, message, request_params: RequestParams | None = None):
         params = self.get_request_params(
             request_params,

--- a/src/mcp_agent/workflows/swarm/swarm_openai.py
+++ b/src/mcp_agent/workflows/swarm/swarm_openai.py
@@ -12,7 +12,7 @@ class OpenAISwarm(Swarm, OpenAIAugmentedLLM):
     MCP version of the OpenAI Swarm class (https://github.com/openai/swarm.), using OpenAI's ChatCompletion as the LLM.
     """
 
-    @track_tokens(node_type="workflow")
+    @track_tokens(node_type="agent")
     async def generate(self, message, request_params: RequestParams | None = None):
         params = self.get_request_params(
             request_params,

--- a/tests/workflows/orchestrator/test_orchestrator_token_counting.py
+++ b/tests/workflows/orchestrator/test_orchestrator_token_counting.py
@@ -268,21 +268,21 @@ class TestOrchestratorTokenCounting:
         app_usage = app_node.aggregate_usage()
         assert app_usage.total_tokens == 720
 
-        # Verify token hierarchy - the app node should have a workflow child
+        # Verify token hierarchy - the app node should have a agent child
         assert len(app_node.children) >= 1
 
-        # Find the Orchestrator workflow node
+        # Find the Orchestrator agent node
         orchestrator_node = None
         for child in app_node.children:
-            if child.node_type == "workflow" and "Orchestrator" in child.name:
+            if child.node_type == "agent" and "Orchestrator" in child.name:
                 orchestrator_node = child
                 break
 
         assert (
             orchestrator_node is not None
-        ), "Orchestrator workflow node not found in hierarchy"
+        ), "Orchestrator agent node not found in hierarchy"
 
-        # The Orchestrator workflow node should have the same token count as the app
+        # The Orchestrator agent node should have the same token count as the app
         orchestrator_usage = orchestrator_node.aggregate_usage()
         assert orchestrator_usage.total_tokens == 720
         assert orchestrator_usage.input_tokens == 480
@@ -360,18 +360,18 @@ class TestOrchestratorTokenCounting:
         # Verify token hierarchy
         assert len(app_node.children) >= 1
 
-        # Find the Orchestrator workflow node
+        # Find the Orchestrator agent node
         orchestrator_node = None
         for child in app_node.children:
-            if child.node_type == "workflow" and "Orchestrator" in child.name:
+            if child.node_type == "agent" and "Orchestrator" in child.name:
                 orchestrator_node = child
                 break
 
         assert (
             orchestrator_node is not None
-        ), "Orchestrator workflow node not found in hierarchy"
+        ), "Orchestrator agent node not found in hierarchy"
 
-        # The Orchestrator workflow node should have the same token count
+        # The Orchestrator agent node should have the same token count
         orchestrator_usage = orchestrator_node.aggregate_usage()
         assert orchestrator_usage.total_tokens == 480
         assert orchestrator_usage.input_tokens == 320
@@ -400,7 +400,7 @@ class TestOrchestratorTokenCounting:
         orchestrator1.synthesizer.generate_str_mock.return_value = "Result 1"
 
         # Push orchestrator 1 context
-        mock_context_with_token_counter.token_counter.push("orchestrator_1", "workflow")
+        mock_context_with_token_counter.token_counter.push("orchestrator_1", "agent")
 
         # Execute first orchestrator
         await orchestrator1.execute(objective="Objective 1")
@@ -423,7 +423,7 @@ class TestOrchestratorTokenCounting:
         orchestrator2.synthesizer.generate_str_mock.return_value = "Result 2"
 
         # Push orchestrator 2 context
-        mock_context_with_token_counter.token_counter.push("orchestrator_2", "workflow")
+        mock_context_with_token_counter.token_counter.push("orchestrator_2", "agent")
 
         # Execute second orchestrator
         await orchestrator2.execute(objective="Objective 2")
@@ -492,7 +492,7 @@ class TestOrchestratorTokenCounting:
         orchestrator.executor.execute_many = AsyncMock(side_effect=mock_execute_many)
 
         # Push orchestrator context
-        mock_context_with_token_counter.token_counter.push("orchestrator", "workflow")
+        mock_context_with_token_counter.token_counter.push("orchestrator", "agent")
 
         # Execute the step
         plan_result = PlanResult(objective="Test objective", step_results=[])
@@ -549,7 +549,7 @@ class TestOrchestratorTokenCounting:
         )
 
         # Push orchestrator context
-        mock_context_with_token_counter.token_counter.push("orchestrator", "workflow")
+        mock_context_with_token_counter.token_counter.push("orchestrator", "agent")
 
         # Execute orchestration (should raise error)
         with pytest.raises(Exception, match="Planner error"):


### PR DESCRIPTION
Allow someone to watch for token updates using TokenCounter, specifying a callback and notification preferences, inspired by reactive updates in React and event-driven watches in k8s. 

- WatchConfig dataclass for configuration
- Cached aggregation in TokenNode to avoid deep recursion
- watch() and unwatch() methods on TokenCounter

Integrated into the rich progress display, which now shows a token counter on the "root" node (MCPApp), showing the aggregated total token and cost as the workflow is progressing. To try, simply run `uv run main.py` in the `examples/basic/mcp_basic_agent` example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced real-time and hierarchical token usage tracking and reporting, including live displays and detailed summaries of token consumption and cost.
  * Added tools to fetch and display token usage and cost breakdowns for workflow runs, both in server and client interfaces.

* **Improvements**
  * Enhanced progress displays to show live token usage and cost updates.
  * Integrated token tracking into logging and progress interfaces for better observability.
  * Improved robustness and flexibility of token tracking, including support for watches, notifications, and async callbacks.

* **Bug Fixes**
  * Improved error handling and conditional logic in user input and elicitation callbacks to prevent runtime errors.

* **Tests**
  * Added comprehensive tests for token usage watch functionality and updated tests to reflect changes in token tracking node types.

* **Refactor**
  * Standardized token tracking node types from "workflow" to "agent" for consistency across workflows and agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->