### PR TITLE
Fix Azure user parameter handling in request_completion_task

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_azure.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_azure.py
@@ -539,12 +539,20 @@ class AzureCompletionTasks:
                 ),
             )
 
-        payload = request.payload
+        payload = request.payload.copy()
+        # Remove user from kwargs - Azure SDK expects it in request body, not as kwarg
+        user = payload.pop('user', None)
+        
         # Offload sync SDK call to a thread to avoid blocking the event loop
         loop = asyncio.get_running_loop()
-        response = await loop.run_in_executor(
-            None, functools.partial(azure_client.complete, **payload)
-        )
+        if user:
+            response = await loop.run_in_executor(
+                None, functools.partial(azure_client.complete, user=user, **payload)
+            )
+        else:
+            response = await loop.run_in_executor(
+                None, functools.partial(azure_client.complete, **payload)
+            )
         return response
 
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the user parameter was not being properly transmitted to Azure OpenAI API calls.

## Changes

- Modified `AzureCompletionTasks.request_completion_task()` to properly extract the user parameter from the payload
- Pass user parameter as a separate kwarg to `azure_client.complete()` instead of including it in the payload
- Ensures user parameter is handled according to Azure SDK expectations

## Technical Details

The Azure SDK expects the `user` parameter to be passed as a keyword argument to the `complete()` method, not as part of the request payload. This change:

1. Extracts the user parameter from the payload using `payload.pop('user', None)`
2. Passes it separately as `user=user` kwarg when calling `azure_client.complete()`

## Related

- Related to issue #393 where custom parameters need proper handling in Azure requests
- Builds upon the user parameter support added in previous PR #394

## Testing

This fix ensures that user attribution works correctly for Azure OpenAI API calls when the user parameter is provided via RequestParams or Azure config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures user context is sent correctly to Azure, improving accuracy and auditability.
  * Prevents unintended payload mutations that could affect subsequent requests.
* **Performance**
  * Improves responsiveness by executing Azure requests in a background thread, reducing blocking during LLM operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->