### PR TITLE
Added validation for http_client property on OllamaAugmentedLLM to mi…

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_ollama.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_ollama.py
@@ -103,7 +103,10 @@ class OllamaCompletionTasks:
         async with AsyncOpenAI(
             api_key=request.config.api_key,
             base_url=request.config.base_url,
-            http_client=request.config.http_client,
+            http_client=request.config.http_client
+             if hasattr(request.config, "http_client")
+            else None,
+
         ) as async_client:
             client = instructor.from_openai(
                 async_client,


### PR DESCRIPTION
…rror OpenAIAutmentedLLM

The `OpenAICompletionTasks` object has validation for a potentially missing property that `OllamaCompletionTasks` does not, causing this error when trying to use `generate_structured()` on an OllamaAugmentedLLM.

```
Error executing task: 'OpenAISettings' object has no attribute 'http_client'
```


See existing validation here.

https://github.com/lastmile-ai/mcp-agent/blob/1385dbf7c43ba57636956736d083d2d3581c2427/src/mcp_agent/workflows/llm/augmented_llm_openai.py#L876

