### PR TITLE
[Feature] Support OTLP exporter headers

### DIFF
--- a/examples/tracing/langfuse/README.md
+++ b/examples/tracing/langfuse/README.md
@@ -1,0 +1,70 @@
+# Langfuse Trace Exporter Example
+
+This example shows how to configure a Langfuse OTLP trace exporter for use in `mcp-agent` by configuring the
+`otel.otlp_settings` with the expected endpoint and headers.
+Following information from https://langfuse.com/integrations/native/opentelemetry
+
+## `1` App set up
+
+First, clone the repo and navigate to the tracing/langfuse example:
+
+```bash
+git clone https://github.com/lastmile-ai/mcp-agent.git
+cd mcp-agent/examples/tracing/langfuse
+```
+
+Install `uv` (if you don’t have it):
+
+```bash
+pip install uv
+```
+
+Sync `mcp-agent` project dependencies:
+
+```bash
+uv sync
+```
+
+Install requirements specific to this example:
+
+```bash
+uv pip install -r requirements.txt
+```
+
+## `2` Set up secrets and environment variables
+
+Copy and configure your secrets and env variables:
+
+```bash
+cp mcp_agent.secrets.yaml.example mcp_agent.secrets.yaml
+```
+
+Then open `mcp_agent.secrets.yaml` and add your api key for your preferred LLM for your MCP servers.
+
+Obtain a secret and public API key for your desired Langfuse project and then generate a base-64 encoded AUTH_STRING in a terminal:
+
+```bash
+echo -n "pk-your-public-key:sk-your-secret-key" | base64
+```
+
+In `mcp_agent.secrets.yaml` set the Authorization header for OTLP:
+
+```yaml
+otel:
+  otlp_settings:
+    headers:
+      Authorization: "Basic AUTH_STRING"
+```
+
+Lastly, ensure the proper trace endpoint is configured for the `otel.otlp_settings.endpoint` in `mcp_agent.yaml` for the relevant
+Langfuse data region.
+
+## `4` Run locally
+
+In a terminal, run:
+
+```bash
+uv run main.py
+```
+
+<img width="2160" alt="Image" src="https://github.com/user-attachments/assets/664da099-ec50-4fa8-bb89-9e6fa9880d95" />

--- a/examples/tracing/langfuse/main.py
+++ b/examples/tracing/langfuse/main.py
@@ -1,0 +1,108 @@
+import asyncio
+import os
+import time
+
+from mcp_agent.app import MCPApp
+from mcp_agent.agents.agent import Agent
+from mcp_agent.human_input.types import HumanInputRequest, HumanInputResponse
+from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLLM
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+
+async def human_input_handler(request: HumanInputRequest) -> HumanInputResponse:
+    # Simulate a single-step response
+    return HumanInputResponse(
+        request_id=request.request_id,
+        response=f"Mocking input for request: {request.prompt}",
+        metadata={"mocked": True},
+    )
+
+
+# Settings loaded from mcp_agent.config.yaml/mcp_agent.secrets.yaml
+app = MCPApp(name="agent_tracing_example", human_input_callback=human_input_handler)
+
+
+async def agent_tracing():
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+        context = agent_app.context
+
+        logger.info("Current config:", data=context.config.model_dump())
+
+        # Add the current directory to the filesystem server's args
+        context.config.mcp.servers["filesystem"].args.extend([os.getcwd()])
+
+        finder_agent = Agent(
+            name="finder",
+            instruction="""You are an agent with access to the filesystem, 
+            as well as the ability to fetch URLs. Your job is to identify 
+            the closest match to a user's request, make the appropriate tool calls, 
+            and return the URI and CONTENTS of the closest match.""",
+            server_names=["fetch", "filesystem"],
+            human_input_callback=human_input_handler,
+        )
+
+        async with finder_agent:
+            logger.info("finder: Connected to server, calling list_tools...")
+            result = await finder_agent.list_tools()
+            logger.info("Tools available:", data=result.model_dump())
+
+            fetch_capabilities = await finder_agent.get_capabilities("fetch")
+            logger.info("fetch capabilities:", data=fetch_capabilities.model_dump())
+
+            filesystem_capabilities = await finder_agent.get_capabilities("filesystem")
+            logger.info(
+                "filesystem capabilities:", data=filesystem_capabilities.model_dump()
+            )
+
+            fetch_prompts = await finder_agent.list_prompts("fetch")
+            logger.info("fetch prompts:", data=fetch_prompts.model_dump())
+
+            filesystem_prompts = await finder_agent.list_prompts("filesystem")
+            logger.info("filesystem prompts:", data=filesystem_prompts.model_dump())
+
+            fetch_prompt = await finder_agent.get_prompt(
+                "fetch_fetch", {"url": "https://modelcontextprotocol.io"}
+            )
+            logger.info("fetch prompt:", data=fetch_prompt.model_dump())
+
+            llm = await finder_agent.attach_llm(OpenAIAugmentedLLM)
+            result = await llm.generate_str(
+                message="Print the contents of mcp_agent.config.yaml verbatim",
+            )
+            logger.info(f"mcp_agent.config.yaml contents: {result}")
+
+            human_input = await finder_agent.request_human_input(
+                request=HumanInputRequest(
+                    prompt="Please provide a URL to fetch",
+                    description="This is a test human input request",
+                    request_id="test_request_id",
+                    workflow_id="test_workflow_id",
+                    timeout_seconds=5,
+                    metadata={"key": "value"},
+                ),
+            )
+
+            logger.info(f"Human input: {human_input.response}")
+
+            tool_res = await finder_agent.call_tool(
+                "fetch_fetch", {"url": "https://modelcontextprotocol.io"}
+            )
+            logger.info(f"Tool result: {tool_res}")
+
+            # Let's switch the same agent to a different LLM
+            llm = await finder_agent.attach_llm(AnthropicAugmentedLLM)
+
+            result = await llm.generate_str(
+                message="Print the first 2 paragraphs of https://modelcontextprotocol.io/introduction",
+            )
+            logger.info(f"First 2 paragraphs of Model Context Protocol docs: {result}")
+
+
+if __name__ == "__main__":
+    start = time.time()
+    asyncio.run(agent_tracing())
+    end = time.time()
+    t = end - start
+
+    print(f"Total run time: {t:.2f}s")

--- a/examples/tracing/langfuse/mcp_agent.config.yaml
+++ b/examples/tracing/langfuse/mcp_agent.config.yaml
@@ -1,0 +1,33 @@
+$schema: ../../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  transports: [file]
+  level: debug
+  progress_display: true
+  path_settings:
+    path_pattern: "logs/mcp-agent-{unique_id}.jsonl"
+    unique_id: "timestamp" # Options: "timestamp" or "session_id"
+    timestamp_format: "%Y%m%d_%H%M%S"
+
+mcp:
+  servers:
+    fetch:
+      command: "uvx"
+      args: ["mcp-server-fetch"]
+    filesystem:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-filesystem"]
+
+openai:
+  # Secrets (API keys, etc.) are stored in an mcp_agent.secrets.yaml file which can be gitignored
+  #  default_model: "o3-mini"
+  default_model: "gpt-4o-mini"
+
+otel:
+  enabled: true
+  exporters: ["otlp"]
+  otlp_settings:
+    endpoint: "https://us.cloud.langfuse.com/api/public/otel/v1/traces"
+    # Set Authorization header with API key in mcp_agent.secrets.yaml
+  service_name: "BasicTracingLangfuseExample"

--- a/examples/tracing/langfuse/mcp_agent.secrets.yaml.example
+++ b/examples/tracing/langfuse/mcp_agent.secrets.yaml.example
@@ -1,0 +1,12 @@
+$schema: ../../../schema/mcp-agent.config.schema.json
+
+openai:
+  api_key: openai_api_key
+
+anthropic:
+  api_key: anthropic_api_key
+
+otel:
+  otlp_settings:
+    headers:
+      Authorization: "Basic <Langfuse AUTH_STRING>"

--- a/examples/tracing/langfuse/requirements.txt
+++ b/examples/tracing/langfuse/requirements.txt
@@ -1,0 +1,6 @@
+# Core framework dependency
+mcp-agent @ file://../../../  # Link to the local mcp-agent project root
+
+# Additional dependencies specific to this example
+anthropic
+openai

--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -962,14 +962,35 @@
       "description": "Settings for OTLP exporter in OpenTelemetry.",
       "properties": {
         "endpoint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "title": "Endpoint",
-          "type": "string",
           "description": "OTLP endpoint for exporting traces."
+        },
+        "headers": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Headers",
+          "description": "Optional headers for OTLP exporter."
         }
       },
-      "required": [
-        "endpoint"
-      ],
       "title": "TraceOTLPSettings",
       "type": "object"
     },

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -268,8 +268,11 @@ class TraceOTLPSettings(BaseModel):
     Settings for OTLP exporter in OpenTelemetry.
     """
 
-    endpoint: str
+    endpoint: str | None = None
     """OTLP endpoint for exporting traces."""
+
+    headers: Dict[str, str] | None = None
+    """Optional headers for OTLP exporter."""
 
 
 class OpenTelemetrySettings(BaseModel):

--- a/src/mcp_agent/tracing/tracer.py
+++ b/src/mcp_agent/tracing/tracer.py
@@ -105,7 +105,10 @@ class TracingConfig:
                 if settings.otlp_settings:
                     tracer_provider.add_span_processor(
                         BatchSpanProcessor(
-                            OTLPSpanExporter(endpoint=settings.otlp_settings.endpoint)
+                            OTLPSpanExporter(
+                                endpoint=settings.otlp_settings.endpoint,
+                                headers=settings.otlp_settings.headers,
+                            )
                         )
                     )
                 else:


### PR DESCRIPTION
# Description
As mentioned in #375 it would be nice to support integration with observability tools like Langfuse via tracing. Langfuse makes this super easy by supporting exporting OpenTelemetry traces to a Langfuse otlp endpoint and then handling any necessary massaging of traces to the Langfuse format (https://langfuse.com/integrations/native/opentelemetry). This exporter requires Basic Authorization headers to be used for the otlp export requests, so this PR adds support for headers in the `OTLPSettings` in `mcp-agent`.

## Testing
Created new example for Langfuse trace exporting and can see these traces in Langfuse:

<img width="2085" height="1287" alt="Screenshot 2025-08-13 at 2 05 21 PM" src="https://github.com/user-attachments/assets/054c355f-3499-48ef-ad26-c1a0cc51d98d" />

Note that trace doesn't have input/output; its root span is the agent initialize (KP with tracer being closed before the root span gets written)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Langfuse tracing example demonstrating agent tracing, LLM switching, and OTLP export with configurable headers (e.g., Authorization).
  - OTLP exporter accepts an optional endpoint and custom HTTP headers.

- **Documentation**
  - Added a README with step-by-step setup, secrets/Authorization guidance, and run instructions for the Langfuse example.

- **Chores**
  - Included ready-to-run configs, secrets template, and example-specific dependencies for local execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->