### PR TITLE
[Fix] Prevent Duplicate Tool Registration Attempts for MCP Server

### DIFF
--- a/tests/server/test_app_server.py
+++ b/tests/server/test_app_server.py
@@ -1,7 +1,11 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from types import SimpleNamespace
-from mcp_agent.server.app_server import _workflow_run
+from mcp_agent.server.app_server import (
+    _workflow_run,
+    ServerContext,
+    create_workflow_tools,
+)
 from mcp_agent.executor.workflow import WorkflowExecution
 
 
@@ -252,3 +256,177 @@ async def test_workflow_run_preserves_user_params_with_similar_names(
 
     # The "__mcp_agent_workflow_id" from user params should not override system param
     assert call_kwargs["__mcp_agent_workflow_id"] != "should-not-happen"
+
+
+def test_workflow_tools_idempotent_registration():
+    """Test that workflow tools are only registered once per workflow"""
+    # Create mock FastMCP and context
+    mock_mcp = MagicMock()
+    mock_app = MagicMock()
+    mock_context = MagicMock(app=mock_app)
+
+    # Ensure the mcp mock doesn't have _registered_workflow_tools initially
+    # so ServerContext.__init__ will create it
+    if hasattr(mock_mcp, "_registered_workflow_tools"):
+        delattr(mock_mcp, "_registered_workflow_tools")
+
+    mock_app.workflows = {}
+    # Need to mock the config and workflow_registry for ServerContext init
+    mock_context.workflow_registry = None
+    mock_context.config = MagicMock()
+    mock_context.config.execution_engine = "asyncio"
+
+    server_context = ServerContext(mcp=mock_mcp, context=mock_context)
+
+    # Mock workflows
+    mock_workflow_class = MagicMock()
+    mock_workflow_class.__doc__ = "Test workflow"
+    mock_run = MagicMock()
+    mock_run.__name__ = "run"
+    mock_workflow_class.run = mock_run
+
+    mock_app.workflows = {
+        "workflow1": mock_workflow_class,
+        "workflow2": mock_workflow_class,
+    }
+
+    tools_created = []
+
+    def track_tool_calls(*args, **kwargs):
+        def decorator(func):
+            tools_created.append(kwargs.get("name", args[0] if args else "unknown"))
+            return func
+
+        return decorator
+
+    mock_mcp.tool = track_tool_calls
+
+    # First call to create_workflow_tools
+    create_workflow_tools(mock_mcp, server_context)
+
+    # Verify tools were created for both workflows
+    expected_tools = [
+        "workflows-workflow1-run",
+        "workflows-workflow1-get_status",
+        "workflows-workflow2-run",
+        "workflows-workflow2-get_status",
+    ]
+
+    assert len(tools_created) == 4
+    for expected_tool in expected_tools:
+        assert expected_tool in tools_created
+
+    # Verify the registered workflow tools are tracked on the MCP instance
+    assert hasattr(mock_mcp, "_registered_workflow_tools")
+    assert mock_mcp._registered_workflow_tools == {"workflow1", "workflow2"}
+
+    # Reset tools and call create_workflow_tools again
+    tools_created.clear()
+    create_workflow_tools(mock_mcp, server_context)
+
+    # Verify no additional tools were created (idempotent)
+    assert len(tools_created) == 0
+    assert mock_mcp._registered_workflow_tools == {"workflow1", "workflow2"}
+
+    # Test register_workflow with a new workflow
+    new_workflow_class = MagicMock()
+    new_workflow_class.__doc__ = "New workflow"
+    new_mock_run = MagicMock()
+    new_mock_run.__name__ = "run"
+    new_workflow_class.run = new_mock_run
+
+    server_context.register_workflow("workflow3", new_workflow_class)
+
+    # Verify the new workflow was added and its tools created
+    assert "workflow3" in server_context.workflows
+    assert "workflow3" in mock_mcp._registered_workflow_tools
+    assert len(tools_created) == 2  # run and get_status for workflow3
+    assert "workflows-workflow3-run" in tools_created
+    assert "workflows-workflow3-get_status" in tools_created
+
+    # Test registering the same workflow again (should be idempotent)
+    tools_created.clear()
+    server_context.register_workflow("workflow3", new_workflow_class)
+
+    # Should not create duplicate tools or add to workflows again
+    assert len(tools_created) == 0
+    assert mock_mcp._registered_workflow_tools == {
+        "workflow1",
+        "workflow2",
+        "workflow3",
+    }
+
+
+def test_workflow_tools_persistent_across_sse_requests():
+    """Test that workflow tools registration persists across SSE request context recreation"""
+    # Create mock FastMCP instance (this persists across requests)
+    mock_mcp = MagicMock()
+
+    # Ensure the mcp mock doesn't have _registered_workflow_tools initially
+    if hasattr(mock_mcp, "_registered_workflow_tools"):
+        delattr(mock_mcp, "_registered_workflow_tools")
+
+    # Mock workflows
+    mock_workflow_class = MagicMock()
+    mock_workflow_class.__doc__ = "Test workflow"
+    mock_run = MagicMock()
+    mock_run.__name__ = "run"
+    mock_workflow_class.run = mock_run
+
+    tools_created = []
+
+    def track_tool_calls(*args, **kwargs):
+        def decorator(func):
+            tools_created.append(kwargs.get("name", args[0] if args else "unknown"))
+            return func
+
+        return decorator
+
+    mock_mcp.tool = track_tool_calls
+
+    # Simulate first SSE request - create new ServerContext
+    mock_app1 = MagicMock()
+    mock_context1 = MagicMock(app=mock_app1)
+    mock_context1.workflow_registry = None
+    mock_context1.config = MagicMock()
+    mock_context1.config.execution_engine = "asyncio"
+    mock_app1.workflows = {"workflow1": mock_workflow_class}
+    server_context1 = ServerContext(mcp=mock_mcp, context=mock_context1)
+
+    # Register tools in first request
+    create_workflow_tools(mock_mcp, server_context1)
+
+    # Verify tools were created
+    assert len(tools_created) == 2  # run and get_status
+    assert "workflows-workflow1-run" in tools_created
+    assert "workflows-workflow1-get_status" in tools_created
+    assert hasattr(mock_mcp, "_registered_workflow_tools")
+    assert "workflow1" in mock_mcp._registered_workflow_tools
+
+    # Reset tools tracker
+    tools_created.clear()
+
+    # Simulate second SSE request - create NEW ServerContext (simulates fastmcp behavior)
+    mock_app2 = MagicMock()
+    mock_context2 = MagicMock(app=mock_app2)
+    mock_context2.workflow_registry = None
+    mock_context2.config = MagicMock()
+    mock_context2.config.execution_engine = "asyncio"
+    mock_app2.workflows = {"workflow1": mock_workflow_class}  # Same workflow
+    server_context2 = ServerContext(mcp=mock_mcp, context=mock_context2)  # NEW context!
+
+    # The MCP instance should still have the registration from the first context
+    assert hasattr(mock_mcp, "_registered_workflow_tools")
+    assert isinstance(
+        mock_mcp._registered_workflow_tools, set
+    )  # Should be a real set now
+
+    # But the FastMCP instance should still have the persistent registration
+    assert mock_mcp._registered_workflow_tools == {"workflow1"}
+
+    # Call create_workflow_tools again - should be idempotent due to persistent storage
+    create_workflow_tools(mock_mcp, server_context2)
+
+    # Verify NO additional tools were created (idempotent)
+    assert len(tools_created) == 0
+    assert mock_mcp._registered_workflow_tools == {"workflow1"}


### PR DESCRIPTION
## Description
Currently, workflow tools are attempted to be re-registered during each sse request to an app-associated mcp server:
```bash
INFO:mcp_agent:[mcp_agent.server.app_server] Workflow BasicAgentWorkflow started with workflow ID BasicAgentWorkflow-05052bde-b3a5-4e4c-8995-90e4d03d9912 and run ID 0198e1c1-edc0-7a64-9572-1ec2d3a43d3c. Parameters: {'input': 'Print the first 2 paragraphs of https://modelcontextprotocol.io/introduction'}
INFO:     127.0.0.1:59463 - "POST /messages/?session_id=9e7c609706a24436884f58ee5ad43c8a HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type ListToolsRequest
INFO:     127.0.0.1:59463 - "POST /messages/?session_id=9e7c609706a24436884f58ee5ad43c8a HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type CallToolRequest
INFO:     127.0.0.1:59484 - "POST /messages/?session_id=9e7c609706a24436884f58ee5ad43c8a HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type CallToolRequest
WARNING:mcp.server.fastmcp.tools.tool_manager:Tool already exists: workflows-BasicAgentWorkflow-run
WARNING:mcp.server.fastmcp.tools.tool_manager:Tool already exists: workflows-BasicAgentWorkflow-get_status
WARNING:mcp.server.fastmcp.tools.tool_manager:Tool already exists: workflows-PauseResumeWorkflow-run
WARNING:mcp.server.fastmcp.tools.tool_manager:Tool already exists: workflows-PauseResumeWorkflow-get_status
INFO:     127.0.0.1:59503 - "GET /sse HTTP/1.1" 200 OK
```
The reasoning is because fastmcp has a `handle_sse` callback for sse requests which calls `server.run()` (see [here](https://github.com/modelcontextprotocol/python-sdk/blob/eaf7cf41d5c1d3bcfd4416494ab5dc62b9c17a4a/src/mcp/server/fastmcp/server.py#L738-L751)) and enters lifespan context per each request. And entering that context calls `create_workflow_tools` again before yielding server_context, i.e. per-request/per-session app initialization/tools registration.

Our app initialization is already idempotent, so this PR updates the workflow tools registration to be similarly idempotent per mcp instance.

## Testing
```bash
make tests
```

Run the `mcp-agent/examples/mcp_agent_server/temporal` example and spawn two clients. Without this fix, see the above warnings about tools already existing. With this fix, no warnings and the client results are still correct.

```bash
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:mcp_agent:[mcp_agent.core.context] Configuring logger with level: debug
INFO:mcp_agent:[mcp_agent.basic_agent_server] Loading subagents from configuration...
INFO:mcp_agent:[mcp_agent.basic_agent_server] MCPApp initialized
INFO:     127.0.0.1:50176 - "GET /sse HTTP/1.1" 200 OK
INFO:     127.0.0.1:50177 - "POST /messages/?session_id=68c78373fdb94fa79af24cfcbb69d034 HTTP/1.1" 202 Accepted
INFO:     127.0.0.1:50177 - "POST /messages/?session_id=68c78373fdb94fa79af24cfcbb69d034 HTTP/1.1" 202 Accepted
INFO:     127.0.0.1:50177 - "POST /messages/?session_id=68c78373fdb94fa79af24cfcbb69d034 HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type CallToolRequest
[DEBUG] 2025-08-25T13:15:41 
workflow.BasicAgentWorkflow - Initializing 
workflow BasicAgentWorkflow
[DEBUG] 2025-08-25T13:15:41 
mcp_agent.executor.temporal.workflow_signal - 
Attaching signal handler to workflow 
BasicAgentWorkflow
[DEBUG] 2025-08-25T13:15:41 
workflow.BasicAgentWorkflow - Workflow started 
with workflow ID: 
BasicAgentWorkflow-cdbcb8b0-b715-418e-9112-613ff
6cd97e8, run ID: 
0198e23a-81d3-7242-af0f-22258d3f2a3d
[INFO] 2025-08-25T13:15:41 
mcp_agent.server.app_server - Workflow 
BasicAgentWorkflow started with workflow ID 
BasicAgentWorkflow-cdbcb8b0-b715-418e-9112-613ff
6cd97e8 and run ID 
0198e23a-81d3-7242-af0f-22258d3f2a3d. 
Parameters: {'input': 'Print the first 2 
paragraphs of 
https://modelcontextprotocol.io/introduction'}
INFO:mcp_agent:[mcp_agent.server.app_server] Workflow BasicAgentWorkflow started with workflow ID BasicAgentWorkflow-cdbcb8b0-b715-418e-9112-613ff6cd97e8 and run ID 0198e23a-81d3-7242-af0f-22258d3f2a3d. Parameters: {'input': 'Print the first 2 paragraphs of https://modelcontextprotocol.io/introduction'}
INFO:     127.0.0.1:50177 - "POST /messages/?session_id=68c78373fdb94fa79af24cfcbb69d034 HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type ListToolsRequest
INFO:     127.0.0.1:50177 - "POST /messages/?session_id=68c78373fdb94fa79af24cfcbb69d034 HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type CallToolRequest
INFO:     127.0.0.1:50192 - "POST /messages/?session_id=68c78373fdb94fa79af24cfcbb69d034 HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type CallToolRequest
INFO:     127.0.0.1:50196 - "GET /sse HTTP/1.1" 200 OK
INFO:     127.0.0.1:50197 - "POST /messages/?session_id=f3b522b7d4234a5b803d59a2ee09715e HTTP/1.1" 202 Accepted
INFO:     127.0.0.1:50197 - "POST /messages/?session_id=f3b522b7d4234a5b803d59a2ee09715e HTTP/1.1" 202 Accepted
INFO:     127.0.0.1:50197 - "POST /messages/?session_id=f3b522b7d4234a5b803d59a2ee09715e HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type CallToolRequest
[DEBUG] 2025-08-25T13:15:51 
workflow.BasicAgentWorkflow - Initializing 
workflow BasicAgentWorkflow
[DEBUG] 2025-08-25T13:15:51 
mcp_agent.executor.temporal.workflow_signal - 
Attaching signal handler to workflow 
BasicAgentWorkflow
[DEBUG] 2025-08-25T13:15:51 
workflow.BasicAgentWorkflow - Workflow started 
with workflow ID: 
BasicAgentWorkflow-952def02-133f-4e5c-8d00-b6f44
7bfdd8d, run ID: 
0198e23a-a740-73ef-ac83-582ae66d1543
[INFO] 2025-08-25T13:15:51 
mcp_agent.server.app_server - Workflow 
BasicAgentWorkflow started with workflow ID 
BasicAgentWorkflow-952def02-133f-4e5c-8d00-b6f44
7bfdd8d and run ID 
0198e23a-a740-73ef-ac83-582ae66d1543. 
Parameters: {'input': 'Print the first 2 
paragraphs of 
https://modelcontextprotocol.io/introduction'}
INFO:mcp_agent:[mcp_agent.server.app_server] Workflow BasicAgentWorkflow started with workflow ID BasicAgentWorkflow-952def02-133f-4e5c-8d00-b6f447bfdd8d and run ID 0198e23a-a740-73ef-ac83-582ae66d1543. Parameters: {'input': 'Print the first 2 paragraphs of https://modelcontextprotocol.io/introduction'}
INFO:     127.0.0.1:50197 - "POST /messages/?session_id=f3b522b7d4234a5b803d59a2ee09715e HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type ListToolsRequest
INFO:     127.0.0.1:50197 - "POST /messages/?session_id=f3b522b7d4234a5b803d59a2ee09715e HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type CallToolRequest
INFO:     127.0.0.1:50201 - "POST /messages/?session_id=68c78373fdb94fa79af24cfcbb69d034 HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type CallToolRequest
[DEBUG] 2025-08-25T13:15:52 
workflow.BasicAgentWorkflow - Cleaning up 
workflow BasicAgentWorkflow
INFO:     127.0.0.1:50207 - "POST /messages/?session_id=f3b522b7d4234a5b803d59a2ee09715e HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type CallToolRequest
INFO:     127.0.0.1:50208 - "POST /messages/?session_id=68c78373fdb94fa79af24cfcbb69d034 HTTP/1.1" 202 Accepted
INFO:mcp.server.lowlevel.server:Processing request of type CallToolRequest
[DEBUG] 2025-08-25T13:15:59 
workflow.BasicAgentWorkflow - Cleaning up 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate workflow tools after reconnections, making registration idempotent and tool lists consistent.
* **Performance**
  * Reduces overhead during repeated initializations, improving responsiveness on reconnect.
* **Reliability**
  * Ensures workflow tool registrations persist across reconnections for stable behavior.
* **Public API**
  * Exposes additional server components for advanced integrations.
* **Tests**
  * Adds comprehensive coverage for workflow tool lifecycle, idempotent registration, and reconnection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->