### PR TITLE
Updates to TokenCounter to make it resilient to concurrent scenarios

### DIFF
--- a/examples/basic/mcp_basic_agent/main.py
+++ b/examples/basic/mcp_basic_agent/main.py
@@ -3,7 +3,6 @@ import os
 import time
 
 from mcp_agent.app import MCPApp
-from mcp_agent.core.context import Context
 from mcp_agent.config import (
     Settings,
     LoggerSettings,
@@ -17,7 +16,7 @@ from mcp_agent.workflows.llm.augmented_llm import RequestParams
 from mcp_agent.workflows.llm.llm_selector import ModelPreferences
 from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLLM
 from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
-from mcp_agent.tracing.token_counter import TokenUsage, TokenSummary
+from mcp_agent.tracing.token_counter import TokenSummary
 
 settings = Settings(
     execution_engine="asyncio",
@@ -101,39 +100,23 @@ async def example_usage():
             )
             logger.info(f"Paragraph as a tweet: {result}")
 
-        # Display final comprehensive token usage summary
-        await display_token_summary(context)
+        # Display final comprehensive token usage summary (use app convenience)
+        await display_token_summary(agent_app, finder_agent)
 
 
-def display_token_usage(usage: TokenUsage, label: str = "Token Usage"):
-    """Display token usage in a formatted way"""
-    print(f"\n{label}:")
-    print(f"  Total tokens: {usage.total_tokens:,}")
-    print(f"  Input tokens: {usage.input_tokens:,}")
-    print(f"  Output tokens: {usage.output_tokens:,}")
-
-
-async def display_token_summary(context: Context):
-    """Display comprehensive token usage summary"""
-    if not context.token_counter:
-        print("\nNo token counter available")
-        return
-
-    summary: TokenSummary = await context.token_counter.get_summary()
+async def display_token_summary(app_ctx: MCPApp, agent: Agent | None = None):
+    """Display comprehensive token usage summary using app/agent convenience APIs."""
+    summary: TokenSummary = await app_ctx.get_token_summary()
 
     print("\n" + "=" * 50)
     print("TOKEN USAGE SUMMARY")
     print("=" * 50)
 
-    # Total usage
-    display_token_usage(
-        TokenUsage(
-            total_tokens=summary.usage.total_tokens,
-            input_tokens=summary.usage.input_tokens,
-            output_tokens=summary.usage.output_tokens,
-        ),
-        label="Total Usage",
-    )
+    # Total usage and cost
+    print("\nTotal Usage:")
+    print(f"  Total tokens: {summary.usage.total_tokens:,}")
+    print(f"  Input tokens: {summary.usage.input_tokens:,}")
+    print(f"  Output tokens: {summary.usage.output_tokens:,}")
     print(f"  Total cost: ${summary.cost:.4f}")
 
     # Breakdown by model
@@ -146,15 +129,15 @@ async def display_token_summary(context: Context):
             )
             print(f"    Cost: ${data.cost:.4f}")
 
-    # Breakdown by agent
-    agents_breakdown = await context.token_counter.get_agents_breakdown()
-    if agents_breakdown:
-        print("\nBreakdown by Agent:")
-        for agent_name, usage in agents_breakdown.items():
-            print(f"\n  {agent_name}:")
-            print(f"    Total tokens: {usage.total_tokens:,}")
-            print(f"    Input tokens: {usage.input_tokens:,}")
-            print(f"    Output tokens: {usage.output_tokens:,}")
+    # Optional: show a specific agent's aggregated usage
+    if agent is not None:
+        agent_usage = await agent.get_token_usage()
+        if agent_usage:
+            print("\nAgent Usage:")
+            print(f"  Agent: {agent.name}")
+            print(f"  Total tokens: {agent_usage.total_tokens:,}")
+            print(f"  Input tokens: {agent_usage.input_tokens:,}")
+            print(f"  Output tokens: {agent_usage.output_tokens:,}")
 
     print("\n" + "=" * 50)
 

--- a/examples/workflows/workflow_orchestrator_worker/graded_report.md
+++ b/examples/workflows/workflow_orchestrator_worker/graded_report.md
@@ -1,87 +1,56 @@
-# Graded Report for 'The Battle of Glimmerwood'
+# Graded Report for "The Battle of Glimmerwood"
 
 ## Proofreading Feedback
 
-### Grammar, Spelling, and Punctuation Errors
+1. **Grammar and Sentence Structure:**
+   - **Sentence Fragmentation:**
+     - Consider splitting run-on sentences for clarity, such as: "Amidst the chaos, a young girl named Elara stood her ground. She rallied the villagers and devised a clever plan."
+   - **Conjunction Use:**
+     - Ensure commas are used to separate introductory clauses: "Using the forest's natural defenses, they lured the marauders into a trap."
+   - **Comma Usage:**
+     - Revise sentences with misused commas to improve flow: "As the bandits approached the village square, a herd of Glimmerfoxes emerged, blinding them with their dazzling light. The villagers seized the opportunity to capture the invaders."
 
-1. "know" should be "known."
-2. "who were live" should be "who lived."
-3. "shimmer" should be "shimmered."
-4. "shaterred" should be "shattered."
-5. "attack" should be "attacked."
-6. "Lead" should be "Led."
-7. "aim" should be "aimed."
-8. "was" should be "were."
-9. "choas" should be "chaos."
-10. Comma after "ground" should be replaced with a period or semicolon for better clarity.
-11. Apostrophe correctness: "forests" should be "forest's."
-12. "aproached" should be "approached."
-13. Comma after "light" should be replaced with a period or semicolon.
-14. "captured" should be "capture."
-15. Comma needed after "celebrated."
+2. **Punctuation:**
+   - Address comma splices to connect independent clauses properly with conjunctions.
 
-### Awkward Phrasing
+3. **Word Choice and Clarity:**
+   - Clarify ambiguous terms, such as "secured," to denote whether the Glimmerstones are hidden or guarded.
 
-- "In the heart of Glimmerwood, a mystical forest knowed for its radiant trees, a small village thrived." could be clearer. Consider rephrasing to: "In the heart of Glimmerwood, a mystical forest known for its radiant trees, thrived a small village."
-- "Whispers of a hidden agenda linger among the villagers" should be "lingered among the villagers" to maintain past tense consistency.
+4. **Structural Flow:**
+   - Integrate whispers of a hidden agenda among the villagers more naturally into the narrative's conclusion.
 
-### Structural Issues
+5. **Logical Consistency:**
+   - Introduce the idea of uncertainty about the Glimmerstones' powers earlier in the story for coherence.
 
-- The paragraph detailing Elara’s bravery is slightly long and could be split for easier reading. Consider creating a new paragraph starting from "Using the forest's natural defenses..."
 
-## Factuality and Logical Consistency Feedback
+## Factual Consistency Feedback
 
-### Setting and Context Consistency
+1. **Glimmerstones' Powers:**
+   - Define the nature and limitations of the Glimmerstones' powers more clearly to align motivations and outcomes accurately.
 
-- The story establishes a mystical setting in Glimmerwood, consistent throughout the narrative as a coherent backdrop for the events.
+2. **Response and Motivation:**
+   - Detail Elara's leadership skills and rallies to focus on preparatory actions effectively.
 
-### Character Actions and Logic
+3. **Security of the Glimmerstones:**
+   - Highlight the effectiveness of the ancient spell in securing the Glimmerstones, despite the unconfirmed nature of their powers.
 
-- Elara's actions fit her as courageous and resourceful, rallying villagers and devising plans is typical heroic trope.
-- The villagers' complex defensive maneuver execution might appear abrupt without prior preparedness hints.
 
-### Plot Developments
+## Style Adherence Feedback
 
-- Transition from peace to chaos is clear; however, the village's advanced trap needs context for feasibility.
-- Emphasize the villagers and Glimmerfoxes bond to improve plausibility.
+1. **Narrative Flow and Clarity:**
+   - Break paragraphs for separate actions and different sections of the plot for better readability.
 
-### Logical Consistencies and Potential Contradictions
+2. **Pacing and Descriptive Detail:**
+   - Expand on the climatic battle and emotions involved to enhance tension and engagement.
 
-- Quick transition from peace to orchestrated defense plan without backstory mars believability.
-- Clarify immortality belief in Glimmerstones for internal logic consistency.
+3. **Descriptive Language:**
+   - Use vivid sensory descriptions to immerse readers in the mystical setting of Glimmerwood.
 
-### Conclusion
-
-- Narrative mostly consistent, needs exposition on villagers’ and forest's bond, and Elara's strategy.
-
-## Style Adherence and Additional Feedback
-
-### Narrative Flow
-
-- Well described beginning and open-ended ending for intrigue.
-- Detailed execution needed in Elara's plan to enhance reading engagement.
-
-### Clarity of Expression
-
-- Correction of issues such as "knowed" to "known" necessary.
-- Improve sentence structure for clarity and flow.
-
-### Tone
-
-- Consistent magical realism tone, suitable for heroism tales.
-- Emotional depth, particularly involving Elara's perspective, would enrich the tone.
-
-### APA Style Adherence
-
-- Correct punctuation and capitalization help with professional readability. Although creative writing isn't APA-focused, basic consistency applies.
-
-### Suggestions for Improvement
-
-1. **Enhance Detail in Key Scenes**: More drama in Elara's plan execution.
-2. **Correct Grammatical Errors**: Ensure clear, structured sentences.
-3. **Enrich Character Development**: Delve into Elara’s thoughts for engagement.
-4. **Apply Simple APA Elements**: Consistency in writing will improve readability.
+4. **Tone and Character Development:**
+   - Maintain a formal and narrative tone throughout, while enhancing character depth by exploring Elara's internal motivations and personal stakes.
 
 ---
 
-By addressing these areas, the story should improve in coherence, engagement, and overall readability.
+### Overall Assessment:
+
+While "The Battle of Glimmerwood" presents a compelling premise, addressing the identified proofreading, factual consistency, and style adherence issues can greatly enhance the clarity, coherence, and impact of the narrative. Strengthening these areas will also align the story closer to general narrative principles inspired by academic guidelines.

--- a/examples/workflows/workflow_orchestrator_worker/reports/graded_report.md
+++ b/examples/workflows/workflow_orchestrator_worker/reports/graded_report.md
@@ -1,0 +1,38 @@
+# Graded Report for "The Battle of Glimmerwood"
+
+## Proofreading Feedback
+The short story "The Battle of Glimmerwood" underwent a detailed proofreading process. Various grammar, spelling, and punctuation issues were found and corrected. The revisions improved the clarity and overall readability of the narrative. Here are some of the key adjustments:
+
+- Corrected "knowed" to "known."
+- Fixed "who were live" to "who lived."
+- Changed "shimmer" to "shimmered," and so on.
+
+In total, 17 changes were made to enhance the grammatical precision and fluency of the text.
+
+## Factuality and Logical Consistency Feedback
+An analysis of the logical consistency within the story identified several areas in need of clarification:
+
+1. **Preemptive Trap:** The villagers' ability to prepare a trap implies foreknowledge of the attack, which is not explained in the narrative.
+2. **Rapid Planning:** Elara's quick rallying of the villagers and execution of a complex plan is unrealistic given the immediacy of the threat.
+3. **Glimmerstones' Ambiguity:** There's ambiguity about the Glimmerstones' power, as the belief in their immortality-granting ability contrasts with their unconfirmed power.
+4. **Quick Resolution:** The villagers' quick victory over the dangerous Marauders seems overly convenient, lacking explanation for their swift success.
+5. **Unresolved Element:** The mention of a "hidden agenda" among the villagers is not followed up, leading to an unresolved plotline.
+
+For improved narrative coherence, the story should address these inconsistencies, providing more depth to character actions and plot developments.
+
+## Adherence to Style Guidelines
+Based on APA formatting standards, here are some improvement suggestions:
+
+1. **Title Page and Header:** Introduce a formal title page featuring the story's title, the author's name, and institutional affiliation. Include a running head and page numbers on each page.
+
+2. **Consistent Formatting:** Utilize a clear and consistent font, such as Times New Roman, and maintain double spacing throughout with uniform margins.
+
+3. **Abstract Addition:** Though optional for fiction, an abstract can summarize key story elements, enhancing reader understanding and guiding visibility according to APA standards.
+
+4. **Narrative Structure:** Ensure logical flow and clear sectioning for improved readability through enhanced organization.
+
+Implementing these style recommendations will align the story closer to academic presentation standards without losing its narrative core.
+
+---
+
+By addressing these proofreading, factual, logical, and style adherence areas, the short story can be significantly refined, offering readers a more engaging and seamlessly readable experience.

--- a/src/mcp_agent/tracing/token_tracking_decorator.py
+++ b/src/mcp_agent/tracing/token_tracking_decorator.py
@@ -25,39 +25,22 @@ def track_tokens(
         async def wrapper(self, *args, **kwargs) -> T:
             # Only track if we have a token counter in context
             if hasattr(self, "context") and self.context and self.context.token_counter:
-                pushed = False
-                try:
-                    # Build metadata
-                    metadata = {
-                        "method": method.__name__,
-                        "class": self.__class__.__name__,
-                    }
+                # Build metadata
+                metadata = {
+                    "method": method.__name__,
+                    "class": self.__class__.__name__,
+                }
 
-                    # Add any model info if available
-                    if hasattr(self, "provider"):
-                        metadata["provider"] = self.provider
+                # Add any model info if available
+                if hasattr(self, "provider"):
+                    metadata["provider"] = getattr(self, "provider")
 
-                    # Push context
-                    await self.context.token_counter.push(
-                        name=getattr(self, "name", self.__class__.__name__),
-                        node_type=node_type,
-                        metadata=metadata,
-                    )
-                    pushed = True
-                except Exception:
-                    pass  # Ignore errors in pushing context
-
-                try:
-                    # Execute the wrapped method
-                    result = await method(self, *args, **kwargs)
-                    return result
-                finally:
-                    # Only pop if we successfully pushed
-                    try:
-                        if pushed:
-                            await self.context.token_counter.pop()
-                    except Exception:
-                        pass
+                async with self.context.token_counter.scope(
+                    name=getattr(self, "name", self.__class__.__name__),
+                    node_type=node_type,
+                    metadata=metadata,
+                ):
+                    return await method(self, *args, **kwargs)
             else:
                 # No token counter, just execute normally
                 return await method(self, *args, **kwargs)

--- a/src/mcp_agent/workflows/llm/augmented_llm.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm.py
@@ -229,6 +229,8 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol[MessageParamT, Message
 
     provider: str | None = None
     logger: Union["Logger", None] = None
+    # Suggested node type for token tracking for base LLMs
+    token_node_type: str = "llm"
 
     def __init__(
         self,
@@ -679,3 +681,79 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol[MessageParamT, Message
             identifier = str(self.context.executor.uuid())
 
         return f"{prefix}-{identifier}"
+
+    async def get_token_node(
+        self, return_all_matches: bool = False, node_type: str | None = None
+    ):
+        """Return this LLM's token node(s) from the global counter."""
+        if not self.context or not getattr(self.context, "token_counter", None):
+            return [] if return_all_matches else None
+        counter = self.context.token_counter
+        # Prefer explicit node_type, else default to this class's suggested node type
+        t = node_type or getattr(self, "token_node_type", None)
+        if return_all_matches:
+            if t == "llm":
+                return await counter.get_llm_node(self.name, return_all_matches=True)
+            if t == "agent":
+                return await counter.get_agent_node(self.name, return_all_matches=True)
+            # Fallback: gather both types
+            nodes = await counter.get_llm_node(self.name, return_all_matches=True)
+            nodes += await counter.get_agent_node(self.name, return_all_matches=True)
+            return nodes
+        else:
+            if t == "agent":
+                node = await counter.get_agent_node(self.name)
+                if node:
+                    return node
+            if t == "llm" or not t:
+                node = await counter.get_llm_node(self.name)
+                if node:
+                    return node
+            # Fallback try agent if not found
+            return await counter.get_agent_node(self.name)
+
+    async def get_token_usage(self, node_type: str | None = None):
+        """Return aggregated token usage for this LLM node (including children)."""
+        if not self.context or not getattr(self.context, "token_counter", None):
+            return None
+        counter = self.context.token_counter
+        t = node_type or getattr(self, "token_node_type", None)
+        if t == "agent":
+            return await counter.get_agent_usage(self.name)
+        if t == "llm":
+            return await counter.get_node_usage(self.name, "llm")
+        # Unknown type: try both
+        return await counter.get_node_usage(self.name)
+
+    async def get_token_cost(self, node_type: str | None = None) -> float:
+        """Return total cost for this LLM node (including children)."""
+        if not self.context or not getattr(self.context, "token_counter", None):
+            return 0.0
+        counter = self.context.token_counter
+        t = node_type or getattr(self, "token_node_type", None)
+        if t:
+            return await counter.get_node_cost(self.name, t)
+        return await counter.get_node_cost(self.name)
+
+    async def watch_tokens(
+        self,
+        callback,
+        *,
+        threshold: int | None = None,
+        throttle_ms: int | None = None,
+        include_subtree: bool = True,
+        node_type: str | None = None,
+    ) -> str | None:
+        """Watch this LLM's token usage. Returns a watch_id or None if not available."""
+        if not self.context or not getattr(self.context, "token_counter", None):
+            return None
+        counter = self.context.token_counter
+        t = node_type or getattr(self, "token_node_type", None) or "llm"
+        return await counter.watch(
+            callback=callback,
+            node_name=self.name,
+            node_type=t,
+            threshold=threshold,
+            throttle_ms=throttle_ms,
+            include_subtree=include_subtree,
+        )

--- a/src/mcp_agent/workflows/llm/augmented_llm_azure.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_azure.py
@@ -222,9 +222,22 @@ class AzureAugmentedLLM(AugmentedLLM[MessageParam, ResponseMessage]):
 
                 self._annotate_span_for_completion_response(span, response, i)
 
-                total_input_tokens += response.usage["prompt_tokens"]
-                total_output_tokens += response.usage["completion_tokens"]
+                # Per-iteration token counts
+                iteration_input = response.usage["prompt_tokens"]
+                iteration_output = response.usage["completion_tokens"]
+
+                total_input_tokens += iteration_input
+                total_output_tokens += iteration_output
                 finish_reasons.append(response.choices[0].finish_reason)
+
+                # Incremental token tracking inside loop so watchers update during long runs
+                if self.context.token_counter:
+                    await self.context.token_counter.record_usage(
+                        input_tokens=iteration_input,
+                        output_tokens=iteration_output,
+                        model_name=model,
+                        provider=self.provider,
+                    )
 
                 message = response.choices[0].message
                 responses.append(message)
@@ -283,15 +296,6 @@ class AzureAugmentedLLM(AugmentedLLM[MessageParam, ResponseMessage]):
                         )
                     )
                     span.set_attributes(response_data)
-
-            # Record token usage in context token counter
-            if self.context.token_counter:
-                await self.context.token_counter.record_usage(
-                    input_tokens=total_input_tokens,
-                    output_tokens=total_output_tokens,
-                    model_name=model,
-                    provider=self.provider,
-                )
 
             return responses
 

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -282,8 +282,21 @@ class OpenAIAugmentedLLM(
 
                 self._annotate_span_for_completion_response(span, response, i)
 
-                total_input_tokens += response.usage.prompt_tokens
-                total_output_tokens += response.usage.completion_tokens
+                # Per-iteration token counts
+                iteration_input = response.usage.prompt_tokens
+                iteration_output = response.usage.completion_tokens
+
+                total_input_tokens += iteration_input
+                total_output_tokens += iteration_output
+
+                # Incremental token tracking inside loop so watchers update during long runs
+                if self.context.token_counter:
+                    await self.context.token_counter.record_usage(
+                        input_tokens=iteration_input,
+                        output_tokens=iteration_output,
+                        model_name=model,
+                        provider=self.provider,
+                    )
 
                 if not response.choices or len(response.choices) == 0:
                     # No response from the model, we're done
@@ -372,15 +385,6 @@ class OpenAIAugmentedLLM(
                         )
                     )
                     span.set_attributes(response_data)
-
-            # Record token usage in context token counter
-            if self.context.token_counter:
-                await self.context.token_counter.record_usage(
-                    input_tokens=total_input_tokens,
-                    output_tokens=total_output_tokens,
-                    model_name=model,
-                    provider=self.provider,
-                )
 
             return responses
 

--- a/tests/tracing/test_token_counter_concurrency.py
+++ b/tests/tracing/test_token_counter_concurrency.py
@@ -1,0 +1,96 @@
+import asyncio
+from typing import List
+
+import pytest
+
+from mcp_agent.tracing.token_counter import TokenCounter
+
+
+@pytest.mark.asyncio
+async def test_concurrent_workflows_and_agents_isolated_stacks():
+    counter = TokenCounter()
+
+    # Create global app root (as MCPApp.run() would do)
+    await counter.push("app", "app", {"env": "test"})
+
+    # Worker that simulates a workflow with a nested agent and an LLM call
+    async def worker(i: int, paths: List[List[str]]):
+        workflow_name = f"workflow_{i}"
+        agent_name = f"agent_{i}"
+
+        # Push workflow and agent scopes
+        await counter.push(workflow_name, "workflow")
+        await counter.push(agent_name, "agent")
+
+        # Capture current path inside the nested scopes (for isolation check)
+        paths.append(await counter.get_current_path())
+
+        # Simulate an LLM call within the agent and record tokens
+        await counter.push(f"llm_call_{i}", "llm", {"provider": "TestProvider"})
+        await counter.record_usage(
+            input_tokens=100,
+            output_tokens=50,
+            model_name="test-model",
+            provider="TestProvider",
+        )
+        await counter.pop()  # llm
+
+        # Pop agent and workflow
+        await counter.pop()  # agent
+        await counter.pop()  # workflow
+
+    paths: List[List[str]] = []
+
+    # Run many workers concurrently
+    await asyncio.gather(*(worker(i, paths) for i in range(10)))
+
+    # Validate that paths captured were isolated per task
+    assert all(p[:1] == ["app"] for p in paths)
+    assert len(paths) == 10
+    # Ensure each path had exactly 3 levels: app -> workflow_i -> agent_i
+    assert all(len(p) == 3 for p in paths)
+
+    # Validate the resulting tree structure
+    tree = await counter.get_tree()
+    assert tree is not None
+    assert tree["name"] == "app"
+    # Expect 10 workflows directly under app
+    workflow_children = [c for c in tree["children"] if c["type"] == "workflow"]
+    assert len(workflow_children) == 10
+    # Each workflow should have one agent child, and each agent one llm child
+    for wf in workflow_children:
+        assert len(wf["children"]) == 1
+        agent = wf["children"][0]
+        assert agent["type"] == "agent"
+        assert len(agent["children"]) == 1
+        llm = agent["children"][0]
+        assert llm["type"] == "llm"
+        # Each agent subtree total should be 150
+        assert agent["aggregate_usage"]["total_tokens"] == 150
+
+
+@pytest.mark.asyncio
+async def test_concurrent_record_usage_with_scope_context_manager():
+    counter = TokenCounter()
+    await counter.push("app", "app")
+
+    async def worker(i: int):
+        async with counter.scope(f"workflow_{i}", "workflow"):
+            async with counter.scope(f"agent_{i}", "agent"):
+                async with counter.scope(f"llm_call_{i}", "llm", {"provider": "Test"}):
+                    await counter.record_usage(120, 30, model_name="m", provider="Test")
+
+    await asyncio.gather(*(worker(i) for i in range(5)))
+
+    # Validate tree usage
+    tree = await counter.get_tree()
+    assert tree is not None
+    # Expect 5 workflow children each with 1 agent and 1 llm
+    workflows = [c for c in tree["children"] if c["type"] == "workflow"]
+    assert len(workflows) == 5
+    for wf in workflows:
+        agent = wf["children"][0]
+        llm = agent["children"][0]
+        assert llm["aggregate_usage"]["total_tokens"] == 150
+        assert agent["aggregate_usage"]["total_tokens"] == 150
+        assert wf["aggregate_usage"]["total_tokens"] == 150

--- a/tests/tracing/test_token_integration_convenience.py
+++ b/tests/tracing/test_token_integration_convenience.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from mcp_agent.app import MCPApp
+from mcp_agent.core.context import initialize_context
+from mcp_agent.agents.agent import Agent
+from mcp_agent.executor.workflow import Workflow, WorkflowResult
+from mcp_agent.tracing.token_counter import TokenCounter
+from mcp_agent.workflows.llm.augmented_llm import AugmentedLLM, RequestParams
+
+
+@pytest.mark.asyncio
+async def test_app_convenience_metrics_and_watch():
+    app = MCPApp(name="test_app")
+
+    usage_updates = []
+
+    async def on_app_usage(node, usage):
+        usage_updates.append(usage.total_tokens)
+
+    async with app.run():
+        # Ensure root node exists and query convenience methods
+        root_node = await app.get_token_node()
+        assert root_node is not None
+
+        # Watch root
+        watch_id = await app.watch_tokens(on_app_usage, throttle_ms=0)
+        assert watch_id is not None
+
+        # Record usage at current scope (app is on the stack)
+        ctx = app.context
+        await ctx.token_counter.record_usage(input_tokens=20, output_tokens=10)
+
+        # Allow async callbacks to run
+        await asyncio.sleep(0.05)
+
+        # Verify convenience methods reflect usage
+        usage = await app.get_token_usage()
+        assert usage is not None
+        assert usage.total_tokens == 30
+
+        summary = await app.get_token_summary()
+        assert summary.usage.total_tokens == 30
+
+    # Watch callback fired at least once
+    assert any(v >= 30 for v in usage_updates)
+
+
+class _DummyWorkflow(Workflow[str]):
+    async def run(self, *args, **kwargs) -> WorkflowResult[str]:
+        return WorkflowResult(value="ok")
+
+
+class _DummyLLM(AugmentedLLM[str, str]):
+    provider = "TestProvider"
+
+    async def generate(self, message, request_params: RequestParams | None = None):
+        return ["ok"]
+
+    async def generate_str(
+        self, message, request_params: RequestParams | None = None
+    ) -> str:
+        return "ok"
+
+    async def generate_structured(
+        self, message, response_model, request_params: RequestParams | None = None
+    ):
+        return response_model()
+
+
+@pytest.mark.asyncio
+async def test_agent_convenience_and_disambiguation():
+    ctx = await initialize_context()
+    counter: TokenCounter = ctx.token_counter
+
+    # Two agents with same name
+    a1 = Agent(name="dup_agent", context=ctx)
+    a2 = Agent(name="dup_agent", context=ctx)
+
+    # Push usage for each separately in this task
+    await counter.push(a1.name, "agent", {"agent_id": "A1"})
+    await counter.record_usage(50, 20, model_name="m", provider="p")
+    await counter.pop()
+
+    await counter.push(a2.name, "agent", {"agent_id": "A2"})
+    await counter.record_usage(30, 10, model_name="m", provider="p")
+    await counter.pop()
+
+    # Single get_token_usage is ambiguous; return_all_matches should list both nodes
+    nodes = await a1.get_token_node(return_all_matches=True)
+    assert isinstance(nodes, list) and len(nodes) == 2
+
+    # Watch by name should trigger for both nodes if they receive updates
+    callbacks = []
+
+    async def on_agent_usage(node, usage):
+        callbacks.append((node.metadata.get("agent_id"), usage.total_tokens))
+
+    watch_id = await a1.watch_tokens(on_agent_usage, throttle_ms=0)
+    assert watch_id is not None
+
+    # Update both nodes again
+    # We need to re-push each node to be current, then record
+    # Note: we can bind the current task to the node by pushing the same name/type under the app root
+    await counter.push(a1.name, "agent", {"agent_id": "A1"})
+    await counter.record_usage(5, 5, model_name="m", provider="p")
+    await counter.pop()
+
+    await counter.push(a2.name, "agent", {"agent_id": "A2"})
+    await counter.record_usage(5, 5, model_name="m", provider="p")
+    await counter.pop()
+
+    await asyncio.sleep(0.05)
+    assert len(callbacks) >= 2
+    ids = [cid for (cid, _u) in callbacks if cid in ("A1", "A2")]
+    # We may get multiple callbacks per node; ensure both node IDs appeared
+    assert "A1" in ids and "A2" in ids
+
+
+@pytest.mark.asyncio
+async def test_workflow_convenience_with_ids():
+    ctx = await initialize_context()
+    counter: TokenCounter = ctx.token_counter
+
+    wf = _DummyWorkflow(name="wfX", context=ctx)
+    # Simulate workflow IDs (normally set in run_async)
+    wf._workflow_id = "WID_1"
+    wf._run_id = "RUN_2"
+
+    # Create two workflow nodes with same name, different IDs
+    await counter.push("wfX", "workflow", {"workflow_id": "WID_1", "run_id": "RUN_1"})
+    await counter.record_usage(10, 5, model_name="m", provider="p")
+    await counter.pop()
+
+    await counter.push("wfX", "workflow", {"workflow_id": "WID_1", "run_id": "RUN_2"})
+    await counter.record_usage(7, 3, model_name="m", provider="p")
+    await counter.pop()
+
+    # By run_id, should resolve to the RUN_2 node
+    node = await wf.get_token_node()
+    assert node is not None
+    assert node.metadata.get("run_id") == "RUN_2"
+
+    usage = await wf.get_token_usage()
+    assert usage is not None
+    # By default, workflow convenience resolves to this instance's run_id (RUN_2)
+    assert usage.total_tokens == 7 + 3
+
+
+@pytest.mark.asyncio
+async def test_llm_convenience_and_watch():
+    ctx = await initialize_context()
+    llm = _DummyLLM(context=ctx, name="llmA")
+
+    # Manually create LLM node and record usage
+    await ctx.token_counter.push(llm.name, "llm")
+    await ctx.token_counter.record_usage(12, 8, model_name="m", provider="p")
+    await ctx.token_counter.pop()
+
+    usage = await llm.get_token_usage()
+    assert usage is not None and usage.total_tokens == 20
+
+    got = []
+
+    async def on_llm(node, u):
+        got.append(u.total_tokens)
+
+    wid = await llm.watch_tokens(on_llm, throttle_ms=0)
+    assert wid is not None
+
+    # Update llm again
+    await ctx.token_counter.push(llm.name, "llm")
+    await ctx.token_counter.record_usage(3, 2, model_name="m", provider="p")
+    await ctx.token_counter.pop()
+
+    await asyncio.sleep(0.05)
+    assert any(v >= 25 for v in got)


### PR DESCRIPTION
Also added convenience methods to `get_token_node` for any object in the MCP-agent tree, so you can get usage stats, and even watch for usage as it is progressing. Updated examples to showcase this. Added new tests as well