### PR TITLE
Add user parameter support to AzureAugmentedLLM

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_azure.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_azure.py
@@ -194,6 +194,11 @@ class AzureAugmentedLLM(AugmentedLLM[MessageParam, ResponseMessage]):
                     "stop": params.stopSequences,
                     "tools": tools,
                 }
+                
+                # Add user parameter if present in params or config
+                user = params.user or getattr(self.context.config.azure, "user", None)
+                if user:
+                    arguments["user"] = user
 
                 if params.metadata:
                     arguments = {**arguments, **params.metadata}


### PR DESCRIPTION
Defined the user property in the RequestParams object which is passed as a request_params field on generate, generate_str, and generate_structured in order to facilitate communication to Azure OpenAI endpoints.