### PR TITLE
Use more flexible structured output mode for openai

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -917,7 +917,7 @@ class OpenAICompletionTasks:
         ) as async_client:
             client = instructor.from_openai(
                 async_client,
-                mode=instructor.Mode.TOOLS_STRICT,
+                mode=instructor.Mode.TOOLS,
             )
 
             try:

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -77,6 +77,7 @@ class RequestStructuredCompletionRequest(BaseModel):
     response_str: str
     model: str
     user: str | None = None
+    strict: bool = False
 
 
 class OpenAIAugmentedLLM(
@@ -478,6 +479,7 @@ class OpenAIAugmentedLLM(
                     model=model,
                     user=params.user
                     or getattr(self.context.config.openai, "user", None),
+                    strict=getattr(params, "strict", False),
                 ),
             )
             # TODO: saqadri (MAC) - fix request_structured_completion_task to return ensure_serializable
@@ -917,7 +919,9 @@ class OpenAICompletionTasks:
         ) as async_client:
             client = instructor.from_openai(
                 async_client,
-                mode=instructor.Mode.TOOLS,
+                mode=instructor.Mode.TOOLS_STRICT
+                if request.strict
+                else instructor.Mode.TOOLS,
             )
 
             try:


### PR DESCRIPTION
In strict mode, OpenAI's structured output only supports a subset of JSON schema spec. Allow option to toggle between strict and non-strict mode via `RequestParams`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional “strict” mode for structured completion requests to enforce exact schema conformity when needed.
- Behavior/Performance
  - Default behavior is now non-strict for structured completions, allowing more flexible responses unless strict mode is explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->