### PR TITLE
Enable log notifications from MCP agent server to client

### DIFF
--- a/examples/mcp_agent_server/asyncio/basic_agent_server.py
+++ b/examples/mcp_agent_server/asyncio/basic_agent_server.py
@@ -11,9 +11,10 @@ import argparse
 import asyncio
 import os
 import logging
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP, Context as MCPContext
+from mcp_agent.core.context import Context as AppContext
 
 from mcp_agent.app import MCPApp
 from mcp_agent.server.app_server import create_mcp_server_for_app
@@ -26,15 +27,12 @@ from mcp_agent.workflows.parallel.parallel_llm import ParallelLLM
 from mcp_agent.executor.workflow import Workflow, WorkflowResult
 from mcp_agent.tracing.token_counter import TokenNode
 
-# Initialize logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
-
 # Note: This is purely optional:
 # if not provided, a default FastMCP server will be created by MCPApp using create_mcp_server_for_app()
 mcp = FastMCP(name="basic_agent_server", description="My basic agent server example.")
 
-# Define the MCPApp instance
+# Define the MCPApp instance. The server created for this app will advertise the
+# MCP logging capability and forward structured logs upstream to connected clients.
 app = MCPApp(
     name="basic_agent_server",
     description="Basic agent server example",
@@ -112,71 +110,146 @@ class BasicAgentWorkflow(Workflow[str]):
             return WorkflowResult(value=result)
 
 
-@app.workflow
-class ParallelWorkflow(Workflow[str]):
+@app.tool
+async def grade_story(story: str, app_ctx: Optional[AppContext] = None) -> str:
     """
-    This workflow can be used to grade a student's short story submission and generate a report.
+    This tool can be used to grade a student's short story submission and generate a report.
     It uses multiple agents to perform different tasks in parallel.
     The agents include:
     - Proofreader: Reviews the story for grammar, spelling, and punctuation errors.
     - Fact Checker: Verifies the factual consistency within the story.
     - Style Enforcer: Analyzes the story for adherence to style guidelines.
     - Grader: Compiles the feedback from the other agents into a structured report.
+    
+    Args:
+        story: The student's short story to grade
+        app_ctx: Optional MCPApp context for accessing app resources and logging
+    """
+    # Use the context's app if available for proper logging with upstream_session
+    _app = app_ctx.app if app_ctx else app
+    # Ensure the app's logger is bound to the current context with upstream_session
+    if _app._logger and hasattr(_app._logger, '_bound_context'):
+        _app._logger._bound_context = app_ctx
+    logger = _app.logger
+    logger.info(f"grade_story: Received input: {story}")
+
+    proofreader = Agent(
+        name="proofreader",
+        instruction=""""Review the short story for grammar, spelling, and punctuation errors.
+        Identify any awkward phrasing or structural issues that could improve clarity. 
+        Provide detailed feedback on corrections.""",
+    )
+
+    fact_checker = Agent(
+        name="fact_checker",
+        instruction="""Verify the factual consistency within the story. Identify any contradictions,
+        logical inconsistencies, or inaccuracies in the plot, character actions, or setting. 
+        Highlight potential issues with reasoning or coherence.""",
+    )
+
+    style_enforcer = Agent(
+        name="style_enforcer",
+        instruction="""Analyze the story for adherence to style guidelines.
+        Evaluate the narrative flow, clarity of expression, and tone. Suggest improvements to 
+        enhance storytelling, readability, and engagement.""",
+    )
+
+    grader = Agent(
+        name="grader",
+        instruction="""Compile the feedback from the Proofreader, Fact Checker, and Style Enforcer
+        into a structured report. Summarize key issues and categorize them by type. 
+        Provide actionable recommendations for improving the story, 
+        and give an overall grade based on the feedback.""",
+    )
+
+    parallel = ParallelLLM(
+        fan_in_agent=grader,
+        fan_out_agents=[proofreader, fact_checker, style_enforcer],
+        llm_factory=OpenAIAugmentedLLM,
+        context=app_ctx if app_ctx else app.context,
+    )
+
+    try:
+        result = await parallel.generate_str(
+            message=f"Student short story submission: {story}",
+        )
+    except Exception as e:
+        logger.error(f"grade_story: Error generating result: {e}")
+        return None
+
+    if not result:
+        logger.error("grade_story: No result from parallel LLM")
+    else:
+        logger.info(f"grade_story: Result: {result}")
+
+    return result
+
+
+@app.async_tool(name="grade_story_async")
+async def grade_story_async(story: str, app_ctx: Optional[AppContext] = None) -> str:
+    """
+    Async variant of grade_story that starts a workflow run and returns IDs.
+    
+    Args:
+        story: The student's short story to grade
+        app_ctx: Optional MCPApp context for accessing app resources and logging
     """
 
-    @app.workflow_run
-    async def run(self, input: str) -> WorkflowResult[str]:
-        """
-        Run the workflow, processing the input data.
+    # Use the context's app if available for proper logging with upstream_session
+    _app = app_ctx.app if app_ctx else app
+    # Ensure the app's logger is bound to the current context with upstream_session
+    if _app._logger and hasattr(_app._logger, '_bound_context'):
+        _app._logger._bound_context = app_ctx
+    logger = _app.logger
+    logger.info(f"grade_story_async: Received input: {story}")
 
-        Args:
-            input_data: The data to process
+    proofreader = Agent(
+        name="proofreader",
+        instruction="""Review the short story for grammar, spelling, and punctuation errors.
+        Identify any awkward phrasing or structural issues that could improve clarity. 
+        Provide detailed feedback on corrections.""",
+    )
 
-        Returns:
-            A WorkflowResult containing the processed data
-        """
+    fact_checker = Agent(
+        name="fact_checker",
+        instruction="""Verify the factual consistency within the story. Identify any contradictions,
+        logical inconsistencies, or inaccuracies in the plot, character actions, or setting. 
+        Highlight potential issues with reasoning or coherence.""",
+    )
 
-        proofreader = Agent(
-            name="proofreader",
-            instruction=""""Review the short story for grammar, spelling, and punctuation errors.
-            Identify any awkward phrasing or structural issues that could improve clarity. 
-            Provide detailed feedback on corrections.""",
-        )
+    style_enforcer = Agent(
+        name="style_enforcer",
+        instruction="""Analyze the story for adherence to style guidelines.
+        Evaluate the narrative flow, clarity of expression, and tone. Suggest improvements to 
+        enhance storytelling, readability, and engagement.""",
+    )
 
-        fact_checker = Agent(
-            name="fact_checker",
-            instruction="""Verify the factual consistency within the story. Identify any contradictions,
-            logical inconsistencies, or inaccuracies in the plot, character actions, or setting. 
-            Highlight potential issues with reasoning or coherence.""",
-        )
+    grader = Agent(
+        name="grader",
+        instruction="""Compile the feedback from the Proofreader, Fact Checker, and Style Enforcer
+        into a structured report. Summarize key issues and categorize them by type. 
+        Provide actionable recommendations for improving the story, 
+        and give an overall grade based on the feedback.""",
+    )
 
-        style_enforcer = Agent(
-            name="style_enforcer",
-            instruction="""Analyze the story for adherence to style guidelines.
-            Evaluate the narrative flow, clarity of expression, and tone. Suggest improvements to 
-            enhance storytelling, readability, and engagement.""",
-        )
+    parallel = ParallelLLM(
+        fan_in_agent=grader,
+        fan_out_agents=[proofreader, fact_checker, style_enforcer],
+        llm_factory=OpenAIAugmentedLLM,
+        context=app_ctx if app_ctx else app.context,
+    )
 
-        grader = Agent(
-            name="grader",
-            instruction="""Compile the feedback from the Proofreader, Fact Checker, and Style Enforcer
-            into a structured report. Summarize key issues and categorize them by type. 
-            Provide actionable recommendations for improving the story, 
-            and give an overall grade based on the feedback.""",
-        )
+    logger.info("grade_story_async: Starting parallel LLM")
 
-        parallel = ParallelLLM(
-            fan_in_agent=grader,
-            fan_out_agents=[proofreader, fact_checker, style_enforcer],
-            llm_factory=OpenAIAugmentedLLM,
-            context=app.context,
-        )
-
+    try:
         result = await parallel.generate_str(
-            message=f"Student short story submission: {input}",
+            message=f"Student short story submission: {story}",
         )
+    except Exception as e:
+        logger.error(f"grade_story_async: Error generating result: {e}")
+        return None
 
-        return WorkflowResult(value=result)
+    return result
 
 
 # Add custom tool to get token usage for a workflow
@@ -313,11 +386,11 @@ async def main():
             context.config.mcp.servers["filesystem"].args.extend([os.getcwd()])
 
         # Log registered workflows and agent configurations
-        logger.info(f"Creating MCP server for {agent_app.name}")
+        agent_app.logger.info(f"Creating MCP server for {agent_app.name}")
 
-        logger.info("Registered workflows:")
+        agent_app.logger.info("Registered workflows:")
         for workflow_id in agent_app.workflows:
-            logger.info(f"  - {workflow_id}")
+            agent_app.logger.info(f"  - {workflow_id}")
 
         # Create the MCP server that exposes both workflows and agent configurations,
         # optionally using custom FastMCP settings
@@ -327,7 +400,7 @@ async def main():
             else None
         )
         mcp_server = create_mcp_server_for_app(agent_app, **(fast_mcp_settings or {}))
-        logger.info(f"MCP Server settings: {mcp_server.settings}")
+        agent_app.logger.info(f"MCP Server settings: {mcp_server.settings}")
 
         # Run the server
         await mcp_server.run_stdio_async()

--- a/examples/mcp_agent_server/asyncio/client.py
+++ b/examples/mcp_agent_server/asyncio/client.py
@@ -2,11 +2,15 @@ import argparse
 import asyncio
 import json
 import time
-from mcp.types import CallToolResult
+from datetime import timedelta
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from mcp import ClientSession
+from mcp.types import CallToolResult, LoggingMessageNotificationParams
 from mcp_agent.app import MCPApp
 from mcp_agent.config import MCPServerSettings
 from mcp_agent.executor.workflow import WorkflowExecution
 from mcp_agent.mcp.gen_client import gen_client
+from mcp_agent.mcp.mcp_agent_client_session import MCPAgentClientSession
 
 from rich import print
 
@@ -17,6 +21,12 @@ async def main():
         "--custom-fastmcp-settings",
         action="store_true",
         help="Enable custom FastMCP settings for the server",
+    )
+    parser.add_argument(
+        "--server-log-level",
+        type=str,
+        default=None,
+        help="Set initial server logging level (debug, info, notice, warning, error, critical, alert, emergency)",
     )
     args = parser.parse_args()
     use_custom_fastmcp_settings = args.custom_fastmcp_settings
@@ -45,7 +55,41 @@ async def main():
         )
 
         # Connect to the workflow server
-        async with gen_client("basic_agent_server", context.server_registry) as server:
+        # Define a logging callback to receive server-side log notifications
+        async def on_server_log(params: LoggingMessageNotificationParams) -> None:
+            # Pretty-print server logs locally for demonstration
+            level = params.level.upper()
+            name = params.logger or "server"
+            # params.data can be any JSON-serializable data
+            print(f"[SERVER LOG] [{level}] [{name}] {params.data}")
+
+        # Provide a client session factory that installs our logging callback
+        def make_session(
+            read_stream: MemoryObjectReceiveStream,
+            write_stream: MemoryObjectSendStream,
+            read_timeout_seconds: timedelta | None,
+        ) -> ClientSession:
+            return MCPAgentClientSession(
+                read_stream=read_stream,
+                write_stream=write_stream,
+                read_timeout_seconds=read_timeout_seconds,
+                logging_callback=on_server_log,
+            )
+
+        async with gen_client(
+            "basic_agent_server",
+            context.server_registry,
+            client_session_factory=make_session,
+        ) as server:
+            # Ask server to send logs at the requested level (default info)
+            level = (args.server_log_level or "info").lower()
+            print(f"[client] Setting server logging level to: {level}")
+            try:
+                await server.set_logging_level(level)
+            except Exception:
+                # Older servers may not support logging capability
+                print("[client] Server does not support logging/setLevel")
+
             # List available tools
             tools_result = await server.list_tools()
             logger.info(
@@ -61,7 +105,7 @@ async def main():
                 data=_tool_result_to_json(workflows_response) or workflows_response,
             )
 
-            # Call the BasicAgentWorkflow
+            # Call the BasicAgentWorkflow (run + status)
             run_result = await server.call_tool(
                 "workflows-BasicAgentWorkflow-run",
                 arguments={
@@ -71,7 +115,22 @@ async def main():
                 },
             )
 
-            execution = WorkflowExecution(**json.loads(run_result.content[0].text))
+            # Tolerant parsing of run IDs from tool result
+            run_payload = _tool_result_to_json(run_result)
+            if not run_payload:
+                sc = getattr(run_result, "structuredContent", None)
+                if isinstance(sc, dict):
+                    run_payload = sc.get("result") or sc
+            if not run_payload:
+                # Last resort: parse unstructured content if present and non-empty
+                if getattr(run_result, "content", None) and run_result.content[0].text:
+                    run_payload = json.loads(run_result.content[0].text)
+                else:
+                    raise RuntimeError(
+                        "Unable to extract workflow run IDs from tool result"
+                    )
+
+            execution = WorkflowExecution(**run_payload)
             run_id = execution.run_id
             logger.info(
                 f"Started BasicAgentWorkflow-run. workflow ID={execution.workflow_id}, run ID={run_id}"
@@ -84,7 +143,12 @@ async def main():
                     arguments={"run_id": run_id},
                 )
 
+                # Tolerant parsing of get_status result
                 workflow_status = _tool_result_to_json(get_status_result)
+                if workflow_status is None:
+                    sc = getattr(get_status_result, "structuredContent", None)
+                    if isinstance(sc, dict):
+                        workflow_status = sc.get("result") or sc
                 if workflow_status is None:
                     logger.error(
                         f"Failed to parse workflow status response: {get_status_result}"
@@ -108,7 +172,6 @@ async def main():
                         f"Workflow run {run_id} completed successfully! Result:",
                         data=workflow_status.get("result"),
                     )
-
                     break
                 elif workflow_status.get("status") == "error":
                     logger.error(
@@ -135,12 +198,6 @@ async def main():
 
                 await asyncio.sleep(5)
 
-                # TODO: UNCOMMENT ME to try out cancellation:
-                # await server.call_tool(
-                #     "workflows-cancel",
-                #     arguments={"workflow_id": "BasicAgentWorkflow", "run_id": run_id},
-                # )
-
             # Get the token usage summary
             logger.info("Fetching token usage summary...")
             token_usage_result = await server.call_tool(
@@ -158,6 +215,70 @@ async def main():
 
             # Display the token usage summary
             print(token_usage_result.structuredContent)
+
+            # Call the sync tool 'grade_story' separately (no run/status loop)
+            try:
+                grade_result = await server.call_tool(
+                    "grade_story",
+                    arguments={"story": "This is a test story."},
+                )
+                grade_payload = _tool_result_to_json(grade_result) or (
+                    (
+                        grade_result.structuredContent.get("result")
+                        if getattr(grade_result, "structuredContent", None)
+                        else None
+                    )
+                    or (grade_result.content[0].text if grade_result.content else None)
+                )
+                logger.info("grade_story result:", data=grade_payload)
+            except Exception as e:
+                logger.error("grade_story call failed", data=str(e))
+
+            # Call the async tool 'grade_story_async': start then poll status
+            try:
+                async_run_result = await server.call_tool(
+                    "grade_story_async-async-run",
+                    arguments={"run_parameters": {"story": "This is a test story."}},
+                )
+                async_ids = (
+                    (getattr(async_run_result, "structuredContent", {}) or {}).get(
+                        "result"
+                    )
+                    or _tool_result_to_json(async_run_result)
+                    or json.loads(async_run_result.content[0].text)
+                )
+                async_run_id = async_ids["run_id"]
+                logger.info(
+                    f"Started grade_story_async. run ID={async_run_id}",
+                )
+
+                # Poll status until completion
+                while True:
+                    async_status = await server.call_tool(
+                        "grade_story_async-get_status",
+                        arguments={"run_id": async_run_id},
+                    )
+                    async_status_json = (
+                        getattr(async_status, "structuredContent", {}) or {}
+                    ).get("result") or _tool_result_to_json(async_status)
+                    if async_status_json is None:
+                        logger.error(
+                            "grade_story_async: failed to parse status",
+                            data=async_status,
+                        )
+                        break
+                    logger.info("grade_story_async status:", data=async_status_json)
+                    if async_status_json.get("status") in (
+                        "completed",
+                        "error",
+                        "cancelled",
+                    ):
+                        break
+                    await asyncio.sleep(2)
+            except Exception as e:
+                logger.error("grade_story_async call failed", data=str(e))
+
+            await asyncio.sleep(5)
 
 
 def _tool_result_to_json(tool_result: CallToolResult):

--- a/src/mcp_agent/app.py
+++ b/src/mcp_agent/app.py
@@ -624,6 +624,12 @@ class MCPApp:
 
             return fn
 
+        # Support bare usage: @app.tool without parentheses
+        if callable(name) and description is None and structured_output is None:
+            fn = name  # type: ignore[assignment]
+            name = None
+            return decorator(fn)  # type: ignore[arg-type]
+
         return decorator
 
     def async_tool(
@@ -660,6 +666,12 @@ class MCPApp:
                 }
             )
             return fn
+
+        # Support bare usage: @app.async_tool without parentheses
+        if callable(name) and description is None:
+            fn = name  # type: ignore[assignment]
+            name = None
+            return decorator(fn)  # type: ignore[arg-type]
 
         return decorator
 

--- a/src/mcp_agent/app.py
+++ b/src/mcp_agent/app.py
@@ -194,7 +194,7 @@ class MCPApp:
             )
         else:
             # Update the logger's bound context in case upstream_session was set after logger creation
-            if self._context and hasattr(self._logger, '_bound_context'):
+            if self._context and hasattr(self._logger, "_bound_context"):
                 self._logger._bound_context = self._context
         return self._logger
 

--- a/src/mcp_agent/cli/cloud/main.py
+++ b/src/mcp_agent/cli/cloud/main.py
@@ -14,7 +14,11 @@ from rich.panel import Panel
 from typer.core import TyperGroup
 
 from mcp_agent.cli.cloud.commands import configure_app, deploy_config, login
-from mcp_agent.cli.cloud.commands.app import delete_app, get_app_status, list_app_workflows
+from mcp_agent.cli.cloud.commands.app import (
+    delete_app,
+    get_app_status,
+    list_app_workflows,
+)
 from mcp_agent.cli.cloud.commands.apps import list_apps
 from mcp_agent.cli.cloud.commands.workflow import get_workflow_status
 from mcp_agent.cli.exceptions import CLIError

--- a/src/mcp_agent/executor/workflow.py
+++ b/src/mcp_agent/executor/workflow.py
@@ -94,7 +94,9 @@ class Workflow(ABC, Generic[T], ContextDependent):
         ContextDependent.__init__(self, context=context)
 
         self.name = name or self.__class__.__name__
-        self._logger = get_logger(f"workflow.{self.name}")
+        # Bind workflow logger to the provided context so events can carry
+        # the current upstream_session even when emitted from background tasks.
+        self._logger = get_logger(f"workflow.{self.name}", context=context)
         self._initialized = False
         self._workflow_id = None  # Will be set during run_async
         self._run_id = None  # Will be set during run_async

--- a/src/mcp_agent/logging/events.py
+++ b/src/mcp_agent/logging/events.py
@@ -50,6 +50,10 @@ class Event(BaseModel):
     data: Dict[str, Any] = Field(default_factory=dict)
     context: EventContext | None = None
 
+    # Runtime-only handle for upstream forwarding. Present for listeners to
+    # use, explicitly excluded from any serialization/dumps.
+    upstream_session: Any | None = Field(default=None, exclude=True)
+
     # For distributed tracing
     span_id: str | None = None
     trace_id: str | None = None

--- a/src/mcp_agent/logging/listeners.py
+++ b/src/mcp_agent/logging/listeners.py
@@ -7,10 +7,23 @@ import logging
 import time
 
 from abc import ABC, abstractmethod
-from typing import Dict, List
+from typing import Any, Dict, List, Optional, Protocol, TYPE_CHECKING
 
 from mcp_agent.logging.events import Event, EventFilter, EventType
 from mcp_agent.logging.event_progress import convert_log_event
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from mcp.types import LoggingLevel
+
+
+class UpstreamServerSessionProtocol(Protocol):
+    async def send_log_message(
+        self,
+        level: "LoggingLevel",
+        data: Dict[str, Any],
+        logger: str | None = None,
+        related_request_id: str | None = None,
+    ) -> None: ...
 
 
 class EventListener(ABC):
@@ -217,3 +230,80 @@ class BatchingListener(FilteredListener):
 
     async def _process_batch(self, events: List[Event]):
         pass
+
+
+class MCPUpstreamLoggingListener(FilteredListener):
+    """
+    Sends matched log events to the connected MCP client via upstream_session
+    using notifications/message.
+
+    This relies on a globally available Context (see get_current_context())
+    which is established when the app initializes. If no upstream_session is
+    present, events are skipped.
+    """
+
+    def __init__(self, event_filter: EventFilter | None = None) -> None:
+        super().__init__(event_filter=event_filter)
+
+    async def handle_matched_event(self, event: Event) -> None:
+        # Resolve upstream session from the global/app context when available
+        try:
+            # Import inline to avoid import cycles at module load
+            from mcp_agent.core.context import get_current_context
+        except Exception:
+            return
+
+        try:
+            ctx = get_current_context()
+        except Exception:
+            return
+
+        upstream_session: Optional[UpstreamServerSessionProtocol] = getattr(
+            ctx, "upstream_session", None
+        )
+        if upstream_session is None:
+            return
+
+        # Map our EventType to MCP LoggingLevel; fold progress -> info
+        mcp_level_map: Dict[str, str] = {
+            "debug": "debug",
+            "info": "info",
+            "warning": "warning",
+            "error": "error",
+            "progress": "info",
+        }
+        # Use string type to avoid hard dependency; annotated for type checkers
+        mcp_level: "LoggingLevel" = mcp_level_map.get(event.type, "info")  # type: ignore[assignment]
+
+        # Build structured data payload
+        data: Dict[str, Any] = {
+            "message": event.message,
+            "namespace": event.namespace,
+            "name": event.name,
+            "timestamp": event.timestamp.isoformat(),
+        }
+        if event.data:
+            # Merge user-provided event data under 'data'
+            data["data"] = event.data
+        if event.trace_id or event.span_id:
+            data["trace"] = {"trace_id": event.trace_id, "span_id": event.span_id}
+        if event.context is not None:
+            try:
+                data["context"] = event.context.dict()
+            except Exception:
+                pass
+
+        # Determine logger name (namespace + optional name)
+        logger_name: str = (
+            event.namespace if not event.name else f"{event.namespace}.{event.name}"
+        )
+
+        try:
+            await upstream_session.send_log_message(
+                level=mcp_level,  # type: ignore[arg-type]
+                data=data,
+                logger=logger_name,
+            )
+        except Exception:
+            # Avoid raising inside listener; best-effort delivery
+            pass

--- a/src/mcp_agent/logging/logger.py
+++ b/src/mcp_agent/logging/logger.py
@@ -118,22 +118,7 @@ class Logger:
         except Exception:
             pass
 
-        # 2) Fallback to low-level request_ctx if available (in-request logs)
-        if "upstream_session" not in extra_event_fields:
-            try:
-                from mcp.server.lowlevel.server import (
-                    request_ctx as _lowlevel_request_ctx,
-                )  # type: ignore
-
-                try:
-                    req_ctx = _lowlevel_request_ctx.get()
-                    extra_event_fields["upstream_session"] = getattr(
-                        req_ctx, "session", None
-                    )
-                except LookupError:
-                    pass
-            except Exception:
-                pass
+        # No further fallback: rely solely on the bound context for upstream_session
 
         evt = Event(
             type=etype,

--- a/src/mcp_agent/logging/transport.py
+++ b/src/mcp_agent/logging/transport.py
@@ -325,7 +325,15 @@ class AsyncEventBus:
             # Signal shutdown
             cls._instance._running = False
             if hasattr(cls._instance, "_stop_event"):
-                cls._instance._stop_event.set()
+                try:
+                    # _stop_event.set() schedules on the event's loop; this can fail if
+                    # the loop is already closed in test teardown. Swallow to ensure
+                    # reset never raises in those cases.
+                    cls._instance._stop_event.set()
+                except RuntimeError:
+                    pass
+                except Exception:
+                    pass
 
             # Clear the singleton instance
             cls._instance = None

--- a/src/mcp_agent/server/app_server.py
+++ b/src/mcp_agent/server/app_server.py
@@ -629,9 +629,9 @@ def create_declared_function_tools(mcp: FastMCP, server_context: ServerContext):
                 registered.add(status_tool_name)
 
         elif mode == "async":
-            # Create only named aliases for async: <name>-async-run and <name>-async-get_status
+            # Create named aliases for async: <name>-async-run and <name>-get_status
             run_tool_name = f"{name}-async-run"
-            status_tool_name = f"{name}-async-get_status"
+            status_tool_name = f"{name}-get_status"
 
             if run_tool_name not in registered:
 

--- a/src/mcp_agent/server/app_server.py
+++ b/src/mcp_agent/server/app_server.py
@@ -132,6 +132,12 @@ def _resolve_workflows_and_context(
 def _resolve_workflow_registry(ctx: MCPContext) -> WorkflowRegistry | None:
     """Resolve the workflow registry regardless of startup mode."""
     lifespan_ctx = getattr(ctx.request_context, "lifespan_context", None)
+    # Prefer the underlying app context's registry if available
+    if lifespan_ctx is not None and hasattr(lifespan_ctx, "context"):
+        ctx_inner = getattr(lifespan_ctx, "context", None)
+        if ctx_inner is not None and hasattr(ctx_inner, "workflow_registry"):
+            return ctx_inner.workflow_registry
+    # Fallback: top-level lifespan registry if present
     if lifespan_ctx is not None and hasattr(lifespan_ctx, "workflow_registry"):
         return lifespan_ctx.workflow_registry
 
@@ -140,6 +146,43 @@ def _resolve_workflow_registry(ctx: MCPContext) -> WorkflowRegistry | None:
         return app.context.workflow_registry
 
     return None
+
+
+def _get_param_source_function_from_workflow(workflow_cls: Type["Workflow"]):
+    """Return the function to use for parameter schema for a workflow's run.
+
+    For auto-generated workflows from @app.tool/@app.async_tool, prefer the original
+    function that defined the parameters if available; fall back to the class run.
+    """
+    return getattr(workflow_cls, "__mcp_agent_param_source_fn__", None) or getattr(
+        workflow_cls, "run"
+    )
+
+
+def _build_run_param_tool(workflow_cls: Type["Workflow"]) -> FastTool:
+    """Return a FastTool built from the proper parameter source, skipping 'self'."""
+    param_source = _get_param_source_function_from_workflow(workflow_cls)
+    import inspect as _inspect
+
+    if param_source is getattr(workflow_cls, "run"):
+
+        def _schema_fn_proxy(*args, **kwargs):
+            return None
+
+        sig = _inspect.signature(param_source)
+        params = list(sig.parameters.values())
+        if params and params[0].name == "self":
+            params = params[1:]
+        _schema_fn_proxy.__annotations__ = dict(
+            getattr(param_source, "__annotations__", {})
+        )
+        if "self" in _schema_fn_proxy.__annotations__:
+            _schema_fn_proxy.__annotations__.pop("self", None)
+        _schema_fn_proxy.__signature__ = _inspect.Signature(
+            parameters=params, return_annotation=sig.return_annotation
+        )
+        return FastTool.from_function(_schema_fn_proxy)
+    return FastTool.from_function(param_source)
 
 
 def create_mcp_server_for_app(app: MCPApp, **kwargs: Any) -> FastMCP:
@@ -166,6 +209,8 @@ def create_mcp_server_for_app(app: MCPApp, **kwargs: Any) -> FastMCP:
 
         # Register initial workflow tools when running with our managed lifespan
         create_workflow_tools(mcp, server_context)
+        # Register function-declared tools (from @app.tool/@app.async_tool)
+        create_declared_function_tools(mcp, server_context)
 
         try:
             yield server_context
@@ -189,6 +234,8 @@ def create_mcp_server_for_app(app: MCPApp, **kwargs: Any) -> FastMCP:
 
         # Register per-workflow tools
         create_workflow_tools(mcp, server_context)
+        # Register function-declared tools (from @app.tool/@app.async_tool)
+        create_declared_function_tools(mcp, server_context)
     else:
         mcp = FastMCP(
             name=app.name or "mcp_agent_server",
@@ -403,6 +450,11 @@ def create_workflow_tools(mcp: FastMCP, server_context: ServerContext):
     registered_workflow_tools = _get_registered_workflow_tools(mcp)
 
     for workflow_name, workflow_cls in server_context.workflows.items():
+        # Skip creating generic workflows-* tools for sync/async auto tools
+        if getattr(workflow_cls, "__mcp_agent_sync_tool__", False):
+            continue
+        if getattr(workflow_cls, "__mcp_agent_async_tool__", False):
+            continue
         if workflow_name not in registered_workflow_tools:
             create_workflow_specific_tools(mcp, workflow_name, workflow_cls)
             registered_workflow_tools.add(workflow_name)
@@ -410,12 +462,229 @@ def create_workflow_tools(mcp: FastMCP, server_context: ServerContext):
     setattr(mcp, "_registered_workflow_tools", registered_workflow_tools)
 
 
+def _get_registered_function_tools(mcp: FastMCP) -> Set[str]:
+    return getattr(mcp, "_registered_function_tools", set())
+
+
+def _set_registered_function_tools(mcp: FastMCP, tools: Set[str]):
+    setattr(mcp, "_registered_function_tools", tools)
+
+
+def create_declared_function_tools(mcp: FastMCP, server_context: ServerContext):
+    """
+    Register tools declared via @app.tool/@app.async_tool on the attached app.
+    - @app.tool registers a synchronous tool with the same signature as the function
+      that runs the auto-generated workflow and waits for completion.
+    - @app.async_tool registers alias tools <name>-run and <name>-get_status
+      that proxy to the workflow run/status utilities.
+    """
+    app = _get_attached_app(mcp)
+    if app is None:
+        # Fallbacks for tests or externally provided contexts
+        app = getattr(server_context, "app", None)
+        if app is None:
+            ctx = getattr(server_context, "context", None)
+            if ctx is not None:
+                app = getattr(ctx, "app", None)
+    if app is None:
+        return
+
+    declared = getattr(app, "_declared_tools", []) or []
+    if not declared:
+        return
+
+    registered = _get_registered_function_tools(mcp)
+
+    # Utility: build a wrapper function with the same signature and return annotation
+    import inspect
+    import asyncio
+
+    async def _wait_for_completion(
+        ctx: MCPContext, run_id: str, timeout: float | None = None
+    ):
+        registry = _resolve_workflow_registry(ctx)
+        if not registry:
+            raise ToolError("Workflow registry not found for MCPApp Server.")
+        # Try to get the workflow and wait on its task if available
+        start = asyncio.get_event_loop().time()
+        # Ensure the workflow is registered locally to retrieve the task
+        try:
+            wf = await registry.get_workflow(run_id)
+            if wf is None and hasattr(registry, "register"):
+                # Best-effort: some registries need explicit register; try to find by status
+                # and skip if unavailable. This is a no-op for InMemory which registers at run_async.
+                pass
+        except Exception:
+            pass
+        while True:
+            wf = await registry.get_workflow(run_id)
+            if wf is not None:
+                task = getattr(wf, "_run_task", None)
+                if isinstance(task, asyncio.Task):
+                    return await asyncio.wait_for(task, timeout=timeout)
+                # Fallback to polling the status
+                status = await wf.get_status()
+                if status.get("completed"):
+                    return status.get("result")
+            if (
+                timeout is not None
+                and (asyncio.get_event_loop().time() - start) > timeout
+            ):
+                raise ToolError("Timed out waiting for workflow completion")
+            await asyncio.sleep(0.1)
+
+    for decl in declared:
+        name = decl["name"]
+        if name in registered:
+            continue
+        mode = decl["mode"]
+        workflow_name = decl["workflow_name"]
+        fn = decl.get("source_fn")
+        description = decl.get("description")
+        structured_output = decl.get("structured_output")
+
+        if mode == "sync" and fn is not None:
+            sig = inspect.signature(fn)
+            return_ann = sig.return_annotation
+
+            async def _wrapper(**kwargs):
+                # Context will be injected by FastMCP using the special annotation below
+                ctx: MCPContext = kwargs.pop(
+                    "__context__"
+                )  # placeholder, reassigned below via signature name
+                # Start workflow and wait for completion
+                result_ids = await _workflow_run(ctx, workflow_name, kwargs)
+                run_id = result_ids["run_id"]
+                result = await _wait_for_completion(ctx, run_id)
+                # Unwrap WorkflowResult to match the original function's return type
+                try:
+                    from mcp_agent.executor.workflow import WorkflowResult as _WFRes
+                except Exception:
+                    _WFRes = None  # type: ignore
+                if _WFRes is not None and isinstance(result, _WFRes):
+                    return getattr(result, "value", None)
+                # If get_status returned dict/str, pass through; otherwise return model
+                return result
+
+            # Attach introspection metadata to match the original function
+            ann = dict(getattr(fn, "__annotations__", {}))
+
+            # Choose a context kwarg name unlikely to clash with user params
+            ctx_param_name = "ctx"
+            from mcp.server.fastmcp import Context as _Ctx
+
+            ann[ctx_param_name] = _Ctx
+            ann["return"] = getattr(fn, "__annotations__", {}).get("return", return_ann)
+            _wrapper.__annotations__ = ann
+            _wrapper.__name__ = name
+            _wrapper.__doc__ = description or (fn.__doc__ or "")
+
+            # Build a fake signature containing original params plus context kwarg
+            params = list(sig.parameters.values())
+            ctx_param = inspect.Parameter(
+                ctx_param_name,
+                kind=inspect.Parameter.KEYWORD_ONLY,
+                annotation=_Ctx,
+            )
+            _wrapper.__signature__ = inspect.Signature(
+                parameters=params + [ctx_param], return_annotation=return_ann
+            )
+
+            # FastMCP expects the actual kwarg name for context; it detects it by annotation
+            # We need to map the injected kwarg inside the wrapper body. Achieve this by
+            # creating a thin adapter that renames the injected context kwarg.
+            async def _adapter(**kw):
+                # Receive validated args plus injected context kwarg
+                if ctx_param_name not in kw:
+                    raise ToolError("Context not provided")
+                # Rename to the placeholder expected by _wrapper
+                kw["__context__"] = kw.pop(ctx_param_name)
+                return await _wrapper(**kw)
+
+            # Copy the visible signature/annotations to adapter for correct schema
+            _adapter.__annotations__ = _wrapper.__annotations__
+            _adapter.__name__ = _wrapper.__name__
+            _adapter.__doc__ = _wrapper.__doc__
+            _adapter.__signature__ = _wrapper.__signature__
+
+            # Register the main tool with the same signature as original
+            mcp.add_tool(
+                _adapter,
+                name=name,
+                description=description or (fn.__doc__ or ""),
+                structured_output=structured_output,
+            )
+            registered.add(name)
+
+            # Also register a per-run status tool: <tool-name>-get_status
+            status_tool_name = f"{name}-get_status"
+            if status_tool_name not in registered:
+
+                @mcp.tool(name=status_tool_name)
+                async def _sync_status(ctx: MCPContext, run_id: str) -> Dict[str, Any]:
+                    return await _workflow_status(
+                        ctx, run_id=run_id, workflow_name=workflow_name
+                    )
+
+                registered.add(status_tool_name)
+
+        elif mode == "async":
+            # Create only named aliases for async: <name>-async-run and <name>-async-get_status
+            run_tool_name = f"{name}-async-run"
+            status_tool_name = f"{name}-async-get_status"
+
+            if run_tool_name not in registered:
+
+                @mcp.tool(name=run_tool_name)
+                async def _alias_run(
+                    ctx: MCPContext, run_parameters: Dict[str, Any] | None = None
+                ) -> Dict[str, str]:
+                    return await _workflow_run(ctx, workflow_name, run_parameters or {})
+
+                registered.add(run_tool_name)
+
+            if status_tool_name not in registered:
+
+                @mcp.tool(name=status_tool_name)
+                async def _alias_status(ctx: MCPContext, run_id: str) -> Dict[str, Any]:
+                    return await _workflow_status(
+                        ctx, run_id=run_id, workflow_name=workflow_name
+                    )
+
+                registered.add(status_tool_name)
+
+    _set_registered_function_tools(mcp, registered)
+
+
 def create_workflow_specific_tools(
     mcp: FastMCP, workflow_name: str, workflow_cls: Type["Workflow"]
 ):
     """Create specific tools for a given workflow."""
+    param_source = _get_param_source_function_from_workflow(workflow_cls)
+    # Ensure we don't include 'self' in tool schema; FastMCP will ignore Context but not 'self'
+    import inspect as _inspect
 
-    run_fn_tool = FastTool.from_function(workflow_cls.run)
+    if param_source is getattr(workflow_cls, "run"):
+        # Wrap to drop the first positional param (self) for schema purposes
+        def _schema_fn_proxy(*args, **kwargs):
+            return None
+
+        sig = _inspect.signature(param_source)
+        params = list(sig.parameters.values())
+        # remove leading 'self' if present
+        if params and params[0].name == "self":
+            params = params[1:]
+        _schema_fn_proxy.__annotations__ = dict(
+            getattr(param_source, "__annotations__", {})
+        )
+        if "self" in _schema_fn_proxy.__annotations__:
+            _schema_fn_proxy.__annotations__.pop("self", None)
+        _schema_fn_proxy.__signature__ = _inspect.Signature(
+            parameters=params, return_annotation=sig.return_annotation
+        )
+        run_fn_tool = FastTool.from_function(_schema_fn_proxy)
+    else:
+        run_fn_tool = FastTool.from_function(param_source)
     run_fn_tool_params = json.dumps(run_fn_tool.parameters, indent=2)
 
     @mcp.tool(

--- a/tests/cli/commands/test_app_delete.py
+++ b/tests/cli/commands/test_app_delete.py
@@ -1,4 +1,5 @@
 """Tests for the configure command."""
+
 import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -8,7 +9,8 @@ from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.mcp_app.api_client import MCPApp, MCPAppConfiguration
 from mcp_agent.cli.mcp_app.mock_client import (
     MOCK_APP_CONFIG_ID,
-    MOCK_APP_ID, MockMCPAppClient,
+    MOCK_APP_ID,
+    MockMCPAppClient,
 )
 
 
@@ -72,17 +74,13 @@ def test_delete_app(patched_delete_app, mock_mcp_client):
         app_id_or_url=MOCK_APP_ID,
     )
 
-    patched_delete_app(
-        app_id_or_url=MOCK_APP_ID,
-        dry_run=False
-    )
+    patched_delete_app(app_id_or_url=MOCK_APP_ID, dry_run=False)
     mock_mcp_client.delete_app.assert_called_once_with(MOCK_APP_ID)
 
 
 def test_delete_app_config(patched_delete_app, mock_mcp_client):
     app_config = MCPAppConfiguration(
-        appConfigurationId=MOCK_APP_CONFIG_ID,
-        creatorId="creator"
+        appConfigurationId=MOCK_APP_CONFIG_ID, creatorId="creator"
     )
     mock_mcp_client.get_app_or_config = AsyncMock(return_value=app_config)
 
@@ -91,11 +89,9 @@ def test_delete_app_config(patched_delete_app, mock_mcp_client):
         app_id_or_url=MOCK_APP_ID,
     )
 
-    patched_delete_app(
-        app_id_or_url=MOCK_APP_ID,
-        dry_run=False
-    )
+    patched_delete_app(app_id_or_url=MOCK_APP_ID, dry_run=False)
     mock_mcp_client.delete_app_configuration.assert_called_once_with(MOCK_APP_CONFIG_ID)
+
 
 def test_missing_app_id(patched_delete_app):
     """Test with missing app_id."""
@@ -122,8 +118,8 @@ def test_missing_api_key(patched_delete_app):
 
         # Patch load_api_key_credentials to return None
         with patch(
-                "mcp_agent.cli.cloud.commands.configure.main.load_api_key_credentials",
-                return_value=None,
+            "mcp_agent.cli.cloud.commands.configure.main.load_api_key_credentials",
+            return_value=None,
         ):
             with pytest.raises(CLIError):
                 patched_delete_app(

--- a/tests/cli/commands/test_app_status.py
+++ b/tests/cli/commands/test_app_status.py
@@ -1,4 +1,5 @@
 """Tests for the configure command."""
+
 import datetime
 from unittest.mock import AsyncMock, MagicMock, patch, Mock
 
@@ -10,7 +11,8 @@ from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.mcp_app.api_client import MCPApp, MCPAppConfiguration, AppServerInfo
 from mcp_agent.cli.mcp_app.mock_client import (
     MOCK_APP_CONFIG_ID,
-    MOCK_APP_ID, MockMCPAppClient,
+    MOCK_APP_ID,
+    MockMCPAppClient,
 )
 
 
@@ -68,14 +70,14 @@ def test_status_app(patched_status_app, mock_mcp_client):
         creatorId="creatorId",
         createdAt=datetime.datetime.now(),
         updatedAt=datetime.datetime.now(),
-        appServerInfo=app_server_info
+        appServerInfo=app_server_info,
     )
     mock_mcp_client.get_app_or_config = AsyncMock(return_value=app)
 
     mock_mcp_print_server_details = Mock()
     with patch(
-            "mcp_agent.cli.cloud.commands.app.status.main.print_mcp_server_details",
-            side_effect=mock_mcp_print_server_details
+        "mcp_agent.cli.cloud.commands.app.status.main.print_mcp_server_details",
+        side_effect=mock_mcp_print_server_details,
     ) as mocked_function:
         mock_mcp_print_server_details.return_value = None
 
@@ -85,7 +87,9 @@ def test_status_app(patched_status_app, mock_mcp_client):
             api_key=settings.API_KEY,
         )
 
-        mocked_function.assert_called_once_with(server_url=server_url, api_key=settings.API_KEY)
+        mocked_function.assert_called_once_with(
+            server_url=server_url, api_key=settings.API_KEY
+        )
 
 
 def test_status_app_config(patched_status_app, mock_mcp_client):
@@ -97,14 +101,14 @@ def test_status_app_config(patched_status_app, mock_mcp_client):
     app_config = MCPAppConfiguration(
         appConfigurationId=MOCK_APP_CONFIG_ID,
         creatorId="creator",
-        appServerInfo=app_server_info
+        appServerInfo=app_server_info,
     )
     mock_mcp_client.get_app_or_config = AsyncMock(return_value=app_config)
 
     mock_mcp_print_server_details = Mock()
     with patch(
-            "mcp_agent.cli.cloud.commands.app.status.main.print_mcp_server_details",
-            side_effect=mock_mcp_print_server_details
+        "mcp_agent.cli.cloud.commands.app.status.main.print_mcp_server_details",
+        side_effect=mock_mcp_print_server_details,
     ) as mocked_function:
         mock_mcp_print_server_details.return_value = None
 
@@ -114,7 +118,10 @@ def test_status_app_config(patched_status_app, mock_mcp_client):
             api_key=settings.API_KEY,
         )
 
-        mocked_function.assert_called_once_with(server_url=server_url, api_key=settings.API_KEY)
+        mocked_function.assert_called_once_with(
+            server_url=server_url, api_key=settings.API_KEY
+        )
+
 
 def test_missing_app_id(patched_status_app):
     """Test with missing app_id."""
@@ -141,8 +148,8 @@ def test_missing_api_key(patched_status_app):
 
         # Patch load_api_key_credentials to return None
         with patch(
-                "mcp_agent.cli.cloud.commands.configure.main.load_api_key_credentials",
-                return_value=None,
+            "mcp_agent.cli.cloud.commands.configure.main.load_api_key_credentials",
+            return_value=None,
         ):
             with pytest.raises(CLIError):
                 patched_status_app(

--- a/tests/cli/commands/test_app_workflows.py
+++ b/tests/cli/commands/test_app_workflows.py
@@ -1,4 +1,5 @@
 """Tests for the configure command."""
+
 import datetime
 from unittest.mock import AsyncMock, MagicMock, patch, Mock
 
@@ -10,7 +11,8 @@ from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.mcp_app.api_client import MCPApp, MCPAppConfiguration, AppServerInfo
 from mcp_agent.cli.mcp_app.mock_client import (
     MOCK_APP_CONFIG_ID,
-    MOCK_APP_ID, MockMCPAppClient,
+    MOCK_APP_ID,
+    MockMCPAppClient,
 )
 
 
@@ -68,14 +70,14 @@ def test_status_app(patched_workflows_app, mock_mcp_client):
         creatorId="creatorId",
         createdAt=datetime.datetime.now(),
         updatedAt=datetime.datetime.now(),
-        appServerInfo=app_server_info
+        appServerInfo=app_server_info,
     )
     mock_mcp_client.get_app_or_config = AsyncMock(return_value=app)
 
     mock_mcp_print_mcp_server_workflow_details = Mock()
     with patch(
-            "mcp_agent.cli.cloud.commands.app.workflows.main.print_mcp_server_workflow_details",
-            side_effect=mock_mcp_print_mcp_server_workflow_details
+        "mcp_agent.cli.cloud.commands.app.workflows.main.print_mcp_server_workflow_details",
+        side_effect=mock_mcp_print_mcp_server_workflow_details,
     ) as mocked_function:
         mock_mcp_print_mcp_server_workflow_details.return_value = None
 
@@ -85,7 +87,9 @@ def test_status_app(patched_workflows_app, mock_mcp_client):
             api_key=settings.API_KEY,
         )
 
-        mocked_function.assert_called_once_with(server_url=server_url, api_key=settings.API_KEY)
+        mocked_function.assert_called_once_with(
+            server_url=server_url, api_key=settings.API_KEY
+        )
 
 
 def test_status_app_config(patched_workflows_app, mock_mcp_client):
@@ -97,14 +101,14 @@ def test_status_app_config(patched_workflows_app, mock_mcp_client):
     app_config = MCPAppConfiguration(
         appConfigurationId=MOCK_APP_CONFIG_ID,
         creatorId="creator",
-        appServerInfo=app_server_info
+        appServerInfo=app_server_info,
     )
     mock_mcp_client.get_app_or_config = AsyncMock(return_value=app_config)
 
     mock_mcp_print_mcp_server_workflow_details = Mock()
     with patch(
-            "mcp_agent.cli.cloud.commands.app.workflows.main.print_mcp_server_workflow_details",
-            side_effect=mock_mcp_print_mcp_server_workflow_details
+        "mcp_agent.cli.cloud.commands.app.workflows.main.print_mcp_server_workflow_details",
+        side_effect=mock_mcp_print_mcp_server_workflow_details,
     ) as mocked_function:
         mock_mcp_print_mcp_server_workflow_details.return_value = None
 
@@ -114,7 +118,10 @@ def test_status_app_config(patched_workflows_app, mock_mcp_client):
             api_key=settings.API_KEY,
         )
 
-        mocked_function.assert_called_once_with(server_url=server_url, api_key=settings.API_KEY)
+        mocked_function.assert_called_once_with(
+            server_url=server_url, api_key=settings.API_KEY
+        )
+
 
 def test_missing_app_id(patched_workflows_app):
     """Test with missing app_id."""
@@ -141,8 +148,8 @@ def test_missing_api_key(patched_workflows_app):
 
         # Patch load_api_key_credentials to return None
         with patch(
-                "mcp_agent.cli.cloud.commands.configure.main.load_api_key_credentials",
-                return_value=None,
+            "mcp_agent.cli.cloud.commands.configure.main.load_api_key_credentials",
+            return_value=None,
         ):
             with pytest.raises(CLIError):
                 patched_workflows_app(

--- a/tests/cli/commands/test_cli_secrets.py
+++ b/tests/cli/commands/test_cli_secrets.py
@@ -431,15 +431,12 @@ def test_cli_error_handling(mock_api_credentials):
         # Error message should mention the file doesn't exist
         combined_output = result.stderr + result.stdout
         # remove all lines, dashes, etc
-        ascii_text = re.sub(r'[^A-z0-9 .,-]+', ' ', combined_output)
+        ascii_text = re.sub(r"[^A-z0-9 .,-]+", " ", combined_output)
         # remove any remnants of colour codes
-        without_escape_codes = re.sub(r'\[\d+m', ' ', ascii_text)
+        without_escape_codes = re.sub(r"\[\d+m", " ", ascii_text)
         # normalize spaces and convert to lower case
-        clean_text = ' '.join(without_escape_codes.split()).lower()
-        assert (
-            "does not exist" in clean_text
-            or "no such file" in clean_text
-        )
+        clean_text = " ".join(without_escape_codes.split()).lower()
+        assert "does not exist" in clean_text or "no such file" in clean_text
 
         # Test with the secret value not having a tag
         cmd = [
@@ -464,7 +461,9 @@ def test_cli_error_handling(mock_api_credentials):
 
         # It should mention using the tags
         combined_output = result.stderr + result.stdout
-        clean_text = ' '.join(re.sub(r'[^\x00-\x7F]+', ' ', combined_output).split()).lower()
+        clean_text = " ".join(
+            re.sub(r"[^\x00-\x7F]+", " ", combined_output).split()
+        ).lower()
         assert (
             "secrets must be tagged with !developer_secret or !user_secret"
             in clean_text

--- a/tests/cli/commands/test_configure.py
+++ b/tests/cli/commands/test_configure.py
@@ -7,7 +7,8 @@ from mcp_agent.cli.cloud.commands import configure_app
 from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.mcp_app.mock_client import (
     MOCK_APP_CONFIG_ID,
-    MOCK_APP_ID, MockMCPAppClient,
+    MOCK_APP_ID,
+    MockMCPAppClient,
 )
 
 

--- a/tests/cli/commands/test_deploy_command.py
+++ b/tests/cli/commands/test_deploy_command.py
@@ -62,11 +62,11 @@ def test_deploy_command_help(runner):
     assert result.exit_code == 0
 
     # remove all lines, dashes, etc
-    ascii_text = re.sub(r'[^A-z0-9.,-]+', '', result.stdout)
+    ascii_text = re.sub(r"[^A-z0-9.,-]+", "", result.stdout)
     # remove any remnants of colour codes
-    without_escape_codes = re.sub(r'\[[0-9 ]+m', '', ascii_text)
+    without_escape_codes = re.sub(r"\[[0-9 ]+m", "", ascii_text)
     # normalize spaces and convert to lower case
-    clean_text = ' '.join(without_escape_codes.split()).lower()
+    clean_text = " ".join(without_escape_codes.split()).lower()
 
     # Expected options from the updated CLAUDE.md spec
     assert "--config-dir" in clean_text or "-c" in clean_text
@@ -131,7 +131,9 @@ def test_deploy_command_basic(runner, temp_config_dir):
 def test_deploy_command_no_secrets(runner, temp_config_dir):
     """Test deploy command with --no-secrets flag when a secrets file DOES NOT exist."""
     # Run with --no-secrets flag and --dry-run to avoid real deployment
-    with patch("mcp_agent.cli.cloud.commands.deploy.main.wrangler_deploy") as mock_deploy:
+    with patch(
+        "mcp_agent.cli.cloud.commands.deploy.main.wrangler_deploy"
+    ) as mock_deploy:
         # Mock the wrangler deployment
         mock_deploy.return_value = None
 
@@ -162,7 +164,9 @@ def test_deploy_command_no_secrets(runner, temp_config_dir):
 def test_deploy_command_no_secrets_with_existing_secrets(runner, temp_config_dir):
     """Test deploy command with --no-secrets flag when a secrets file DOES exist."""
     # Run with --no-secrets flag and --dry-run to avoid real deployment
-    with patch("mcp_agent.cli.cloud.commands.deploy.main.wrangler_deploy") as mock_deploy:
+    with patch(
+        "mcp_agent.cli.cloud.commands.deploy.main.wrangler_deploy"
+    ) as mock_deploy:
         # Mock the wrangler deployment
         mock_deploy.return_value = None
 
@@ -292,7 +296,9 @@ def test_rollback_secrets_file(temp_config_dir):
         pre_deploy_secrets_content = f.read()
 
     # Call deploy_config with wrangler_deploy mocked
-    with patch("mcp_agent.cli.cloud.commands.deploy.main.wrangler_deploy") as mock_deploy:
+    with patch(
+        "mcp_agent.cli.cloud.commands.deploy.main.wrangler_deploy"
+    ) as mock_deploy:
         # Mock wrangler_deploy to prevent actual deployment
         mock_deploy.side_effect = Exception("Deployment failed")
 

--- a/tests/cli/utils/jwt_generator.py
+++ b/tests/cli/utils/jwt_generator.py
@@ -206,5 +206,6 @@ def generate_test_token():
         expiry_days=365,
     )
 
+
 if __name__ == "__main__":
     main()

--- a/tests/logging/test_upstream_logging.py
+++ b/tests/logging/test_upstream_logging.py
@@ -1,0 +1,79 @@
+import asyncio
+import pytest
+
+from types import SimpleNamespace
+
+from mcp_agent.logging.logger import LoggingConfig, get_logger
+from mcp_agent.logging.events import EventFilter
+from mcp_agent.logging.transport import AsyncEventBus
+
+
+class DummyUpstreamSession:
+    def __init__(self):
+        self.calls = []
+
+    async def send_log_message(self, level, data, logger, related_request_id=None):
+        self.calls.append(
+            {
+                "level": level,
+                "data": data,
+                "logger": logger,
+                "related_request_id": related_request_id,
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_upstream_logging_listener_sends_notifications(monkeypatch):
+    # Ensure clean bus state
+    AsyncEventBus.reset()
+
+    dummy_session = DummyUpstreamSession()
+
+    # Monkeypatch get_current_context to return an object with upstream_session
+    def _fake_get_current_context():
+        return SimpleNamespace(upstream_session=dummy_session)
+
+    monkeypatch.setattr(
+        "mcp_agent.core.context.get_current_context", _fake_get_current_context
+    )
+
+    # Configure logging with low threshold so our event passes
+    await LoggingConfig.configure(event_filter=EventFilter(min_level="debug"))
+
+    try:
+        logger = get_logger("tests.logging")
+        logger.info("hello world", name="unit", foo="bar")
+
+        # Give the async bus a moment to process
+        await asyncio.sleep(0.05)
+
+        assert len(dummy_session.calls) >= 1
+        call = dummy_session.calls[-1]
+        assert call["level"] in ("info", "debug", "warning", "error")
+        assert call["logger"].startswith("tests.logging")
+        # Ensure our message and custom data are included
+        data = call["data"]
+        assert data.get("message") == "hello world"
+        assert data.get("data", {}).get("foo") == "bar"
+    finally:
+        await LoggingConfig.shutdown()
+        AsyncEventBus.reset()
+
+
+@pytest.mark.asyncio
+async def test_logging_capability_registered_in_fastmcp():
+    # Import here to avoid heavy imports at module import time
+    from mcp_agent.app import MCPApp
+    from mcp_agent.server.app_server import create_mcp_server_for_app
+    import mcp.types as types
+
+    app = MCPApp(name="test_app")
+    mcp = create_mcp_server_for_app(app)
+
+    low = getattr(mcp, "_mcp_server", None)
+    assert low is not None
+
+    # The presence of a SetLevelRequest handler indicates logging capability will be advertised
+    assert types.SetLevelRequest in low.request_handlers
+

--- a/tests/server/test_app_server_workflow_schema.py
+++ b/tests/server/test_app_server_workflow_schema.py
@@ -1,0 +1,59 @@
+import json
+import pytest
+from types import SimpleNamespace
+
+from mcp_agent.app import MCPApp
+from mcp_agent.executor.workflow import Workflow, WorkflowResult
+from mcp_agent.server.app_server import create_workflow_tools
+
+
+class _ToolRecorder:
+    def __init__(self):
+        self.decorated = []
+
+    def tool(self, *args, **kwargs):
+        name = kwargs.get("name", args[0] if args else None)
+
+        def _decorator(func):
+            self.decorated.append((name, func, kwargs))
+            return func
+
+        return _decorator
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_schema_strips_self_and_uses_param_annotations():
+    app = MCPApp(name="schema_app")
+    await app.initialize()
+
+    @app.workflow
+    class MyWF(Workflow[str]):
+        """Doc for MyWF"""
+
+        @app.workflow_run
+        async def run(self, q: int, flag: bool = False) -> WorkflowResult[str]:
+            return WorkflowResult(value=f"{q}:{flag}")
+
+    mcp = _ToolRecorder()
+    server_context = SimpleNamespace(workflows=app.workflows, context=app.context)
+
+    # This should create per-workflow tools; run tool must be built from run signature
+    create_workflow_tools(mcp, server_context)
+
+    # Find the "workflows-MyWF-run" tool and inspect its parameters schema via FastMCP
+    names = [name for name, *_ in mcp.decorated]
+    assert f"workflows-MyWF-run" in names
+
+    # We can’t call FastTool.from_function here since the tool is already created inside create_workflow_tools,
+    # but we can at least ensure that the schema text embedded in the description JSON includes our parameters (q, flag)
+    # Description contains a pretty-printed JSON of parameters; locate and parse it
+    run_entry = next(
+        (entry for entry in mcp.decorated if entry[0] == "workflows-MyWF-run"), None
+    )
+    assert run_entry is not None
+    _, _, kwargs = run_entry
+    desc = kwargs.get("description", "")
+    # The description embeds the JSON schema; assert basic fields are referenced
+    assert "q" in desc
+    assert "flag" in desc
+    assert "self" not in desc

--- a/tests/server/test_app_server_workflow_schema.py
+++ b/tests/server/test_app_server_workflow_schema.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 from types import SimpleNamespace
 
@@ -42,7 +41,7 @@ async def test_workflow_run_schema_strips_self_and_uses_param_annotations():
 
     # Find the "workflows-MyWF-run" tool and inspect its parameters schema via FastMCP
     names = [name for name, *_ in mcp.decorated]
-    assert f"workflows-MyWF-run" in names
+    assert "workflows-MyWF-run" in names
 
     # We can’t call FastTool.from_function here since the tool is already created inside create_workflow_tools,
     # but we can at least ensure that the schema text embedded in the description JSON includes our parameters (q, flag)

--- a/tests/server/test_tool_decorators.py
+++ b/tests/server/test_tool_decorators.py
@@ -130,7 +130,7 @@ async def test_app_async_tool_registers_aliases_and_workflow_tools():
 
     # async aliases only (we suppress workflows-* for async auto tools)
     assert "long-async-run" in decorated_names
-    assert "long-async-get_status" in decorated_names
+    assert "long-get_status" in decorated_names
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_tool_decorators.py
+++ b/tests/server/test_tool_decorators.py
@@ -1,0 +1,173 @@
+import asyncio
+import pytest
+
+from mcp_agent.app import MCPApp
+from mcp_agent.server.app_server import (
+    create_workflow_tools,
+    create_declared_function_tools,
+    _workflow_run,
+    _workflow_status,
+)
+
+
+class _ToolRecorder:
+    """Helper to record tools registered via FastMCP-like interface."""
+
+    def __init__(self):
+        self.decorated_tools = []  # via mcp.tool decorator (workflow endpoints)
+        self.added_tools = []  # via mcp.add_tool (sync @app.tool)
+
+    def tool(self, *args, **kwargs):
+        name = kwargs.get("name", args[0] if args else None)
+
+        def _decorator(func):
+            self.decorated_tools.append((name, func))
+            return func
+
+        return _decorator
+
+    def add_tool(
+        self,
+        fn,
+        *,
+        name=None,
+        title=None,
+        description=None,
+        annotations=None,
+        structured_output=None,
+    ):
+        self.added_tools.append((name, fn, description, structured_output))
+
+
+def _make_ctx(server_context):
+    # Minimal fake MCPContext with request_context.lifespan_context
+    from types import SimpleNamespace
+
+    ctx = SimpleNamespace()
+    # Ensure a workflow registry is available for status waits
+    if not hasattr(server_context, "workflow_registry"):
+        from mcp_agent.executor.workflow_registry import InMemoryWorkflowRegistry
+
+        server_context.workflow_registry = InMemoryWorkflowRegistry()
+
+    req = SimpleNamespace(lifespan_context=server_context)
+    ctx.request_context = req
+    ctx.fastmcp = SimpleNamespace(_mcp_agent_app=None)
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_app_tool_registers_and_executes_sync_tool():
+    app = MCPApp(name="test_app_tool")
+    await app.initialize()
+
+    @app.tool(name="echo", description="Echo input")
+    async def echo(text: str) -> str:
+        return text + "!"
+
+    # Prepare mock FastMCP and server context
+    mcp = _ToolRecorder()
+    server_context = type(
+        "SC", (), {"workflows": app.workflows, "context": app.context}
+    )()
+
+    # Register generated per-workflow tools and function-declared tools
+    create_workflow_tools(mcp, server_context)
+    create_declared_function_tools(mcp, server_context)
+
+    # Verify tool names: sync tool and its status tool
+    decorated_names = {name for name, _ in mcp.decorated_tools}
+    added_names = {name for name, *_ in mcp.added_tools}
+
+    # No workflows-* for sync tools; check echo and echo-get_status
+    assert "echo" in added_names  # synchronous tool
+    assert "echo-get_status" in decorated_names
+
+    # Execute the synchronous tool function and ensure it returns unwrapped value
+    # Find the registered sync tool function
+    sync_tool_fn = next(fn for name, fn, *_ in mcp.added_tools if name == "echo")
+    ctx = _make_ctx(server_context)
+    result = await sync_tool_fn(text="hi", ctx=ctx)
+    assert result == "hi!"  # unwrapped (not WorkflowResult)
+
+    # Also ensure the underlying workflow returned a WorkflowResult
+    # Start via workflow_run to get run_id, then wait for completion and inspect
+    run_info = await _workflow_run(ctx, "echo", {"text": "ok"})
+    run_id = run_info["run_id"]
+    # Poll status until completed (bounded wait)
+    for _ in range(200):
+        status = await _workflow_status(ctx, run_id, "echo")
+        if status.get("completed"):
+            break
+        await asyncio.sleep(0.01)
+    assert status.get("completed") is True
+    # The recorded result is a WorkflowResult model dump; check value field
+    result_payload = status.get("result")
+    if isinstance(result_payload, dict) and "value" in result_payload:
+        assert result_payload["value"] == "ok!"
+    else:
+        assert result_payload in ("ok!", {"result": "ok!"})
+
+
+@pytest.mark.asyncio
+async def test_app_async_tool_registers_aliases_and_workflow_tools():
+    app = MCPApp(name="test_app_async_tool")
+    await app.initialize()
+
+    @app.async_tool(name="long")
+    async def long_task(x: int) -> str:
+        return f"done:{x}"
+
+    mcp = _ToolRecorder()
+    server_context = type(
+        "SC", (), {"workflows": app.workflows, "context": app.context}
+    )()
+
+    create_workflow_tools(mcp, server_context)
+    create_declared_function_tools(mcp, server_context)
+
+    decorated_names = {name for name, _ in mcp.decorated_tools}
+
+    # async aliases only (we suppress workflows-* for async auto tools)
+    assert "long-async-run" in decorated_names
+    assert "long-async-get_status" in decorated_names
+
+
+@pytest.mark.asyncio
+async def test_auto_workflow_wraps_plain_return_in_workflowresult():
+    app = MCPApp(name="test_wrap")
+    await app.initialize()
+
+    @app.async_tool(name="wrapme")
+    async def wrapme(v: int) -> int:
+        # plain int, should be wrapped inside WorkflowResult internally
+        return v + 1
+
+    mcp = _ToolRecorder()
+    server_context = type(
+        "SC", (), {"workflows": app.workflows, "context": app.context}
+    )()
+    create_workflow_tools(mcp, server_context)
+    create_declared_function_tools(mcp, server_context)
+
+    ctx = _make_ctx(server_context)
+    run_info = await _workflow_run(ctx, "wrapme", {"v": 41})
+    run_id = run_info["run_id"]
+
+    # Inspect workflow's task result type by polling status for completion
+    for _ in range(100):
+        status = await _workflow_status(ctx, run_id, "wrapme")
+        if status.get("completed"):
+            break
+        await asyncio.sleep(0.01)
+    assert status.get("completed") is True
+
+    # Cross-check that the underlying run returned a WorkflowResult by re-running via registry path
+    # We can't import the internal task here; assert observable effect: result equals expected and no exceptions
+    assert status.get("error") in (None, "")
+    # And the computed value was correct
+    result_payload = status.get("result")
+    if isinstance(result_payload, dict) and "value" in result_payload:
+        assert result_payload["value"] == 42
+    else:
+        assert result_payload in (42, {"result": 42})


### PR DESCRIPTION
MCP models logging via the `notifications/message` messages: https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging

We leverage this so that when an agent is set up as an MCP server, the logger emits notification messages back to the upstream client. 

Note: currently this will work for asyncio execution mode. Additional work is necessary for it to work in a Temporal context, which @roman-van-der-krogt  is tackling as part of #386 