### PR TITLE
[WIP] notifications via proxy

### DIFF
--- a/src/mcp_agent/executor/temporal/__init__.py
+++ b/src/mcp_agent/executor/temporal/__init__.py
@@ -32,6 +32,7 @@ from temporalio.worker import Worker
 
 from mcp_agent.config import TemporalSettings
 from mcp_agent.executor.executor import Executor, ExecutorConfig, R
+from mcp_agent.executor.temporal.context_propagation_interceptor import ContextPropagationInterceptor
 from mcp_agent.executor.temporal.workflow_signal import TemporalSignalHandler
 from mcp_agent.executor.workflow_signal import SignalHandler
 from mcp_agent.logging.logger import get_logger
@@ -263,9 +264,12 @@ class TemporalExecutor(Executor):
                 api_key=self.config.api_key,
                 tls=self.config.tls,
                 data_converter=pydantic_data_converter,
-                interceptors=[TracingInterceptor()]
+                interceptors=[
+                    TracingInterceptor(),
+                    ContextPropagatorInterceptor(),
+                ]
                 if self.context.tracing_enabled
-                else [],
+                else [ContextPropagatorInterceptor(),
                 rpc_metadata=self.config.rpc_metadata or {},
             )
 

--- a/src/mcp_agent/executor/temporal/context_propagation_interceptor.py
+++ b/src/mcp_agent/executor/temporal/context_propagation_interceptor.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Mapping, Protocol, Type
+
+import temporalio.activity
+import temporalio.api.common.v1
+import temporalio.client
+import temporalio.converter
+import temporalio.worker
+import temporalio.workflow
+
+from mcp_agent.executor.temporal.temporal_context import (
+    EXECUTION_ID_KEY,
+    PROXY_URL_KEY,
+    execution_id,
+    proxy_url,
+)
+
+
+class _InputWithHeaders(Protocol):
+    headers: Mapping[str, temporalio.api.common.v1.Payload]
+
+
+def set_header_from_context(
+    input: _InputWithHeaders, payload_converter: temporalio.converter.PayloadConverter
+) -> None:
+    mcp_id_val = execution_id.get()
+    proxy_url_val = proxy_url.get()
+
+    if mcp_id_val and proxy_url_val:
+        input.headers = {
+            **input.headers,
+            EXECUTION_ID_KEY: payload_converter.to_payload(mcp_id_val),
+            PROXY_URL_KEY: payload_converter.to_payload(proxy_url_val),
+        }
+    elif mcp_id_val:
+        input.headers = {
+            **input.headers,
+            EXECUTION_ID_KEY: payload_converter.to_payload(mcp_id_val),
+        }
+    elif proxy_url_val:
+        input.headers = {
+            **input.headers,
+            PROXY_URL_KEY: payload_converter.to_payload(proxy_url_val),
+        }
+
+
+@contextmanager
+def context_from_header(
+    input: _InputWithHeaders, payload_converter: temporalio.converter.PayloadConverter
+):
+    execution_payload = input.headers.get(EXECUTION_ID_KEY)
+    execution_id_from_header = (
+        payload_converter.from_payload(execution_payload, str)
+        if execution_payload
+        else None
+    )
+    execution_token = (
+        execution_id.set(execution_id_from_header) if execution_id_from_header else None
+    )
+    proxy_payload = input.headers.get(PROXY_URL_KEY)
+    proxy_url_from_header = (
+        payload_converter.from_payload(proxy_payload, str) if proxy_payload else None
+    )
+    proxy_token = (
+        proxy_url.set(proxy_url_from_header) if proxy_url_from_header else None
+    )
+
+    try:
+        yield
+    finally:
+        if execution_token:
+            execution_id.reset(execution_token)
+        if proxy_token:
+            proxy_url.reset(proxy_token)
+
+
+class ContextPropagationInterceptor(
+    temporalio.client.Interceptor, temporalio.worker.Interceptor
+):
+    """Interceptor that propagates a value through client, workflow and activity calls.
+
+    This interceptor implements methods `temporalio.client.Interceptor` and  `temporalio.worker.Interceptor` so that
+
+    (1) a user ID key is taken from context by the client code and sent in a header field with outbound requests
+    (2) workflows take this value from their task input, set it in context, and propagate it into the header field of
+        their outbound calls
+    (3) activities similarly take the value from their task input and set it in context so that it's available for their
+        outbound calls
+    """
+
+    def __init__(
+        self,
+        payload_converter: temporalio.converter.PayloadConverter = temporalio.converter.default().payload_converter,
+    ) -> None:
+        self._payload_converter = payload_converter
+
+    def intercept_client(
+        self, next: temporalio.client.OutboundInterceptor
+    ) -> temporalio.client.OutboundInterceptor:
+        return _ContextPropagationClientOutboundInterceptor(
+            next, self._payload_converter
+        )
+
+    def intercept_activity(
+        self, next: temporalio.worker.ActivityInboundInterceptor
+    ) -> temporalio.worker.ActivityInboundInterceptor:
+        return _ContextPropagationActivityInboundInterceptor(next)
+
+    def workflow_interceptor_class(
+        self, input: temporalio.worker.WorkflowInterceptorClassInput
+    ) -> Type[_ContextPropagationWorkflowInboundInterceptor]:
+        return _ContextPropagationWorkflowInboundInterceptor
+
+
+class _ContextPropagationClientOutboundInterceptor(
+    temporalio.client.OutboundInterceptor
+):
+    def __init__(
+        self,
+        next: temporalio.client.OutboundInterceptor,
+        payload_converter: temporalio.converter.PayloadConverter,
+    ) -> None:
+        super().__init__(next)
+        self._payload_converter = payload_converter
+
+    async def start_workflow(
+        self, input: temporalio.client.StartWorkflowInput
+    ) -> temporalio.client.WorkflowHandle[Any, Any]:
+        set_header_from_context(input, self._payload_converter)
+        return await super().start_workflow(input)
+
+    async def query_workflow(self, input: temporalio.client.QueryWorkflowInput) -> Any:
+        set_header_from_context(input, self._payload_converter)
+        return await super().query_workflow(input)
+
+    async def signal_workflow(
+        self, input: temporalio.client.SignalWorkflowInput
+    ) -> None:
+        set_header_from_context(input, self._payload_converter)
+        await super().signal_workflow(input)
+
+    async def start_workflow_update(
+        self, input: temporalio.client.StartWorkflowUpdateInput
+    ) -> temporalio.client.WorkflowUpdateHandle[Any]:
+        set_header_from_context(input, self._payload_converter)
+        return await self.next.start_workflow_update(input)
+
+
+class _ContextPropagationActivityInboundInterceptor(
+    temporalio.worker.ActivityInboundInterceptor
+):
+    async def execute_activity(
+        self, input: temporalio.worker.ExecuteActivityInput
+    ) -> Any:
+        with context_from_header(input, temporalio.activity.payload_converter()):
+            return await self.next.execute_activity(input)
+
+
+class _ContextPropagationWorkflowInboundInterceptor(
+    temporalio.worker.WorkflowInboundInterceptor
+):
+    def init(self, outbound: temporalio.worker.WorkflowOutboundInterceptor) -> None:
+        self.next.init(_ContextPropagationWorkflowOutboundInterceptor(outbound))
+
+    async def execute_workflow(
+        self, input: temporalio.worker.ExecuteWorkflowInput
+    ) -> Any:
+        with context_from_header(input, temporalio.workflow.payload_converter()):
+            return await self.next.execute_workflow(input)
+
+    async def handle_signal(self, input: temporalio.worker.HandleSignalInput) -> None:
+        with context_from_header(input, temporalio.workflow.payload_converter()):
+            return await self.next.handle_signal(input)
+
+    async def handle_query(self, input: temporalio.worker.HandleQueryInput) -> Any:
+        with context_from_header(input, temporalio.workflow.payload_converter()):
+            return await self.next.handle_query(input)
+
+    def handle_update_validator(
+        self, input: temporalio.worker.HandleUpdateInput
+    ) -> None:
+        with context_from_header(input, temporalio.workflow.payload_converter()):
+            self.next.handle_update_validator(input)
+
+    async def handle_update_handler(
+        self, input: temporalio.worker.HandleUpdateInput
+    ) -> Any:
+        with context_from_header(input, temporalio.workflow.payload_converter()):
+            return await self.next.handle_update_handler(input)
+
+
+class _ContextPropagationWorkflowOutboundInterceptor(
+    temporalio.worker.WorkflowOutboundInterceptor
+):
+    async def signal_child_workflow(
+        self, input: temporalio.worker.SignalChildWorkflowInput
+    ) -> None:
+        set_header_from_context(input, temporalio.workflow.payload_converter())
+        return await self.next.signal_child_workflow(input)
+
+    async def signal_external_workflow(
+        self, input: temporalio.worker.SignalExternalWorkflowInput
+    ) -> None:
+        set_header_from_context(input, temporalio.workflow.payload_converter())
+        return await self.next.signal_external_workflow(input)
+
+    def start_activity(
+        self, input: temporalio.worker.StartActivityInput
+    ) -> temporalio.workflow.ActivityHandle:
+        set_header_from_context(input, temporalio.workflow.payload_converter())
+        return self.next.start_activity(input)
+
+    async def start_child_workflow(
+        self, input: temporalio.worker.StartChildWorkflowInput
+    ) -> temporalio.workflow.ChildWorkflowHandle:
+        set_header_from_context(input, temporalio.workflow.payload_converter())
+        return await self.next.start_child_workflow(input)
+
+    def start_local_activity(
+        self, input: temporalio.worker.StartLocalActivityInput
+    ) -> temporalio.workflow.ActivityHandle:
+        set_header_from_context(input, temporalio.workflow.payload_converter())
+        return self.next.start_local_activity(input)

--- a/src/mcp_agent/executor/temporal/temporal_context.py
+++ b/src/mcp_agent/executor/temporal/temporal_context.py
@@ -1,0 +1,8 @@
+from contextvars import ContextVar
+from typing import Optional
+
+EXECUTION_ID_KEY = "__execution_id"
+PROXY_URL_KEY = "__proxy_url"
+
+execution_id: ContextVar[Optional[str]] = ContextVar("execution_id", default=None)
+proxy_url: ContextVar[Optional[str]] = ContextVar("proxy_url", default=None)


### PR DESCRIPTION
- Added an interceptor that adds headers to temporal calls passing the proxy url as well as a unique id for the mcp client we need to use to forward the messages to
- the unique id is created when we run a workflow. (We can't use the run_id, as temporal's retries will result in new run_ids)
- in the logger, if we have proxy configured, forward to the proxy via a simple REST POST call
- in the app server, add a custom route that accepts a notification and forwards it to the correct mcp client, based on the unique id we had assigned to the workflow

WIP: need to confirm this working in its current state (I extracted the interceptor and some of the proxy code from my sampling work, may have missed something) and fix any linting/test issues.