### PR TITLE
Router LLM should extend AugmentedLLM to enable composability

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm.py
@@ -20,6 +20,7 @@ from mcp.types import (
     CallToolResult,
     CreateMessageRequestParams,
     CreateMessageResult,
+    ListToolsResult,
     SamplingMessage,
     TextContent,
     PromptMessage,
@@ -679,3 +680,19 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol[MessageParamT, Message
             identifier = str(self.context.executor.uuid())
 
         return f"{prefix}-{identifier}"
+
+    # --- Agent convenience proxies -------------------------------------------------
+    async def list_tools(self, server_name: str | None = None) -> ListToolsResult:
+        """Proxy to the underlying agent's list_tools for a simpler API."""
+        return await self.agent.list_tools(server_name=server_name)
+
+    async def close(self):
+        """Close underlying agent connections."""
+        await self.agent.close()
+
+    async def __aenter__(self):
+        await self.agent.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.agent.__aexit__(exc_type, exc_val, exc_tb)

--- a/src/mcp_agent/workflows/router/router_llm_anthropic.py
+++ b/src/mcp_agent/workflows/router/router_llm_anthropic.py
@@ -1,6 +1,7 @@
 from typing import Callable, List, Optional, TYPE_CHECKING
 
 from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm import AugmentedLLM
 from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLLM
 from mcp_agent.workflows.router.router_llm import LLMRouter
 
@@ -49,6 +50,7 @@ class AnthropicLLMRouter(LLMRouter):
     @classmethod
     async def create(
         cls,
+        llm: AugmentedLLM | None = None,
         server_names: List[str] | None = None,
         agents: List[Agent] | None = None,
         functions: List[Callable] | None = None,

--- a/src/mcp_agent/workflows/router/router_llm_openai.py
+++ b/src/mcp_agent/workflows/router/router_llm_openai.py
@@ -1,6 +1,7 @@
 from typing import Callable, List, Optional, TYPE_CHECKING
 
 from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm import AugmentedLLM
 from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
 from mcp_agent.workflows.router.router_llm import LLMRouter
 
@@ -49,6 +50,7 @@ class OpenAILLMRouter(LLMRouter):
     @classmethod
     async def create(
         cls,
+        llm: AugmentedLLM | None = None,
         server_names: List[str] | None = None,
         agents: List[Agent] | None = None,
         functions: List[Callable] | None = None,


### PR DESCRIPTION
Leading up to a wider revamp that removes the need to use both `Agent` and `AugmentedLLM` classes (stay tuned)