### PR TITLE
Feat/temporal rpc metadata

### DIFF
--- a/LLMS.txt
+++ b/LLMS.txt
@@ -1536,6 +1536,7 @@ Example usage:
   - `max_concurrent_activities` (int | None) = None
   - `api_key` (str | None) = None
   - `timeout_seconds` (int | None) = 60
+  - `rpc_metadata` (Dict[str, str] | None) = None
 
 **Class: `UsageTelemetrySettings`**
 - **Inherits from**: BaseModel

--- a/examples/temporal/mcp_agent.config.yaml
+++ b/examples/temporal/mcp_agent.config.yaml
@@ -10,6 +10,8 @@ temporal:
   namespace: "default" # Default Temporal namespace
   task_queue: "mcp-agent" # Task queue for workflows and activities
   max_concurrent_activities: 10 # Maximum number of concurrent activities
+  rpc_metadata:
+    X-Client-Name: "mcp-agent"
 
 # Logger settings
 logger:

--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -934,6 +934,21 @@
           ],
           "default": 60,
           "title": "Timeout Seconds"
+        },
+        "rpc_metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rpc Metadata"
         }
       },
       "required": [

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -219,6 +219,7 @@ class TemporalSettings(BaseModel):
     task_queue: str
     max_concurrent_activities: int | None = None
     timeout_seconds: int | None = 60
+    rpc_metadata: Dict[str, str] | None = None
 
 
 class UsageTelemetrySettings(BaseModel):

--- a/src/mcp_agent/executor/temporal/__init__.py
+++ b/src/mcp_agent/executor/temporal/__init__.py
@@ -349,6 +349,7 @@ class TemporalExecutor(Executor):
                 id=workflow_id,
                 task_queue=task_queue,
                 id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+                rpc_metadata=self.config.rpc_metadata,
             )
         else:
             handle: WorkflowHandle = await self.client.start_workflow(
@@ -356,6 +357,7 @@ class TemporalExecutor(Executor):
                 id=workflow_id,
                 task_queue=task_queue,
                 id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+                rpc_metadata=self.config.rpc_metadata,
             )
 
         # Wait for the result if requested

--- a/src/mcp_agent/executor/temporal/__init__.py
+++ b/src/mcp_agent/executor/temporal/__init__.py
@@ -262,6 +262,7 @@ class TemporalExecutor(Executor):
                 api_key=self.config.api_key,
                 tls=self.config.tls,
                 data_converter=pydantic_data_converter,
+                rpc_metadata=self.config.rpc_metadata,
             )
 
         return self.client


### PR DESCRIPTION
## Description
Support propagating rpc-metadata through temporal client requests. This is useful for setting request headers for the rpc requests. In our case, we would like to be able to propagate an api token through the request but Temporal only supports sending the api token parameter across when TLS is enabled. We're running the app and worker on local internal container network without TLS and need the api token passed through. We can leverage Authorization headers to pass it as the Bearer token using this PR change.

## Testing
Run the temporal example for basic agent. Dump the request traffic to a file
```
sudo tcpdump -i lo0 -s 0 -w temporal.pcap port 7233
```
and sniff it with Wireshark to see the headers set in the GRPC request:
<img width="1313" height="566" alt="Screenshot 2025-08-08 at 5 58 19 PM" src="https://github.com/user-attachments/assets/ee94fa10-ea28-4cd8-aa0b-32d2e7fc70db" />
