### PR TITLE
Feature: Allow Additional Temporal Settings

### DIFF
--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -393,6 +393,12 @@ class TemporalSettings(BaseModel):
     max_concurrent_activities: int | None = None
     timeout_seconds: int | None = 60
     rpc_metadata: Dict[str, str] | None = None
+    id_reuse_policy: Literal[
+        "allow_duplicate",
+        "allow_duplicate_failed_only",
+        "reject_duplicate",
+        "terminate_if_running",
+    ] = "allow_duplicate"
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 

--- a/src/mcp_agent/executor/temporal/__init__.py
+++ b/src/mcp_agent/executor/temporal/__init__.py
@@ -160,8 +160,8 @@ class TemporalExecutor(Executor):
         activity_registry = self.context.task_registry
         activity_task = activity_registry.get_activity(activity_name)
 
-        schedule_to_close = execution_metadata.get(
-            "schedule_to_close_timeout", self.config.timeout_seconds
+        schedule_to_close = self.config.timeout_seconds or execution_metadata.get(
+            "schedule_to_close_timeout"
         )
 
         if schedule_to_close is not None and not isinstance(

--- a/src/mcp_agent/executor/temporal/__init__.py
+++ b/src/mcp_agent/executor/temporal/__init__.py
@@ -345,6 +345,14 @@ class TemporalExecutor(Executor):
         if task_queue is None:
             task_queue = self.config.task_queue
 
+        # Get the id reuse policy from the config, mapped to temporal enum
+        id_reuse_policy = {
+            "allow_duplicate": WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+            "allow_duplicate_failed_only": WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            "reject_duplicate": WorkflowIDReusePolicy.REJECT_DUPLICATE,
+            "terminate_if_running": WorkflowIDReusePolicy.TERMINATE_IF_RUNNING,
+        }.get(self.config.id_reuse_policy, WorkflowIDReusePolicy.ALLOW_DUPLICATE)
+
         # Start the workflow
         if input_arg is not None:
             handle: WorkflowHandle = await self.client.start_workflow(
@@ -352,7 +360,7 @@ class TemporalExecutor(Executor):
                 input_arg,
                 id=workflow_id,
                 task_queue=task_queue,
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+                id_reuse_policy=id_reuse_policy,
                 rpc_metadata=self.config.rpc_metadata or {},
             )
         else:
@@ -360,7 +368,7 @@ class TemporalExecutor(Executor):
                 wf,
                 id=workflow_id,
                 task_queue=task_queue,
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+                id_reuse_policy=id_reuse_policy,
                 rpc_metadata=self.config.rpc_metadata or {},
             )
 


### PR DESCRIPTION
## Description
Alongside fixing #379 to have the `timeout_seconds` in temporal settings take precedence for `schedule_to_close`, also add the ability to specify `id_reuse_policy` in the temporal settings. This can be used to enforce a single workflow ID per closed run.

## Testing
```bash
make tests
```

Ran temporal examples with basic workflow to test the following:

1. With timeout_seconds not set in the config, the basic workflow example succeeds without issue
2. With timeout_seconds set to 3 in the config, the basic workflow example times out:
```bash
uv run basic.py
[INFO] 2025-08-27T11:20:09 mcp_agent.core.context - Configuring logger with 
level: debug
[INFO] 2025-08-27T11:20:09 mcp_agent.temporal_workflow_example - Loading 
subagents from configuration...
[DEBUG] 2025-08-27T11:20:09 mcp_agent.temporal_workflow_example - Registering 
global workflow tasks with application instance.
[DEBUG] 2025-08-27T11:20:09 mcp_agent.temporal_workflow_example - Registering 
global workflow task: 
mcp_agent.workflows.llm.augmented_llm_openai.OpenAICompletionTasks.request_comple
tion_task
[DEBUG] 2025-08-27T11:20:09 mcp_agent.temporal_workflow_example - Registering 
global workflow task: 
mcp_agent.workflows.llm.augmented_llm_openai.OpenAICompletionTasks.request_struct
ured_completion_task
[INFO] 2025-08-27T11:20:09 mcp_agent.temporal_workflow_example - MCPApp 
initialized
{
  "data": {
    "progress_action": "Running",
    "target": "temporal_workflow_example",
    "agent_name": "mcp_application_loop",
    "session_id": "0398a9b1-452e-4f4f-9bb4-e239a8eca1d4"
  }
}
INFO:mcp_agent:[mcp_agent.core.context] Configuring logger with level: debug
INFO:mcp_agent:[mcp_agent.temporal_workflow_example] Loading subagents from configuration...
INFO:mcp_agent:[mcp_agent.temporal_workflow_example] MCPApp initialized
temporalio.exceptions.TimeoutError: activity ScheduleToClose timeout
```

3. Without `id_reuse_policy` set in the config, I can re-run a workflow with the same hardcoded id
<img width="1321" height="195" alt="Screenshot 2025-08-27 at 11 46 51 AM" src="https://github.com/user-attachments/assets/8ede6351-334a-4b90-ab5d-ba31eebb7e67" />

4. With `id_reuse_policy` set to `allow_duplicate_failed_only` the subsequent use of a workflow id fails:
```bash
INFO:mcp_agent:[mcp_agent.core.context] Configuring logger with level: debug
INFO:mcp_agent:[mcp_agent.temporal_workflow_example] Loading subagents from configuration...
INFO:mcp_agent:[mcp_agent.temporal_workflow_example] MCPApp initialized
Traceback (most recent call last):
  File "/Users/ryanholinshead/Projects/mcp-agent/.venv/lib/python3.10/site-packages/temporalio/service.py", line 1243, in _rpc_call
    resp = await client.call(
  File "/Users/ryanholinshead/Projects/mcp-agent/.venv/lib/python3.10/site-packages/temporalio/bridge/client.py", line 151, in call
    resp.ParseFromString(await resp_fut)
temporal_sdk_bridge.RPCError: (6, 'Workflow execution already finished successfully. WorkflowId: WorkflowIDReuseTestShouldFailSecondUse, RunId: 0198ec2e-92e3-7d7d-bc7f-3c25798e47d4. Workflow Id reuse policy: allow duplicate workflow Id if last run failed.', b'\x08\x06\x12\xdc\x01Workflow execution already finished successfully. WorkflowId: WorkflowIDReuseTestShouldFailSecondUse, RunId: 0198ec2e-92e3-7d7d-bc7f-3c25798e47d4. Workflow Id reuse policy: allow duplicate workflow Id if last run failed.\x1a\xa7\x01\nWtype.googleapis.com/temporal.api.errordetails.v1.WorkflowExecutionAlreadyStartedFailure\x12L\n$32910777-04b8-451a-b95d-71257d6e7bfd\x12$0198ec2e-92e3-7d7d-bc7f-3c25798e47d4')
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configurable workflow ID reuse policy with options: allow_duplicate (default), allow_duplicate_failed_only, reject_duplicate, and terminate_if_running.
  - Updated timeout behavior: a global timeout setting now takes precedence over per-task metadata, with metadata used as a fallback when no global timeout is set.

- Tests
  - Added coverage to validate ID reuse policy mapping and timeout precedence, ensuring consistent behavior across workflow starts and task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->