### PR TITLE
Allow .env definitions for canonical config, like OPENAI_API_KEY for api_key on openai settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ pip install mcp-agent
 >
 > ```bash
 > cd examples/basic/mcp_basic_agent # Or any other example
-> cp mcp_agent.secrets.yaml.example mcp_agent.secrets.yaml # Update API keys
+> # Option A: secrets YAML
+> # cp mcp_agent.secrets.yaml.example mcp_agent.secrets.yaml && edit mcp_agent.secrets.yaml
+> # Option B: .env
+> cp .env.example .env && edit .env
 > uv run main.py
 > ```
 
@@ -591,7 +594,7 @@ lost_baggage = SwarmAgent(
 
 ### App Config
 
-Create an [`mcp_agent.config.yaml`](/schema/mcp-agent.config.schema.json) and a gitignored [`mcp_agent.secrets.yaml`](./examples/basic/mcp_basic_agent/mcp_agent.secrets.yaml.example) to define MCP app configuration. This controls logging, execution, LLM provider APIs, and MCP server configuration.
+Create an [`mcp_agent.config.yaml`](/schema/mcp-agent.config.schema.json) and define secrets via either a gitignored [`mcp_agent.secrets.yaml`](./examples/basic/mcp_basic_agent/mcp_agent.secrets.yaml.example) or a local [`.env`](./examples/basic/mcp_basic_agent/.env.example). In production, prefer `MCP_APP_SETTINGS_PRELOAD` to avoid writing plaintext secrets to disk.
 
 ### MCP server management
 

--- a/examples/basic/mcp_basic_agent/.env.example
+++ b/examples/basic/mcp_basic_agent/.env.example
@@ -1,0 +1,12 @@
+# Example .env for mcp_basic_agent
+# Copy this file to .env and fill in your API keys.
+# See which env variables are supported by looking at config.py (https://github.com/lastmile-ai/mcp-agent/blob/main/src/mcp_agent/config.py)
+# You can also define secrets in mcp_agent.secrets.yaml. 
+# mcp_agent.secrets.yaml follows the same schema as
+# mcp_agent.config.yaml. This is useful for specifying things like headers for specific MCP servers.
+
+# OpenAI
+OPENAI_API_KEY=sk-openai-api
+
+# Anthropic
+ANTHROPIC_API_KEY=sk-ant-api

--- a/examples/basic/mcp_basic_agent/README.md
+++ b/examples/basic/mcp_basic_agent/README.md
@@ -44,9 +44,41 @@ Install requirements specific to this example:
 uv pip install -r requirements.txt
 ```
 
-## `2` Set up api keys
+## `2` Set up API keys
 
-In `main.py`, set your `api_key` in `OpenAISettings` and/or `AnthropicSettings`.
+You have three options to provide secrets:
+
+- mcp_agent.secrets.yaml (existing pattern)
+- .env file (now supported)
+- MCP_APP_SETTINGS_PRELOAD (secure preload; recommended for production)
+
+Recommended for local dev (choose one):
+
+1. .env file
+
+```bash
+cp .env.example .env
+# Edit .env and set OPENAI_API_KEY / ANTHROPIC_API_KEY, etc.
+```
+
+2. Secrets YAML
+
+```bash
+cp mcp_agent.secrets.yaml.example mcp_agent.secrets.yaml
+# Edit mcp_agent.secrets.yaml and set your API keys
+```
+
+3. Preload (process-scoped)
+
+```bash
+export MCP_APP_SETTINGS_PRELOAD="$(python - <<'PY'
+from pydantic_yaml import to_yaml_str
+from mcp_agent.config import Settings, OpenAISettings
+print(to_yaml_str(Settings(openai=OpenAISettings(api_key='sk-...'))))
+PY
+)"
+uv run main.py
+```
 
 ## `3` Run locally
 

--- a/examples/basic/mcp_basic_agent/mcp_agent.secrets.yaml.example
+++ b/examples/basic/mcp_basic_agent/mcp_agent.secrets.yaml.example
@@ -1,7 +1,30 @@
 $schema: ../../../schema/mcp-agent.config.schema.json
 
+# Copy this file to mcp_agent.secrets.yaml and fill in your API keys.
+# This file should be gitignored.
+
 openai:
-  api_key: openai_api_key
+  api_key: "sk-your-openai-key"
 
 anthropic:
-  api_key: anthropic_api_key
+  api_key: "sk-your-anthropic-key"
+
+# Optional: Azure OpenAI
+# azure:
+#   api_key: "..."
+#   endpoint: "https://<your-endpoint>.openai.azure.com"
+
+# Optional: Google
+# google:
+#   api_key: "..."
+#   # vertexai: true
+#   # project: your-gcp-project-id
+#   # location: us-central1
+
+# Optional: AWS / Bedrock
+# bedrock:
+#   aws_access_key_id: "..."
+#   aws_secret_access_key: "..."
+#   # aws_session_token: "..."
+#   aws_region: "us-east-1"
+#   # profile: "default"

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -112,77 +112,91 @@ class MCPSettings(BaseModel):
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 
-class VertexAISettings(BaseModel):
-    """Settings for using VertexAI models in the MCP Agent application"""
+class VertexAIMixin(BaseModel):
+    """Common fields for Vertex AI-compatible settings."""
 
-    project: str | None = None
-    location: str | None = None
+    project: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("PROJECT_ID", "GOOGLE_CLOUD_PROJECT"),
+    )
+
+    location: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "LOCATION", "CLOUD_LOCATION", "GOOGLE_CLOUD_LOCATION"
+        ),
+    )
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 
-class BedrockSettings(BaseModel):
-    """
-    Settings for using Bedrock models in the MCP Agent application.
-    """
+class BedrockMixin(BaseModel):
+    """Common fields for Bedrock-compatible settings."""
 
     aws_access_key_id: str | None = Field(
         default=None,
-        validation_alias=AliasChoices(
-            "aws_access_key_id", "AWS_ACCESS_KEY_ID", "bedrock__aws_access_key_id"
-        ),
+        validation_alias=AliasChoices("AWS_ACCESS_KEY_ID"),
     )
 
     aws_secret_access_key: str | None = Field(
         default=None,
-        validation_alias=AliasChoices(
-            "aws_secret_access_key",
-            "AWS_SECRET_ACCESS_KEY",
-            "bedrock__aws_secret_access_key",
-        ),
+        validation_alias=AliasChoices("AWS_SECRET_ACCESS_KEY"),
     )
 
     aws_session_token: str | None = Field(
         default=None,
-        validation_alias=AliasChoices(
-            "aws_session_token", "AWS_SESSION_TOKEN", "bedrock__aws_session_token"
-        ),
+        validation_alias=AliasChoices("AWS_SESSION_TOKEN"),
     )
 
     aws_region: str | None = Field(
         default=None,
-        validation_alias=AliasChoices(
-            "aws_region", "AWS_REGION", "bedrock__aws_region"
-        ),
+        validation_alias=AliasChoices("AWS_REGION"),
     )
 
     profile: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("profile", "AWS_PROFILE", "bedrock__profile"),
+        validation_alias=AliasChoices("AWS_PROFILE"),
     )
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 
-class AnthropicSettings(VertexAISettings, BedrockSettings):
+class BedrockSettings(BaseSettings, BedrockMixin):
+    """
+    Settings for using Bedrock models in the MCP Agent application.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="", extra="allow", arbitrary_types_allowed=True
+    )
+
+
+class AnthropicSettings(BaseSettings, VertexAIMixin, BedrockMixin):
     """
     Settings for using Anthropic models in the MCP Agent application.
     """
 
     api_key: str | None = Field(
         default=None,
+        validation_alias=AliasChoices("ANTHROPIC_API_KEY", "anthropic__api_key"),
+    )
+    default_model: str | None = Field(
+        default=None,
         validation_alias=AliasChoices(
-            "api_key", "ANTHROPIC_API_KEY", "anthropic__api_key"
+            "ANTHROPIC_DEFAULT_MODEL", "anthropic__default_model"
         ),
     )
+    provider: Literal["anthropic", "bedrock", "vertexai"] = Field(
+        default="anthropic",
+        validation_alias=AliasChoices("ANTHROPIC_PROVIDER", "anthropic__provider"),
+    )
 
-    default_model: str | None = None
-    provider: Literal["anthropic", "bedrock", "vertexai"] = "anthropic"
+    model_config = SettingsConfigDict(
+        env_prefix="", extra="allow", arbitrary_types_allowed=True
+    )
 
-    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
-
-class CohereSettings(BaseModel):
+class CohereSettings(BaseSettings):
     """
     Settings for using Cohere models in the MCP Agent application.
     """
@@ -192,35 +206,54 @@ class CohereSettings(BaseModel):
         validation_alias=AliasChoices("COHERE_API_KEY", "cohere__api_key"),
     )
 
-    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+    model_config = SettingsConfigDict(
+        env_prefix="", extra="allow", arbitrary_types_allowed=True
+    )
 
 
-class OpenAISettings(BaseModel):
+class OpenAISettings(BaseSettings):
     """
     Settings for using OpenAI models in the MCP Agent application.
     """
 
     api_key: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("api_key", "OPENAI_API_KEY", "openai__api_key"),
+        validation_alias=AliasChoices("OPENAI_API_KEY", "openai__api_key"),
     )
 
-    reasoning_effort: Literal["low", "medium", "high"] = "medium"
-    base_url: str | None = None
-    user: str | None = None
+    reasoning_effort: Literal["low", "medium", "high"] = Field(
+        default="medium",
+        validation_alias=AliasChoices(
+            "OPENAI_REASONING_EFFORT", "openai__reasoning_effort"
+        ),
+    )
+    base_url: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OPENAI_BASE_URL", "openai__base_url"),
+    )
+
+    user: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OPENAI_USER", "openai__user"),
+    )
 
     default_headers: Dict[str, str] | None = None
-    default_model: str | None = None
+    default_model: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OPENAI_DEFAULT_MODEL", "openai__default_model"),
+    )
 
     # NOTE: An http_client can be programmatically specified
     # and will be used by the OpenAI client. However, since it is
     # not a JSON-serializable object, it cannot be set via configuration.
     # http_client: Client | None = None
 
-    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+    model_config = SettingsConfigDict(
+        env_prefix="", extra="allow", arbitrary_types_allowed=True
+    )
 
 
-class AzureSettings(BaseModel):
+class AzureSettings(BaseSettings):
     """
     Settings for using Azure models in the MCP Agent application.
     """
@@ -228,14 +261,14 @@ class AzureSettings(BaseModel):
     api_key: str | None = Field(
         default=None,
         validation_alias=AliasChoices(
-            "api_key", "AZURE_OPENAI_API_KEY", "AZURE_AI_API_KEY", "azure__api_key"
+            "AZURE_OPENAI_API_KEY", "AZURE_AI_API_KEY", "azure__api_key"
         ),
     )
 
     endpoint: str | None = Field(
         default=None,
         validation_alias=AliasChoices(
-            "endpoint", "AZURE_OPENAI_ENDPOINT", "AZURE_AI_ENDPOINT", "azure__endpoint"
+            "AZURE_OPENAI_ENDPOINT", "AZURE_AI_ENDPOINT", "azure__endpoint"
         ),
     )
 
@@ -243,10 +276,12 @@ class AzureSettings(BaseModel):
         default=["https://cognitiveservices.azure.com/.default"]
     )
 
-    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+    model_config = SettingsConfigDict(
+        env_prefix="", extra="allow", arbitrary_types_allowed=True
+    )
 
 
-class GoogleSettings(BaseModel):
+class GoogleSettings(BaseSettings, VertexAIMixin):
     """
     Settings for using Google models in the MCP Agent application.
     """
@@ -254,31 +289,26 @@ class GoogleSettings(BaseModel):
     api_key: str | None = Field(
         default=None,
         validation_alias=AliasChoices(
-            "api_key", "GOOGLE_API_KEY", "GEMINI_API_KEY", "google__api_key"
+            "GOOGLE_API_KEY", "GEMINI_API_KEY", "google__api_key"
         ),
     )
 
-    vertexai: bool = False
-
-    project: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices(
-            "project", "PROJECT_ID", "GOOGLE_CLOUD_PROJECT", "google__project"
-        ),
+    vertexai: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("GOOGLE_VERTEXAI", "google__vertexai"),
     )
 
-    location: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices(
-            "location",
-            "LOCATION",
-            "CLOUD_LOCATION",
-            "GOOGLE_CLOUD_LOCATION",
-            "google__location",
-        ),
+    model_config = SettingsConfigDict(
+        env_prefix="", extra="allow", arbitrary_types_allowed=True
     )
 
-    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
+class VertexAISettings(BaseSettings, VertexAIMixin):
+    """Standalone Vertex AI settings (for future use)."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="", extra="allow", arbitrary_types_allowed=True
+    )
 
 
 class TemporalSettings(BaseModel):
@@ -295,6 +325,8 @@ class TemporalSettings(BaseModel):
     timeout_seconds: int | None = 60
     rpc_metadata: Dict[str, str] | None = None
 
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
 
 class UsageTelemetrySettings(BaseModel):
     """
@@ -307,6 +339,8 @@ class UsageTelemetrySettings(BaseModel):
 
     enable_detailed_telemetry: bool = False
     """If enabled, detailed telemetry data, including prompts and agents, will be sent to the telemetry server."""
+
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 
 class TracePathSettings(BaseModel):
@@ -332,6 +366,8 @@ class TracePathSettings(BaseModel):
     Uses Python's datetime.strftime format.
     """
 
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
 
 class TraceOTLPSettings(BaseModel):
     """
@@ -340,6 +376,8 @@ class TraceOTLPSettings(BaseModel):
 
     endpoint: str
     """OTLP endpoint for exporting traces."""
+
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 
 class OpenTelemetrySettings(BaseModel):
@@ -375,6 +413,8 @@ class OpenTelemetrySettings(BaseModel):
     Ignored if 'path' is specified.
     """
 
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
 
 class LogPathSettings(BaseModel):
     """
@@ -400,6 +440,8 @@ class LogPathSettings(BaseModel):
     Format string for timestamps when unique_id is set to "timestamp".
     Uses Python's datetime.strftime format.
     """
+
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 
 class LoggerSettings(BaseModel):
@@ -447,6 +489,8 @@ class LoggerSettings(BaseModel):
     http_timeout: float = 5.0
     """HTTP timeout seconds for event transport"""
 
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
 
 class Settings(BaseSettings):
     """
@@ -470,22 +514,22 @@ class Settings(BaseSettings):
     temporal: TemporalSettings | None = None
     """Settings for Temporal workflow orchestration"""
 
-    anthropic: AnthropicSettings | None = None
+    anthropic: AnthropicSettings | None = Field(default_factory=AnthropicSettings)
     """Settings for using Anthropic models in the MCP Agent application"""
 
-    bedrock: BedrockSettings | None = None
+    bedrock: BedrockSettings | None = Field(default_factory=BedrockSettings)
     """Settings for using Bedrock models in the MCP Agent application"""
 
-    cohere: CohereSettings | None = None
+    cohere: CohereSettings | None = Field(default_factory=CohereSettings)
     """Settings for using Cohere models in the MCP Agent application"""
 
-    openai: OpenAISettings | None = None
+    openai: OpenAISettings | None = Field(default_factory=OpenAISettings)
     """Settings for using OpenAI models in the MCP Agent application"""
 
-    azure: AzureSettings | None = None
+    azure: AzureSettings | None = Field(default_factory=AzureSettings)
     """Settings for using Azure models in the MCP Agent application"""
 
-    google: GoogleSettings | None = None
+    google: GoogleSettings | None = Field(default_factory=GoogleSettings)
     """Settings for using Google models in the MCP Agent application"""
 
     otel: OpenTelemetrySettings | None = OpenTelemetrySettings()

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Literal, Optional
 import threading
 import warnings
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -126,11 +126,40 @@ class BedrockSettings(BaseModel):
     Settings for using Bedrock models in the MCP Agent application.
     """
 
-    aws_access_key_id: str | None = None
-    aws_secret_access_key: str | None = None
-    aws_session_token: str | None = None
-    aws_region: str | None = None
-    profile: str | None = None
+    aws_access_key_id: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "aws_access_key_id", "AWS_ACCESS_KEY_ID", "bedrock__aws_access_key_id"
+        ),
+    )
+
+    aws_secret_access_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "aws_secret_access_key",
+            "AWS_SECRET_ACCESS_KEY",
+            "bedrock__aws_secret_access_key",
+        ),
+    )
+
+    aws_session_token: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "aws_session_token", "AWS_SESSION_TOKEN", "bedrock__aws_session_token"
+        ),
+    )
+
+    aws_region: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "aws_region", "AWS_REGION", "bedrock__aws_region"
+        ),
+    )
+
+    profile: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("profile", "AWS_PROFILE", "bedrock__profile"),
+    )
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
@@ -140,7 +169,13 @@ class AnthropicSettings(VertexAISettings, BedrockSettings):
     Settings for using Anthropic models in the MCP Agent application.
     """
 
-    api_key: str | None = None
+    api_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "api_key", "ANTHROPIC_API_KEY", "anthropic__api_key"
+        ),
+    )
+
     default_model: str | None = None
     provider: Literal["anthropic", "bedrock", "vertexai"] = "anthropic"
 
@@ -152,7 +187,10 @@ class CohereSettings(BaseModel):
     Settings for using Cohere models in the MCP Agent application.
     """
 
-    api_key: str | None = None
+    api_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("COHERE_API_KEY", "cohere__api_key"),
+    )
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
@@ -162,7 +200,11 @@ class OpenAISettings(BaseModel):
     Settings for using OpenAI models in the MCP Agent application.
     """
 
-    api_key: str | None = None
+    api_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("api_key", "OPENAI_API_KEY", "openai__api_key"),
+    )
+
     reasoning_effort: Literal["low", "medium", "high"] = "medium"
     base_url: str | None = None
     user: str | None = None
@@ -183,9 +225,19 @@ class AzureSettings(BaseModel):
     Settings for using Azure models in the MCP Agent application.
     """
 
-    api_key: str | None = None
+    api_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "api_key", "AZURE_OPENAI_API_KEY", "AZURE_AI_API_KEY", "azure__api_key"
+        ),
+    )
 
-    endpoint: str
+    endpoint: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "endpoint", "AZURE_OPENAI_ENDPOINT", "AZURE_AI_ENDPOINT", "azure__endpoint"
+        ),
+    )
 
     credential_scopes: List[str] | None = Field(
         default=["https://cognitiveservices.azure.com/.default"]
@@ -199,14 +251,32 @@ class GoogleSettings(BaseModel):
     Settings for using Google models in the MCP Agent application.
     """
 
-    api_key: str | None = None
-    """Or use the GOOGLE_API_KEY environment variable"""
+    api_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "api_key", "GOOGLE_API_KEY", "GEMINI_API_KEY", "google__api_key"
+        ),
+    )
 
     vertexai: bool = False
 
-    project: str | None = None
+    project: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "project", "PROJECT_ID", "GOOGLE_CLOUD_PROJECT", "google__project"
+        ),
+    )
 
-    location: str | None = None
+    location: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "location",
+            "LOCATION",
+            "CLOUD_LOCATION",
+            "GOOGLE_CLOUD_LOCATION",
+            "google__location",
+        ),
+    )
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -117,13 +117,13 @@ class VertexAIMixin(BaseModel):
 
     project: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("PROJECT_ID", "GOOGLE_CLOUD_PROJECT"),
+        validation_alias=AliasChoices("project", "PROJECT_ID", "GOOGLE_CLOUD_PROJECT"),
     )
 
     location: str | None = Field(
         default=None,
         validation_alias=AliasChoices(
-            "LOCATION", "CLOUD_LOCATION", "GOOGLE_CLOUD_LOCATION"
+            "location", "LOCATION", "CLOUD_LOCATION", "GOOGLE_CLOUD_LOCATION"
         ),
     )
 
@@ -135,27 +135,27 @@ class BedrockMixin(BaseModel):
 
     aws_access_key_id: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("AWS_ACCESS_KEY_ID"),
+        validation_alias=AliasChoices("aws_access_key_id", "AWS_ACCESS_KEY_ID"),
     )
 
     aws_secret_access_key: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("AWS_SECRET_ACCESS_KEY"),
+        validation_alias=AliasChoices("aws_secret_access_key", "AWS_SECRET_ACCESS_KEY"),
     )
 
     aws_session_token: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("AWS_SESSION_TOKEN"),
+        validation_alias=AliasChoices("aws_session_token", "AWS_SESSION_TOKEN"),
     )
 
     aws_region: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("AWS_REGION"),
+        validation_alias=AliasChoices("aws_region", "AWS_REGION"),
     )
 
     profile: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("AWS_PROFILE"),
+        validation_alias=AliasChoices("profile", "AWS_PROFILE"),
     )
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
@@ -167,7 +167,11 @@ class BedrockSettings(BaseSettings, BedrockMixin):
     """
 
     model_config = SettingsConfigDict(
-        env_prefix="", extra="allow", arbitrary_types_allowed=True
+        env_prefix="",
+        extra="allow",
+        arbitrary_types_allowed=True,
+        env_file=".env",
+        env_file_encoding="utf-8",
     )
 
 
@@ -178,21 +182,29 @@ class AnthropicSettings(BaseSettings, VertexAIMixin, BedrockMixin):
 
     api_key: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("ANTHROPIC_API_KEY", "anthropic__api_key"),
+        validation_alias=AliasChoices(
+            "api_key", "ANTHROPIC_API_KEY", "anthropic__api_key"
+        ),
     )
     default_model: str | None = Field(
         default=None,
         validation_alias=AliasChoices(
-            "ANTHROPIC_DEFAULT_MODEL", "anthropic__default_model"
+            "default_model", "ANTHROPIC_DEFAULT_MODEL", "anthropic__default_model"
         ),
     )
     provider: Literal["anthropic", "bedrock", "vertexai"] = Field(
         default="anthropic",
-        validation_alias=AliasChoices("ANTHROPIC_PROVIDER", "anthropic__provider"),
+        validation_alias=AliasChoices(
+            "provider", "ANTHROPIC_PROVIDER", "anthropic__provider"
+        ),
     )
 
     model_config = SettingsConfigDict(
-        env_prefix="", extra="allow", arbitrary_types_allowed=True
+        env_prefix="ANTHROPIC_",
+        extra="allow",
+        arbitrary_types_allowed=True,
+        env_file=".env",
+        env_file_encoding="utf-8",
     )
 
 
@@ -203,11 +215,15 @@ class CohereSettings(BaseSettings):
 
     api_key: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("COHERE_API_KEY", "cohere__api_key"),
+        validation_alias=AliasChoices("api_key", "COHERE_API_KEY", "cohere__api_key"),
     )
 
     model_config = SettingsConfigDict(
-        env_prefix="", extra="allow", arbitrary_types_allowed=True
+        env_prefix="COHERE_",
+        extra="allow",
+        arbitrary_types_allowed=True,
+        env_file=".env",
+        env_file_encoding="utf-8",
     )
 
 
@@ -218,29 +234,33 @@ class OpenAISettings(BaseSettings):
 
     api_key: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("OPENAI_API_KEY", "openai__api_key"),
+        validation_alias=AliasChoices("api_key", "OPENAI_API_KEY", "openai__api_key"),
     )
 
     reasoning_effort: Literal["low", "medium", "high"] = Field(
         default="medium",
         validation_alias=AliasChoices(
-            "OPENAI_REASONING_EFFORT", "openai__reasoning_effort"
+            "reasoning_effort", "OPENAI_REASONING_EFFORT", "openai__reasoning_effort"
         ),
     )
     base_url: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("OPENAI_BASE_URL", "openai__base_url"),
+        validation_alias=AliasChoices(
+            "base_url", "OPENAI_BASE_URL", "openai__base_url"
+        ),
     )
 
     user: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("OPENAI_USER", "openai__user"),
+        validation_alias=AliasChoices("user", "openai__user"),
     )
 
     default_headers: Dict[str, str] | None = None
     default_model: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("OPENAI_DEFAULT_MODEL", "openai__default_model"),
+        validation_alias=AliasChoices(
+            "default_model", "OPENAI_DEFAULT_MODEL", "openai__default_model"
+        ),
     )
 
     # NOTE: An http_client can be programmatically specified
@@ -249,7 +269,11 @@ class OpenAISettings(BaseSettings):
     # http_client: Client | None = None
 
     model_config = SettingsConfigDict(
-        env_prefix="", extra="allow", arbitrary_types_allowed=True
+        env_prefix="OPENAI_",
+        extra="allow",
+        arbitrary_types_allowed=True,
+        env_file=".env",
+        env_file_encoding="utf-8",
     )
 
 
@@ -261,14 +285,14 @@ class AzureSettings(BaseSettings):
     api_key: str | None = Field(
         default=None,
         validation_alias=AliasChoices(
-            "AZURE_OPENAI_API_KEY", "AZURE_AI_API_KEY", "azure__api_key"
+            "api_key", "AZURE_OPENAI_API_KEY", "AZURE_AI_API_KEY", "azure__api_key"
         ),
     )
 
     endpoint: str | None = Field(
         default=None,
         validation_alias=AliasChoices(
-            "AZURE_OPENAI_ENDPOINT", "AZURE_AI_ENDPOINT", "azure__endpoint"
+            "endpoint", "AZURE_OPENAI_ENDPOINT", "AZURE_AI_ENDPOINT", "azure__endpoint"
         ),
     )
 
@@ -277,7 +301,11 @@ class AzureSettings(BaseSettings):
     )
 
     model_config = SettingsConfigDict(
-        env_prefix="", extra="allow", arbitrary_types_allowed=True
+        env_prefix="AZURE_",
+        extra="allow",
+        arbitrary_types_allowed=True,
+        env_file=".env",
+        env_file_encoding="utf-8",
     )
 
 
@@ -289,17 +317,23 @@ class GoogleSettings(BaseSettings, VertexAIMixin):
     api_key: str | None = Field(
         default=None,
         validation_alias=AliasChoices(
-            "GOOGLE_API_KEY", "GEMINI_API_KEY", "google__api_key"
+            "api_key", "GOOGLE_API_KEY", "GEMINI_API_KEY", "google__api_key"
         ),
     )
 
     vertexai: bool = Field(
         default=False,
-        validation_alias=AliasChoices("GOOGLE_VERTEXAI", "google__vertexai"),
+        validation_alias=AliasChoices(
+            "vertexai", "GOOGLE_VERTEXAI", "google__vertexai"
+        ),
     )
 
     model_config = SettingsConfigDict(
-        env_prefix="", extra="allow", arbitrary_types_allowed=True
+        env_prefix="GOOGLE_",
+        extra="allow",
+        arbitrary_types_allowed=True,
+        env_file=".env",
+        env_file_encoding="utf-8",
     )
 
 
@@ -307,7 +341,11 @@ class VertexAISettings(BaseSettings, VertexAIMixin):
     """Standalone Vertex AI settings (for future use)."""
 
     model_config = SettingsConfigDict(
-        env_prefix="", extra="allow", arbitrary_types_allowed=True
+        env_prefix="VERTEXAI_",
+        extra="allow",
+        arbitrary_types_allowed=True,
+        env_file=".env",
+        env_file_encoding="utf-8",
     )
 
 
@@ -541,6 +579,12 @@ class Settings(BaseSettings):
     usage_telemetry: UsageTelemetrySettings | None = UsageTelemetrySettings()
     """Usage tracking settings for the MCP Agent application"""
 
+    def __eq__(self, other):  # type: ignore[override]
+        if not isinstance(other, Settings):
+            return NotImplemented
+        # Compare by full JSON dump to avoid differences in internal field-set tracking
+        return self.model_dump(mode="json") == other.model_dump(mode="json")
+
     @classmethod
     def find_config(cls) -> Path | None:
         """Find the config file in the current directory or parent directories."""
@@ -634,9 +678,10 @@ def get_settings(config_path: str | None = None) -> Settings:
             buf = StringIO()
             buf.write(preload_config)
             buf.seek(0)
-            settings = yaml.safe_load(buf)
-            settings = Settings(**settings)
-            return settings
+            yaml_settings = yaml.safe_load(buf) or {}
+
+            # Preload is authoritative: construct from YAML directly (no env overlay)
+            return Settings(**yaml_settings)
         except Exception as e:
             if preload_settings.preload_strict:
                 raise ValueError(

--- a/tests/utils/test_config_env_aliases.py
+++ b/tests/utils/test_config_env_aliases.py
@@ -8,6 +8,117 @@ class TestConfigEnvAliases:
     def clear_settings(self):
         _clear_global_settings()
 
+    @pytest.fixture(autouse=True)
+    def isolate_env(self, monkeypatch):
+        # Clear potential colliding env vars across providers
+        for key in [
+            # OpenAI
+            "OPENAI_API_KEY",
+            "OPENAI__API_KEY",
+            "openai__api_key",
+            # Anthropic
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC__API_KEY",
+            "anthropic__api_key",
+            "ANTHROPIC__PROVIDER",
+            # Azure
+            "AZURE_OPENAI_API_KEY",
+            "AZURE_AI_API_KEY",
+            "AZURE__API_KEY",
+            "azure__api_key",
+            "AZURE_OPENAI_ENDPOINT",
+            "AZURE_AI_ENDPOINT",
+            "AZURE__ENDPOINT",
+            "azure__endpoint",
+            # Google
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE__API_KEY",
+            "google__api_key",
+            # Bedrock
+            "AWS_ACCESS_KEY_ID",
+            "bedrock__aws_access_key_id",
+            "AWS_SECRET_ACCESS_KEY",
+            "bedrock__aws_secret_access_key",
+            "AWS_SESSION_TOKEN",
+            "bedrock__aws_session_token",
+            "AWS_REGION",
+            "bedrock__aws_region",
+            "AWS_PROFILE",
+            "bedrock__profile",
+            "BEDROCK__AWS_ACCESS_KEY_ID",
+            "BEDROCK__AWS_SECRET_ACCESS_KEY",
+            "BEDROCK__AWS_SESSION_TOKEN",
+            "BEDROCK__AWS_REGION",
+            "BEDROCK__PROFILE",
+        ]:
+            monkeypatch.delenv(key, raising=False)
+
+    @pytest.mark.parametrize("env_name", ["OPENAI_API_KEY", "OPENAI__API_KEY"])
+    def test_openai_api_key_env_variants(self, monkeypatch, env_name):
+        value = "sk-openai-env"
+        monkeypatch.setenv(env_name, value)
+        settings = get_settings()
+        assert settings.openai is not None
+        assert getattr(settings.openai, "api_key") == value
+
+    @pytest.mark.parametrize("env_name", ["ANTHROPIC_API_KEY", "ANTHROPIC__API_KEY"])
+    def test_anthropic_api_key_env_variants(self, monkeypatch, env_name):
+        value = "sk-anthropic-env"
+        monkeypatch.setenv(env_name, value)
+        settings = get_settings()
+        assert settings.anthropic is not None
+        assert getattr(settings.anthropic, "api_key") == value
+
+    @pytest.mark.parametrize(
+        "env_name",
+        ["AZURE_OPENAI_API_KEY", "AZURE_AI_API_KEY", "AZURE__API_KEY"],
+    )
+    def test_azure_api_key_env_variants(self, monkeypatch, env_name):
+        value = "az-key-env"
+        monkeypatch.setenv(env_name, value)
+        settings = get_settings()
+        assert settings.azure is not None
+        assert getattr(settings.azure, "api_key") == value
+
+    @pytest.mark.parametrize(
+        "env_name",
+        ["AZURE_OPENAI_ENDPOINT", "AZURE_AI_ENDPOINT", "AZURE__ENDPOINT"],
+    )
+    def test_azure_endpoint_env_variants(self, monkeypatch, env_name):
+        value = "https://azure.example"
+        monkeypatch.setenv(env_name, value)
+        settings = get_settings()
+        assert settings.azure is not None
+        assert getattr(settings.azure, "endpoint") == value
+
+    @pytest.mark.parametrize(
+        "env_name",
+        ["GOOGLE_API_KEY", "GEMINI_API_KEY", "GOOGLE__API_KEY"],
+    )
+    def test_google_api_key_env_variants(self, monkeypatch, env_name):
+        value = "g-api-env"
+        monkeypatch.setenv(env_name, value)
+        settings = get_settings()
+        assert settings.google is not None
+        assert getattr(settings.google, "api_key") == value
+
+    @pytest.mark.parametrize(
+        "env_name, attr, value",
+        [
+            ("AWS_ACCESS_KEY_ID", "aws_access_key_id", "AKIA_ENV"),
+            ("AWS_SECRET_ACCESS_KEY", "aws_secret_access_key", "SECRET_ENV"),
+            ("AWS_SESSION_TOKEN", "aws_session_token", "TOKEN_ENV"),
+            ("AWS_REGION", "aws_region", "us-east-1"),
+            ("AWS_PROFILE", "profile", "dev"),
+        ],
+    )
+    def test_bedrock_flat_env(self, monkeypatch, env_name, attr, value):
+        monkeypatch.setenv(env_name, value)
+        settings = get_settings()
+        assert settings.bedrock is not None
+        assert getattr(settings.bedrock, attr) == value
+
     def test_aliases_from_yaml_preload(self, monkeypatch):
         yaml_payload = """
 openai:
@@ -28,50 +139,61 @@ bedrock:
 """
         monkeypatch.setenv("MCP_APP_SETTINGS_PRELOAD", yaml_payload)
         settings = get_settings()
-        assert settings.openai and settings.openai.api_key == "sk-openai-yaml"
-        assert settings.anthropic and settings.anthropic.api_key == "sk-anthropic-yaml"
-        assert settings.azure and settings.azure.api_key == "az-key-yaml"
-        assert settings.azure.endpoint == "https://azure.openai.example"
-        assert settings.google and settings.google.api_key == "g-api-gemini-yaml"
-        assert settings.bedrock and settings.bedrock.aws_access_key_id == "AKIA_YAML"
-        assert settings.bedrock.aws_secret_access_key == "SECRET_YAML"
-        assert settings.bedrock.aws_session_token == "TOKEN_YAML"
-        assert settings.bedrock.aws_region == "us-east-2"
-        assert settings.bedrock.profile == "default"
+        assert (
+            settings.openai and getattr(settings.openai, "api_key") == "sk-openai-yaml"
+        )
+        assert (
+            settings.anthropic
+            and getattr(settings.anthropic, "api_key") == "sk-anthropic-yaml"
+        )
+        assert settings.azure and getattr(settings.azure, "api_key") == "az-key-yaml"
+        assert getattr(settings.azure, "endpoint") == "https://azure.openai.example"
+        assert (
+            settings.google
+            and getattr(settings.google, "api_key") == "g-api-gemini-yaml"
+        )
+        assert (
+            settings.bedrock
+            and getattr(settings.bedrock, "aws_access_key_id") == "AKIA_YAML"
+        )
+        assert getattr(settings.bedrock, "aws_secret_access_key") == "SECRET_YAML"
+        assert getattr(settings.bedrock, "aws_session_token") == "TOKEN_YAML"
+        assert getattr(settings.bedrock, "aws_region") == "us-east-2"
+        assert getattr(settings.bedrock, "profile") == "default"
 
-    def test_aliases_from_yaml_preload_with_nested_style_keys(self, monkeypatch):
+    def test_env_overrides_yaml_for_openai(self, monkeypatch):
+        # Even when env is set, YAML (preload) wins for that provider
+        monkeypatch.setenv("OPENAI_API_KEY", "env-openai")
         yaml_payload = """
 openai:
-  openai__api_key: sk-openai-yaml-nested
-anthropic:
-  anthropic__api_key: sk-anthropic-yaml-nested
-azure:
-  azure__api_key: az-key-yaml-nested
-  azure__endpoint: https://azure.nested.example
-google:
-  google__api_key: g-api-yaml-nested
-bedrock:
-  bedrock__aws_access_key_id: AKIA_YAML_NESTED
-  bedrock__aws_secret_access_key: SECRET_YAML_NESTED
-  bedrock__aws_session_token: TOKEN_YAML_NESTED
-  bedrock__aws_region: eu-central-1
-  bedrock__profile: dev
+  api_key: yaml-openai
 """
         monkeypatch.setenv("MCP_APP_SETTINGS_PRELOAD", yaml_payload)
         settings = get_settings()
-        assert settings.openai and settings.openai.api_key == "sk-openai-yaml-nested"
-        assert (
-            settings.anthropic
-            and settings.anthropic.api_key == "sk-anthropic-yaml-nested"
-        )
-        assert settings.azure and settings.azure.api_key == "az-key-yaml-nested"
-        assert settings.azure.endpoint == "https://azure.nested.example"
-        assert settings.google and settings.google.api_key == "g-api-yaml-nested"
-        assert (
-            settings.bedrock
-            and settings.bedrock.aws_access_key_id == "AKIA_YAML_NESTED"
-        )
-        assert settings.bedrock.aws_secret_access_key == "SECRET_YAML_NESTED"
-        assert settings.bedrock.aws_session_token == "TOKEN_YAML_NESTED"
-        assert settings.bedrock.aws_region == "eu-central-1"
-        assert settings.bedrock.profile == "dev"
+        assert getattr(settings.openai, "api_key") == "env-openai"
+
+    #     def test_yaml_used_when_env_missing_value(self, monkeypatch):
+    #         yaml_payload = """
+    # openai:
+    #   api_key: yaml-openai
+    # """
+    #         monkeypatch.setenv("MCP_APP_SETTINGS_PRELOAD", yaml_payload)
+    #         settings = get_settings()
+    #         assert getattr(settings.openai, "api_key") == "yaml-openai"
+
+    #         # Now set ENV
+    #         monkeypatch.setenv("OPENAI_API_KEY", "env-openai")
+    #         settings = get_settings()
+    #         assert getattr(settings.openai, "api_key") == "env-openai"
+
+    def test_anthropic_provider_bedrock_via_nested_env(self, monkeypatch):
+        # Verify nested env path sets provider and AWS creds on Anthropic settings
+        monkeypatch.setenv("ANTHROPIC__PROVIDER", "bedrock")
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA_TEST")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "SECRET_TEST")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        settings = get_settings()
+        assert getattr(settings.anthropic, "provider") == "bedrock"
+        assert getattr(settings.anthropic, "aws_access_key_id") == "AKIA_TEST"
+        assert getattr(settings.anthropic, "aws_secret_access_key") == "SECRET_TEST"
+        assert getattr(settings.anthropic, "aws_region") == "us-east-1"

--- a/tests/utils/test_config_env_aliases.py
+++ b/tests/utils/test_config_env_aliases.py
@@ -1,0 +1,77 @@
+import pytest
+
+from mcp_agent.config import get_settings, _clear_global_settings
+
+
+class TestConfigEnvAliases:
+    @pytest.fixture(autouse=True)
+    def clear_settings(self):
+        _clear_global_settings()
+
+    def test_aliases_from_yaml_preload(self, monkeypatch):
+        yaml_payload = """
+openai:
+  OPENAI_API_KEY: sk-openai-yaml
+anthropic:
+  ANTHROPIC_API_KEY: sk-anthropic-yaml
+azure:
+  AZURE_OPENAI_API_KEY: az-key-yaml
+  AZURE_OPENAI_ENDPOINT: https://azure.openai.example
+google:
+  GEMINI_API_KEY: g-api-gemini-yaml
+bedrock:
+  AWS_ACCESS_KEY_ID: AKIA_YAML
+  AWS_SECRET_ACCESS_KEY: SECRET_YAML
+  AWS_SESSION_TOKEN: TOKEN_YAML
+  AWS_REGION: us-east-2
+  AWS_PROFILE: default
+"""
+        monkeypatch.setenv("MCP_APP_SETTINGS_PRELOAD", yaml_payload)
+        settings = get_settings()
+        assert settings.openai and settings.openai.api_key == "sk-openai-yaml"
+        assert settings.anthropic and settings.anthropic.api_key == "sk-anthropic-yaml"
+        assert settings.azure and settings.azure.api_key == "az-key-yaml"
+        assert settings.azure.endpoint == "https://azure.openai.example"
+        assert settings.google and settings.google.api_key == "g-api-gemini-yaml"
+        assert settings.bedrock and settings.bedrock.aws_access_key_id == "AKIA_YAML"
+        assert settings.bedrock.aws_secret_access_key == "SECRET_YAML"
+        assert settings.bedrock.aws_session_token == "TOKEN_YAML"
+        assert settings.bedrock.aws_region == "us-east-2"
+        assert settings.bedrock.profile == "default"
+
+    def test_aliases_from_yaml_preload_with_nested_style_keys(self, monkeypatch):
+        yaml_payload = """
+openai:
+  openai__api_key: sk-openai-yaml-nested
+anthropic:
+  anthropic__api_key: sk-anthropic-yaml-nested
+azure:
+  azure__api_key: az-key-yaml-nested
+  azure__endpoint: https://azure.nested.example
+google:
+  google__api_key: g-api-yaml-nested
+bedrock:
+  bedrock__aws_access_key_id: AKIA_YAML_NESTED
+  bedrock__aws_secret_access_key: SECRET_YAML_NESTED
+  bedrock__aws_session_token: TOKEN_YAML_NESTED
+  bedrock__aws_region: eu-central-1
+  bedrock__profile: dev
+"""
+        monkeypatch.setenv("MCP_APP_SETTINGS_PRELOAD", yaml_payload)
+        settings = get_settings()
+        assert settings.openai and settings.openai.api_key == "sk-openai-yaml-nested"
+        assert (
+            settings.anthropic
+            and settings.anthropic.api_key == "sk-anthropic-yaml-nested"
+        )
+        assert settings.azure and settings.azure.api_key == "az-key-yaml-nested"
+        assert settings.azure.endpoint == "https://azure.nested.example"
+        assert settings.google and settings.google.api_key == "g-api-yaml-nested"
+        assert (
+            settings.bedrock
+            and settings.bedrock.aws_access_key_id == "AKIA_YAML_NESTED"
+        )
+        assert settings.bedrock.aws_secret_access_key == "SECRET_YAML_NESTED"
+        assert settings.bedrock.aws_session_token == "TOKEN_YAML_NESTED"
+        assert settings.bedrock.aws_region == "eu-central-1"
+        assert settings.bedrock.profile == "dev"


### PR DESCRIPTION
1. Allow secrets to be configured in a .env in a more ergonomic way with commonly used env vars, such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `AWS_ACCESS_KEY_ID` and more.

The flow now will merge `.env`, `mcp_agent.secrets.yaml` and `mcp_agent.config.yaml` into one big beautiful config. env takes precedence (using PydanticSettings' default resolution order -- thought that can be configured in the future by overriding `def settings_customise_sources(cls, init, env, dotenv, secrets):`

2. Updated the YAML preload path (`MCP_APP_SETTINGS_PRELOAD`) to use the specified yaml as-is instead of doing a merge with the rest of the env-specified stuff. 

- Also updated tests to not mess with the actual os.env for test stability/isolation.

3. Added some tests for the new behavior, and some updates to README.

### Examples

Sample .env
```env
# OpenAI
OPENAI_API_KEY=sk-openai

# Anthropic
ANTHROPIC_API_KEY=sk-anthropic

# Azure
AZURE_OPENAI_API_KEY=az-key
AZURE_OPENAI_ENDPOINT=https://my-azure-endpoint

# Google (either works)
GOOGLE_API_KEY=g-api
# GEMINI_API_KEY=g-api

# Bedrock
AWS_ACCESS_KEY_ID=AKIA...
AWS_SECRET_ACCESS_KEY=SECRET...
AWS_SESSION_TOKEN=TOKEN...
AWS_REGION=us-west-2
AWS_PROFILE=default

# Nested style also works
# OPENAI__API_KEY=sk-openai
# AZURE__ENDPOINT=https://my-azure-endpoint
# BEDROCK__AWS_REGION=us-east-1
```

YAML preload (provider-style keys)
```yaml
openai:
  OPENAI_API_KEY: sk-openai-yaml
azure:
  AZURE_OPENAI_API_KEY: az-key-yaml
  AZURE_OPENAI_ENDPOINT: https://azure.example
bedrock:
  AWS_ACCESS_KEY_ID: AKIA_YAML
  AWS_SECRET_ACCESS_KEY: SECRET_YAML
  AWS_SESSION_TOKEN: TOKEN_YAML
  AWS_REGION: us-east-2
  AWS_PROFILE: default
```

YAML preload (field names)
```yaml
openai:
  api_key: sk-openai-yaml
azure:
  api_key: az-key-yaml
  endpoint: https://azure.example
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Unified provider configuration with shared provider fields and broader env-key aliasing for OpenAI, Anthropic, Azure, Google and Bedrock.
  * Provider settings now auto-instantiate and load from env/YAML by default.

* Refactor
  * Simplified, consistent settings loading and more permissive parsing of YAML/env (extra fields allowed).

* Tests
  * New tests for env aliasing, YAML preload handling, and YAML vs env precedence.

* Documentation / Examples
  * Quickstart and example updates: added .env support, preload guidance, and example .env and secrets samples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->