### PR TITLE
[Fix] Default rpc_metadata to empty dict

### DIFF
--- a/src/mcp_agent/executor/temporal/__init__.py
+++ b/src/mcp_agent/executor/temporal/__init__.py
@@ -266,7 +266,7 @@ class TemporalExecutor(Executor):
                 interceptors=[TracingInterceptor()]
                 if self.context.tracing_enabled
                 else [],
-                rpc_metadata=self.config.rpc_metadata,
+                rpc_metadata=self.config.rpc_metadata or {},
             )
 
         return self.client
@@ -353,7 +353,7 @@ class TemporalExecutor(Executor):
                 id=workflow_id,
                 task_queue=task_queue,
                 id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-                rpc_metadata=self.config.rpc_metadata,
+                rpc_metadata=self.config.rpc_metadata or {},
             )
         else:
             handle: WorkflowHandle = await self.client.start_workflow(
@@ -361,7 +361,7 @@ class TemporalExecutor(Executor):
                 id=workflow_id,
                 task_queue=task_queue,
                 id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-                rpc_metadata=self.config.rpc_metadata,
+                rpc_metadata=self.config.rpc_metadata or {},
             )
 
         # Wait for the result if requested


### PR DESCRIPTION
## Description
In project consuming mcp-agent, seeing the following error when creating a temporal server without rpc_metadata specified (and the error is fixed by specifying empty dict)

```bash
async with create_temporal_worker_for_app(app) as worker:
      File "/usr/local/lib/python3.10/contextlib.py", line 199, in __aenter__
        return await anext(self.gen)
      File "/app/.venv/lib/python3.10/site-packages/mcp_agent/executor/temporal/__init__.py", line 469, in create_temporal_worker_for_app
        await running_app.executor.ensure_client()
      File "/app/.venv/lib/python3.10/site-packages/mcp_agent/executor/temporal/__init__.py", line 260, in ensure_client
        self.client = await TemporalClient.connect(
      File "/app/.venv/lib/python3.10/site-packages/temporalio/client.py", line 196, in connect
        service_client = await root_plugin.connect_service_client(connect_config)
      File "/app/.venv/lib/python3.10/site-packages/temporalio/client.py", line 7457, in connect_service_client
        return await temporalio.service.ServiceClient.connect(config)
      File "/app/.venv/lib/python3.10/site-packages/temporalio/service.py", line 209, in connect
        return await _BridgeServiceClient.connect(config)
      File "/app/.venv/lib/python3.10/site-packages/temporalio/service.py", line 1246, in connect
        await client._connected_client()
      File "/app/.venv/lib/python3.10/site-packages/temporalio/service.py", line 1259, in _connected_client
        self._bridge_client = await temporalio.bridge.client.Client.connect(
      File "/app/.venv/lib/python3.10/site-packages/temporalio/bridge/client.py", line 97, in connect
        await temporalio.bridge.temporal_sdk_bridge.connect_client(
    TypeError: argument 'config': failed to extract field ClientConfig.metadata
```

Fix by passing empty dict instead of None

## Testing
Ran the temporal examples without issue (though I was also able to do so without the fix). I think maybe a temporal version difference changes handling of the default metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting to Temporal and starting workflows by defaulting RPC metadata when none is provided. This prevents failures in environments without configured metadata, reducing intermittent errors and ensuring smoother workflow launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->