### PR TITLE
Break unnecessary Temporal dependency in Workflow and Executor

### DIFF
--- a/src/mcp_agent/executor/workflow_signal.py
+++ b/src/mcp_agent/executor/workflow_signal.py
@@ -1,13 +1,15 @@
 import asyncio
 import uuid
 from abc import abstractmethod, ABC
-from typing import Any, Callable, Dict, Generic, List, Protocol, TypeVar
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Generic, List, Optional, Protocol, TypeVar
 
 from pydantic import BaseModel, ConfigDict
+from mcp_agent.logging.logger import get_logger
 
 SignalValueT = TypeVar("SignalValueT")
 
-# TODO: saqadri - handle signals properly that works with other execution backends like Temporal as well
+logger = get_logger(__name__)
 
 
 class Signal(BaseModel, Generic[SignalValueT]):
@@ -93,6 +95,62 @@ class PendingSignal(BaseModel):
     value: SignalValueT | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+@dataclass(slots=True)
+class _Record(Generic[SignalValueT]):
+    """Record for tracking signal values with versioning for broadcast semantics"""
+
+    value: Optional[SignalValueT] = None
+    version: int = 0  # monotonic counter
+
+
+class SignalMailbox(Generic[SignalValueT]):
+    """
+    Deterministic broadcast mailbox that stores signal values with versioning.
+    Each workflow run has its own mailbox instance.
+    """
+
+    def __init__(self) -> None:
+        self._store: Dict[str, _Record[SignalValueT]] = {}
+
+    def push(self, name: str, value: SignalValueT) -> None:
+        """
+        Store a signal value and increment its version counter.
+        This enables broadcast semantics where all waiters see the same value.
+        """
+        rec = self._store.setdefault(name, _Record())
+        rec.value = value
+        rec.version += 1
+
+        logger.debug(
+            f"SignalMailbox.push: name={name}, value={value}, version={rec.version}"
+        )
+
+    def version(self, name: str) -> int:
+        """Get the current version counter for a signal name"""
+        return self._store.get(name, _Record()).version
+
+    def value(self, name: str) -> SignalValueT:
+        """
+        Get the current value for a signal name
+
+        Returns:
+            The signal value
+
+        Raises:
+            ValueError: If no value exists for the signal
+        """
+        value = self._store.get(name, _Record()).value
+
+        if value is None:
+            raise ValueError(f"No value for signal {name}")
+
+        logger.debug(
+            f"SignalMailbox.value: name={name}, value={value}, version={self._store.get(name, _Record()).version}"
+        )
+
+        return value
 
 
 class BaseSignalHandler(ABC, Generic[SignalValueT]):

--- a/tests/executor/temporal/test_signal_handler.py
+++ b/tests/executor/temporal/test_signal_handler.py
@@ -1,10 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
-from mcp_agent.executor.temporal.workflow_signal import (
-    TemporalSignalHandler,
-    SignalMailbox,
-)
-from mcp_agent.executor.workflow_signal import Signal
+from mcp_agent.executor.temporal.workflow_signal import TemporalSignalHandler
+from mcp_agent.executor.workflow_signal import Signal, SignalMailbox
 
 
 @pytest.fixture


### PR DESCRIPTION
This dependency was erroneously introduced when we added `SignalMailbox` for workflow signaling support. 

Fixes #391