### PR TITLE
Allow a custom MCP server definition with MCPApp

### DIFF
--- a/examples/mcp_agent_server/asyncio/basic_agent_server.py
+++ b/examples/mcp_agent_server/asyncio/basic_agent_server.py
@@ -13,6 +13,8 @@ import os
 import logging
 from typing import Dict, Any
 
+from mcp.server.fastmcp import FastMCP
+
 from mcp_agent.app import MCPApp
 from mcp_agent.server.app_server import create_mcp_server_for_app
 from mcp_agent.agents.agent import Agent
@@ -28,8 +30,16 @@ from mcp_agent.tracing.token_counter import TokenNode
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Create a single FastMCPApp instance (which extends MCPApp)
-app = MCPApp(name="basic_agent_server", description="Basic agent server example")
+# Note: This is purely optional:
+# if not provided, a default FastMCP server will be created by MCPApp using create_mcp_server_for_app()
+mcp = FastMCP(name="basic_agent_server", description="My basic agent server example.")
+
+# Define the MCPApp instance
+app = MCPApp(
+    name="basic_agent_server",
+    description="Basic agent server example",
+    mcp=mcp,
+)
 
 
 @app.workflow
@@ -169,6 +179,123 @@ class ParallelWorkflow(Workflow[str]):
         return WorkflowResult(value=result)
 
 
+# Add custom tool to get token usage for a workflow
+@mcp.tool(
+    name="get_token_usage",
+    structured_output=True,
+    description="""
+Get detailed token usage information for a specific workflow run.
+
+This provides a comprehensive breakdown of token usage including:
+- Total tokens used across all LLM calls within the workflow
+- Breakdown by model provider and specific models
+- Hierarchical usage tree showing usage at each level (workflow -> agent -> llm)
+- Total cost estimate based on model pricing
+
+Args:
+    workflow_id: Optional workflow ID (if multiple workflows have the same name)
+    run_id: Optional ID of the workflow run to get token usage for
+    workflow_name: Optional name of the workflow (used as fallback)
+
+Returns:
+    Detailed token usage information for the specific workflow run
+""",
+)
+async def get_workflow_token_usage(
+    workflow_id: str | None = None,
+    run_id: str | None = None,
+    workflow_name: str | None = None,
+) -> Dict[str, Any]:
+    """Get token usage information for a specific workflow run."""
+    context = app.context
+
+    if not context.token_counter:
+        return {
+            "error": "Token counter not available",
+            "message": "Token tracking is not enabled for this application",
+        }
+
+    # Find the specific workflow node
+    workflow_node = await context.token_counter.get_workflow_node(
+        name=workflow_name, workflow_id=workflow_id, run_id=run_id
+    )
+
+    if not workflow_node:
+        return {
+            "error": "Workflow not found",
+            "message": f"Could not find workflow with run_id='{run_id}'",
+        }
+
+    # Get the aggregated usage for this workflow
+    workflow_usage = workflow_node.aggregate_usage()
+
+    # Calculate cost for this workflow
+    workflow_cost = context.token_counter._calculate_node_cost(workflow_node)
+
+    # Build the response
+    result = {
+        "workflow": {
+            "name": workflow_node.name,
+            "run_id": workflow_node.metadata.get("run_id"),
+            "workflow_id": workflow_node.metadata.get("workflow_id"),
+        },
+        "usage": {
+            "input_tokens": workflow_usage.input_tokens,
+            "output_tokens": workflow_usage.output_tokens,
+            "total_tokens": workflow_usage.total_tokens,
+        },
+        "cost": round(workflow_cost, 4),
+        "model_breakdown": {},
+        "usage_tree": workflow_node.to_dict(),
+    }
+
+    # Get model breakdown for this workflow
+    model_usage = {}
+
+    def collect_model_usage(node: TokenNode):
+        """Recursively collect model usage from a node tree"""
+        if node.usage.model_name:
+            model_name = node.usage.model_name
+            provider = node.usage.model_info.provider if node.usage.model_info else None
+
+            # Use tuple as key to handle same model from different providers
+            model_key = (model_name, provider)
+
+            if model_key not in model_usage:
+                model_usage[model_key] = {
+                    "model_name": model_name,
+                    "provider": provider,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0,
+                }
+
+            model_usage[model_key]["input_tokens"] += node.usage.input_tokens
+            model_usage[model_key]["output_tokens"] += node.usage.output_tokens
+            model_usage[model_key]["total_tokens"] += node.usage.total_tokens
+
+        for child in node.children:
+            collect_model_usage(child)
+
+    collect_model_usage(workflow_node)
+
+    # Calculate costs for each model and format for output
+    for (model_name, provider), usage in model_usage.items():
+        cost = context.token_counter.calculate_cost(
+            model_name, usage["input_tokens"], usage["output_tokens"], provider
+        )
+
+        # Create display key with provider info if available
+        display_key = f"{model_name} ({provider})" if provider else model_name
+
+        result["model_breakdown"][display_key] = {
+            **usage,
+            "cost": round(cost, 4),
+        }
+
+    return result
+
+
 async def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -201,124 +328,6 @@ async def main():
         )
         mcp_server = create_mcp_server_for_app(agent_app, **(fast_mcp_settings or {}))
         logger.info(f"MCP Server settings: {mcp_server.settings}")
-
-        # Add custom tool to get token usage for a workflow
-        @mcp_server.tool(
-            name="get_token_usage",
-            structured_output=True,
-            description="""
-            Get detailed token usage information for a specific workflow run.
-            
-            This provides a comprehensive breakdown of token usage including:
-            - Total tokens used across all LLM calls within the workflow
-            - Breakdown by model provider and specific models
-            - Hierarchical usage tree showing usage at each level (workflow -> agent -> llm)
-            - Total cost estimate based on model pricing
-            
-            Args:
-                workflow_id: Optional workflow ID (if multiple workflows have the same name)
-                run_id: Optional ID of the workflow run to get token usage for
-                workflow_name: Optional name of the workflow (used as fallback)
-            
-            Returns:
-                Detailed token usage information for the specific workflow run
-            """,
-        )
-        async def get_workflow_token_usage(
-            workflow_id: str | None = None,
-            run_id: str | None = None,
-            workflow_name: str | None = None,
-        ) -> Dict[str, Any]:
-            """Get token usage information for a specific workflow run."""
-            if not context.token_counter:
-                return {
-                    "error": "Token counter not available",
-                    "message": "Token tracking is not enabled for this application",
-                }
-
-            # Find the specific workflow node
-            workflow_node = await context.token_counter.get_workflow_node(
-                name=workflow_name, workflow_id=workflow_id, run_id=run_id
-            )
-
-            if not workflow_node:
-                return {
-                    "error": "Workflow not found",
-                    "message": f"Could not find workflow with run_id='{run_id}'",
-                }
-
-            # Get the aggregated usage for this workflow
-            workflow_usage = workflow_node.aggregate_usage()
-
-            # Calculate cost for this workflow
-            workflow_cost = context.token_counter._calculate_node_cost(workflow_node)
-
-            # Build the response
-            result = {
-                "workflow": {
-                    "name": workflow_node.name,
-                    "run_id": workflow_node.metadata.get("run_id"),
-                    "workflow_id": workflow_node.metadata.get("workflow_id"),
-                },
-                "usage": {
-                    "input_tokens": workflow_usage.input_tokens,
-                    "output_tokens": workflow_usage.output_tokens,
-                    "total_tokens": workflow_usage.total_tokens,
-                },
-                "cost": round(workflow_cost, 4),
-                "model_breakdown": {},
-                "usage_tree": workflow_node.to_dict(),
-            }
-
-            # Get model breakdown for this workflow
-            model_usage = {}
-
-            def collect_model_usage(node: TokenNode):
-                """Recursively collect model usage from a node tree"""
-                if node.usage.model_name:
-                    model_name = node.usage.model_name
-                    provider = (
-                        node.usage.model_info.provider
-                        if node.usage.model_info
-                        else None
-                    )
-
-                    # Use tuple as key to handle same model from different providers
-                    model_key = (model_name, provider)
-
-                    if model_key not in model_usage:
-                        model_usage[model_key] = {
-                            "model_name": model_name,
-                            "provider": provider,
-                            "input_tokens": 0,
-                            "output_tokens": 0,
-                            "total_tokens": 0,
-                        }
-
-                    model_usage[model_key]["input_tokens"] += node.usage.input_tokens
-                    model_usage[model_key]["output_tokens"] += node.usage.output_tokens
-                    model_usage[model_key]["total_tokens"] += node.usage.total_tokens
-
-                for child in node.children:
-                    collect_model_usage(child)
-
-            collect_model_usage(workflow_node)
-
-            # Calculate costs for each model and format for output
-            for (model_name, provider), usage in model_usage.items():
-                cost = context.token_counter.calculate_cost(
-                    model_name, usage["input_tokens"], usage["output_tokens"], provider
-                )
-
-                # Create display key with provider info if available
-                display_key = f"{model_name} ({provider})" if provider else model_name
-
-                result["model_breakdown"][display_key] = {
-                    **usage,
-                    "cost": round(cost, 4),
-                }
-
-            return result
 
         # Run the server
         await mcp_server.run_stdio_async()

--- a/src/mcp_agent/app.py
+++ b/src/mcp_agent/app.py
@@ -7,6 +7,7 @@ import sys
 from contextlib import asynccontextmanager
 
 from mcp import ServerSession
+from mcp.server.fastmcp import FastMCP
 from mcp_agent.core.context import Context, initialize_context, cleanup_context
 from mcp_agent.config import Settings, get_settings
 from mcp_agent.executor.signal_registry import SignalRegistry
@@ -57,12 +58,13 @@ class MCPApp:
         self,
         name: str = "mcp_application",
         description: str | None = None,
-        settings: Optional[Settings] | str = None,
-        human_input_callback: Optional[HumanInputCallback] = None,
-        elicitation_callback: Optional[ElicitationCallback] = None,
-        signal_notification: Optional[SignalWaitCallback] = None,
+        settings: Settings | str | None = None,
+        mcp: FastMCP | None = None,
+        human_input_callback: HumanInputCallback | None = None,
+        elicitation_callback: ElicitationCallback | None = None,
+        signal_notification: SignalWaitCallback | None = None,
         upstream_session: Optional["ServerSession"] = None,
-        model_selector: ModelSelector = None,
+        model_selector: ModelSelector | None = None,
     ):
         """
         Initialize the application with a name and optional settings.
@@ -72,6 +74,9 @@ class MCPApp:
                 provide a detailed description, since it will be used as the server's description.
             settings: Application configuration - If unspecified, the settings are loaded from mcp_agent.config.yaml.
                 If this is a string, it is treated as the path to the config file to load.
+            mcp: MCP server instance to use for the application to expose agents and workflows as tools.
+                If not provided, a default FastMCP server will be created by create_mcp_server_for_app().
+                If provided, the MCPApp will add tools to the provided server instance.
             human_input_callback: Callback for handling human input
             signal_notification: Callback for getting notified on workflow signals/events.
             upstream_session: Upstream session if the MCPApp is running as a server to an MCP client.
@@ -79,6 +84,7 @@ class MCPApp:
         """
         self.name = name
         self.description = description or "MCP Agent Application"
+        self.mcp = mcp
 
         # We use these to initialize the context in initialize()
         if settings is None:

--- a/src/mcp_agent/core/context.py
+++ b/src/mcp_agent/core/context.py
@@ -10,6 +10,7 @@ import warnings
 from pydantic import BaseModel, ConfigDict
 
 from mcp import ServerSession
+from mcp.server.fastmcp import FastMCP
 
 from opentelemetry import trace
 
@@ -87,6 +88,10 @@ class Context(BaseModel):
         extra="allow",
         arbitrary_types_allowed=True,  # Tell Pydantic to defer type evaluation
     )
+
+    @property
+    def mcp(self) -> FastMCP | None:
+        return self.app.mcp if self.app else None
 
 
 async def configure_otel(

--- a/tests/server/test_app_server.py
+++ b/tests/server/test_app_server.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
+from types import SimpleNamespace
 from mcp_agent.server.app_server import _workflow_run
 from mcp_agent.executor.workflow import WorkflowExecution
 
@@ -7,12 +8,15 @@ from mcp_agent.executor.workflow import WorkflowExecution
 @pytest.fixture
 def mock_server_context():
     """Mock server context for testing"""
-    context = MagicMock()
-    context.request_context = MagicMock()
-    context.request_context.lifespan_context = MagicMock()
-    context.request_context.lifespan_context.workflows = {}
-    context.request_context.lifespan_context.context = MagicMock()
-    return context
+    # Build a minimal ctx object compatible with new resolution helpers
+    app_context = MagicMock()
+    server_context = SimpleNamespace(workflows={}, context=app_context)
+
+    ctx = MagicMock()
+    ctx.request_context = SimpleNamespace(lifespan_context=server_context)
+    # Ensure no attached app path is used in tests; rely on lifespan path
+    ctx.fastmcp = SimpleNamespace(_mcp_agent_app=None)
+    return ctx
 
 
 @pytest.fixture


### PR DESCRIPTION
The overall idea is to let a developer define their own `FastMCP` server definition, in order to define custom tools they may want on their agent server.

`MCPApp` now optionally takes the `FastMCP` object as part of its constructor arguments.

`create_mcp_server_for_app` now handles both cases:

* If app.mcp is provided, we attach the app to the server (mcp.mcp_app = app) and register per-workflow tools immediately so they show up in list_tools without relying on our lifespan.
* If we instantiate FastMCP, we continue to use our lifespan; per-workflow tools are registered there as before.

Tool handlers now prefer the attached app for workflow discovery and registry access when there’s no `ServerContext`:
* workflows-list reads from ctx.fastmcp.mcp_app.workflows when no `ServerContext`.
* workflows-run/get_status fallback to the attached app’s context/workflow_registry if lifespan_context isn’t our `ServerContext`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a token-usage tool to report workflow/run input/output/total tokens, estimated cost, per-model breakdown, and a usage tree.
  - App can now attach to an existing MCP server, enabling bring-your-own-server setups.
- Refactor
  - Server logic updated to support both managed and externally managed startup modes seamlessly.
- Documentation
  - Constructor docs updated to describe the new server integration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->