### PR TITLE
First pass at implementing the mcp-agent CLI

### DIFF
--- a/LLMS.txt
+++ b/LLMS.txt
@@ -1766,7 +1766,7 @@ Provides both global fallback and instance-specific context support.
 
 **Class: `MCPAgentError`**
 - **Inherits from**: Exception
-- **Description**: Base exception class for FastAgent errors
+-- **Description**: Base exception class for agent errors
 
 **Class: `ServerConfigError`**
 - **Inherits from**: MCPAgentError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,9 +101,9 @@ dev = [
 ]
 
 [project.scripts]
-mcp-agent = "mcp_agent.cli.cloud.main:run"
-mcp_agent = "mcp_agent.cli.cloud.main:run"
-mcpagent = "mcp_agent.cli.cloud.main:run"
+mcp-agent = "mcp_agent.cli.main:run"
+mcp_agent = "mcp_agent.cli.main:run"
+mcpagent = "mcp_agent.cli.main:run"
 silsila = "mcp_agent.cli.cloud.main:run"
 prompt-server = "mcp_agent.mcp.prompts.__main__:main"
 

--- a/src/mcp_agent/cli/__main__.py
+++ b/src/mcp_agent/cli/__main__.py
@@ -1,0 +1,62 @@
+import sys
+
+from mcp_agent.cli.main import app
+
+
+GO_OPTIONS = {
+    "--npx",
+    "--uvx",
+    "--stdio",
+    "--url",
+    "--model",
+    "--models",
+    "--instruction",
+    "-i",
+    "--message",
+    "-m",
+    "--prompt-file",
+    "-p",
+    "--servers",
+    "--auth",
+    "--name",
+    "--config-path",
+    "-c",
+    "--script",
+}
+
+KNOWN = {
+    "go",
+    "check",
+    "chat",
+    "dev",
+    "invoke",
+    "serve",
+    "init",
+    "quickstart",
+    "config",
+    "keys",
+    "models",
+    "server",
+    "build",
+    "logs",
+    "doctor",
+    "configure",
+    "cloud",
+}
+
+
+def main():
+    if len(sys.argv) > 1:
+        first = sys.argv[1]
+        if first not in KNOWN:
+            for i, arg in enumerate(sys.argv[1:], 1):
+                if arg in GO_OPTIONS or any(
+                    arg.startswith(opt + "=") for opt in GO_OPTIONS
+                ):
+                    sys.argv.insert(i, "go")
+                    break
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_agent/cli/commands/__init__.py
+++ b/src/mcp_agent/cli/commands/__init__.py
@@ -5,7 +5,24 @@ Each module exposes a Typer app named `app` which is mounted by
 `mcp_agent.cli.main` under an appropriate command group.
 """
 
-from . import chat, dev, invoke, serve, init, quickstart, config, keys, models, server, build, logs, doctor, configure  # noqa: F401
+from . import (
+    chat,
+    dev,
+    invoke,
+    serve,
+    init,
+    quickstart,
+    config,
+    keys,
+    models,
+    server,
+    build,
+    logs,
+    doctor,
+    configure,
+    go,
+    check,
+)  # noqa: F401
 
 __all__ = [
     "chat",
@@ -22,6 +39,6 @@ __all__ = [
     "logs",
     "doctor",
     "configure",
+    "go",
+    "check",
 ]
-
-

--- a/src/mcp_agent/cli/commands/__init__.py
+++ b/src/mcp_agent/cli/commands/__init__.py
@@ -1,0 +1,27 @@
+"""
+Command group entrypoints for the mcp-agent CLI (non-cloud).
+
+Each module exposes a Typer app named `app` which is mounted by
+`mcp_agent.cli.main` under an appropriate command group.
+"""
+
+from . import chat, dev, invoke, serve, init, quickstart, config, keys, models, server, build, logs, doctor, configure  # noqa: F401
+
+__all__ = [
+    "chat",
+    "dev",
+    "invoke",
+    "serve",
+    "init",
+    "quickstart",
+    "config",
+    "keys",
+    "models",
+    "server",
+    "build",
+    "logs",
+    "doctor",
+    "configure",
+]
+
+

--- a/src/mcp_agent/cli/commands/build.py
+++ b/src/mcp_agent/cli/commands/build.py
@@ -1,19 +1,90 @@
 """
-Build preflight (scaffold).
+Build preflight: checks keys, servers, commands; writes manifest.
 """
 
 from __future__ import annotations
 
 import typer
 from rich.console import Console
+from mcp_agent.config import get_settings
+import json
+import shutil
+from pathlib import Path
+import socket
 
 
 app = typer.Typer(help="Preflight and bundle prep for deployment")
 console = Console()
 
 
+def _check_command(cmd: str) -> bool:
+    # Support npx/uvx wrappers always true if present
+    parts = cmd.split()
+    exe = parts[0]
+    return shutil.which(exe) is not None
+
+
+def _check_url(url: str, timeout: float = 2.0) -> bool:
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        host = parsed.hostname
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        if not host:
+            return False
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except Exception:
+        return False
+
+
 @app.callback(invoke_without_command=True)
 def build(check_only: bool = typer.Option(False, "--check-only")) -> None:
-    console.print(f"Build preflight (check_only={check_only}) - scaffold")
+    settings = get_settings()
+    ok = True
+    report = {
+        "providers": {},
+        "servers": {},
+    }
 
+    # Provider keys
+    provs = [
+        ("openai", getattr(settings, "openai", None), "api_key"),
+        ("anthropic", getattr(settings, "anthropic", None), "api_key"),
+        ("google", getattr(settings, "google", None), "api_key"),
+        ("azure", getattr(settings, "azure", None), "api_key"),
+        ("bedrock", getattr(settings, "bedrock", None), "aws_access_key_id"),
+    ]
+    for name, obj, keyfield in provs:
+        has = bool(getattr(obj, keyfield, None)) if obj else False
+        report["providers"][name] = {"configured": has}
 
+    # Servers preflight
+    servers = (settings.mcp.servers if settings.mcp else {}) or {}
+    for name, s in servers.items():
+        status = {"transport": s.transport}
+        if s.transport == "stdio":
+            status["command"] = s.command
+            status["command_found"] = bool(s.command and _check_command(s.command))
+            ok = ok and status["command_found"]
+        else:
+            status["url"] = s.url
+            status["reachable"] = bool(s.url and _check_url(s.url))
+            # Do not fail build if remote URL is not reachable from local dev
+        report["servers"][name] = status
+
+    # Emit manifest
+    out_dir = Path(".mcp-agent")
+    out_dir.mkdir(exist_ok=True)
+    manifest = out_dir / "manifest.json"
+    manifest.write_text(json.dumps(report, indent=2))
+    console.print(f"Wrote manifest: {manifest}")
+
+    if not check_only and not ok:
+        typer.secho(
+            "Preflight checks failed (missing commands)", err=True, fg=typer.colors.RED
+        )
+        raise typer.Exit(3)
+    if ok:
+        console.print("Preflight OK")

--- a/src/mcp_agent/cli/commands/build.py
+++ b/src/mcp_agent/cli/commands/build.py
@@ -1,0 +1,19 @@
+"""
+Build preflight (scaffold).
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+
+
+app = typer.Typer(help="Preflight and bundle prep for deployment")
+console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def build(check_only: bool = typer.Option(False, "--check-only")) -> None:
+    console.print(f"Build preflight (check_only={check_only}) - scaffold")
+
+

--- a/src/mcp_agent/cli/commands/chat.py
+++ b/src/mcp_agent/cli/commands/chat.py
@@ -1,40 +1,638 @@
 """
-Ephemeral REPL for quick iteration (scaffold).
+Ephemeral REPL and one-shot chat, supports multi-model fan-out.
+Maps "go" functionality to "chat" per the spec.
 """
 
 from __future__ import annotations
 
 import asyncio
-from typing import Optional
+from pathlib import Path
+from typing import List, Optional
 
 import typer
 from rich.console import Console
 
-from mcp_agent.app import MCPApp
+from mcp_agent.cli.core.utils import (
+    attach_stdio_servers,
+    attach_url_servers,
+    load_user_app,
+)
+from mcp_agent.cli.utils.url_parser import generate_server_configs, parse_server_urls
+from mcp_agent.workflows.factory import create_llm
+from mcp_agent.agents.agent import Agent
 
 
 app = typer.Typer(help="Ephemeral REPL for quick iteration")
 console = Console()
 
 
-@app.callback(invoke_without_command=True)
+async def _run_single_model(
+    *,
+    script: Path,
+    servers: Optional[List[str]],
+    url_servers,
+    stdio_servers,
+    model: Optional[str],
+    message: Optional[str],
+    prompt_file: Optional[Path],
+    agent_name: str,
+):
+    from mcp.types import TextContent
+    from mcp_agent.utils.prompt_message_multipart import PromptMessageMultipart
+
+    app_obj = load_user_app(script)
+    await app_obj.initialize()
+    attach_url_servers(app_obj, url_servers)
+    attach_stdio_servers(app_obj, stdio_servers)
+
+    async with app_obj.run():
+        provider = None
+        model_id = model
+        if model_id and ":" not in model_id and "." in model_id:
+            maybe_provider = model_id.split(".", 1)[0].lower()
+            if maybe_provider in {
+                "openai",
+                "anthropic",
+                "azure",
+                "google",
+                "bedrock",
+                "ollama",
+            }:
+                provider = maybe_provider
+        if model_id and ":" in model_id:
+            provider = model_id.split(":", 1)[0]
+
+        llm = create_llm(
+            agent_name=agent_name,
+            server_names=servers or [],
+            provider=(provider or "openai"),
+            model=model_id,
+            context=app_obj.context,
+        )
+
+        if message:
+            return await llm.generate_str(message)
+        if prompt_file:
+            text = prompt_file.read_text(encoding="utf-8")
+            multipart = [
+                PromptMessageMultipart(
+                    role="user", content=[TextContent(type="text", text=text)]
+                )
+            ]
+            msgs = []
+            for mp in multipart:
+                msgs.extend(mp.from_multipart())
+            return await llm.generate_str(msgs)
+        return "(no input)"
+
+
+@app.callback(invoke_without_command=True, no_args_is_help=False)
 def chat(
     name: Optional[str] = typer.Option(None, "--name"),
     model: Optional[str] = typer.Option(None, "--model"),
+    models: Optional[str] = typer.Option(None, "--models"),
     message: Optional[str] = typer.Option(None, "--message", "-m"),
+    prompt_file: Optional[Path] = typer.Option(None, "--prompt-file", "-p"),
+    servers_csv: Optional[str] = typer.Option(None, "--servers"),
+    urls: Optional[str] = typer.Option(None, "--url"),
+    auth: Optional[str] = typer.Option(None, "--auth"),
+    npx: Optional[str] = typer.Option(None, "--npx"),
+    uvx: Optional[str] = typer.Option(None, "--uvx"),
+    stdio: Optional[str] = typer.Option(None, "--stdio"),
+    script: Optional[Path] = typer.Option(Path("agent.py"), "--script"),
+    list_servers: bool = typer.Option(False, "--list-servers"),
+    list_tools: bool = typer.Option(False, "--list-tools"),
+    list_resources: bool = typer.Option(False, "--list-resources"),
+    server: Optional[str] = typer.Option(
+        None, "--server", help="Filter to a single server"
+    ),
 ) -> None:
-    """Minimal placeholder: starts MCPApp and exits; full REPL later."""
+    server_list = servers_csv.split(",") if servers_csv else None
 
-    async def _run():
-        app = MCPApp(name=name or "mcp-agent chat")
-        async with app.run():
-            if message:
-                # Placeholder: no LLM wired yet
-                console.print(message)
+    url_servers = None
+    if urls:
+        try:
+            parsed = parse_server_urls(urls, auth)
+            url_servers = generate_server_configs(parsed)
+            if url_servers and not server_list:
+                server_list = list(url_servers.keys())
+            elif url_servers and server_list:
+                server_list.extend(list(url_servers.keys()))
+        except ValueError as e:
+            typer.secho(f"Error parsing URLs: {e}", err=True, fg=typer.colors.RED)
+            raise typer.Exit(6)
 
+    stdio_servers = None
+    stdio_cmds: List[str] = []
+    if npx:
+        stdio_cmds.append(f"npx {npx}")
+    if uvx:
+        stdio_cmds.append(f"uvx {uvx}")
+    if stdio:
+        stdio_cmds.append(stdio)
+    if stdio_cmds:
+        from .go import _parse_stdio_commands
+
+        stdio_servers = _parse_stdio_commands(stdio_cmds)
+        if stdio_servers:
+            if not server_list:
+                server_list = list(stdio_servers.keys())
+            else:
+                server_list.extend(list(stdio_servers.keys()))
+
+    # Listing mode (no generation)
+    if list_servers or list_tools or list_resources:
+        try:
+
+            async def _list():
+                app_obj = load_user_app(script or Path("agent.py"))
+                await app_obj.initialize()
+                attach_url_servers(app_obj, url_servers)
+                attach_stdio_servers(app_obj, stdio_servers)
+                async with app_obj.run():
+                    cfg = app_obj.context.config
+                    all_servers = (
+                        list((cfg.mcp.servers or {}).keys()) if cfg.mcp else []
+                    )
+                    target_servers = [server] if server else all_servers
+                    if list_servers:
+                        for s in target_servers:
+                            console.print(s)
+                        if not (list_tools or list_resources):
+                            return
+                    agent = Agent(
+                        name="chat-lister",
+                        instruction="You list tools and resources",
+                        server_names=target_servers,
+                        context=app_obj.context,
+                    )
+                    async with agent:
+                        if list_tools:
+                            res = (
+                                await agent.list_tools(server_name=server)
+                                if server
+                                else await agent.list_tools()
+                            )
+                            for t in res.tools:
+                                console.print(t.name)
+                        if list_resources:
+                            res = (
+                                await agent.list_resources(server_name=server)
+                                if server
+                                else await agent.list_resources()
+                            )
+                            for r in getattr(res, "resources", []):
+                                try:
+                                    console.print(r.uri)
+                                except Exception:
+                                    console.print(str(getattr(r, "uri", "")))
+
+            asyncio.run(_list())
+        except KeyboardInterrupt:
+            pass
+        return
+
+    # Multi-model fan-out
+    if models:
+        model_list = [x.strip() for x in models.split(",") if x.strip()]
+        # Interactive multi-model REPL when no one-shot input
+        if (
+            not message
+            and not prompt_file
+            and not (list_servers or list_tools or list_resources)
+        ):
+
+            async def _parallel_repl():
+                app_obj = load_user_app(script or Path("agent.py"))
+                await app_obj.initialize()
+                attach_url_servers(app_obj, url_servers)
+                attach_stdio_servers(app_obj, stdio_servers)
+                async with app_obj.run():
+                    # Build one LLM per model
+                    llms = []
+                    for m in model_list:
+                        provider = None
+                        if ":" in m:
+                            provider = m.split(":", 1)[0]
+                        elif "." in m:
+                            prov_guess = m.split(".", 1)[0].lower()
+                            if prov_guess in {
+                                "openai",
+                                "anthropic",
+                                "azure",
+                                "google",
+                                "bedrock",
+                                "ollama",
+                            }:
+                                provider = prov_guess
+                        llm = create_llm(
+                            agent_name=m,
+                            server_names=server_list or [],
+                            provider=(provider or "openai"),
+                            model=m,
+                            context=app_obj.context,
+                        )
+                        llms.append(llm)
+
+                    console.print(
+                        "Interactive parallel chat. Commands: /help, /servers, /tools [server], /resources [server], /usage, /quit"
+                    )
+                    from mcp_agent.agents.agent import Agent as _Agent
+
+                    while True:
+                        try:
+                            inp = input("> ")
+                        except (EOFError, KeyboardInterrupt):
+                            break
+                        if not inp:
+                            continue
+                        if inp.startswith("/quit"):
+                            break
+                        if inp.startswith("/help"):
+                            console.print(
+                                "/servers, /tools [server], /resources [server], /usage, /quit"
+                            )
+                            continue
+                        if inp.startswith("/servers"):
+                            cfg = app_obj.context.config
+                            svrs = (
+                                list((cfg.mcp.servers or {}).keys()) if cfg.mcp else []
+                            )
+                            for s in svrs:
+                                console.print(s)
+                            continue
+                        if inp.startswith("/tools"):
+                            parts = inp.split()
+                            srv = parts[1] if len(parts) > 1 else None
+                            ag = _Agent(
+                                name="chat-lister",
+                                instruction="list tools",
+                                server_names=[srv] if srv else (server_list or []),
+                                context=app_obj.context,
+                            )
+                            async with ag:
+                                res = (
+                                    await ag.list_tools(server_name=srv)
+                                    if srv
+                                    else await ag.list_tools()
+                                )
+                                for t in res.tools:
+                                    console.print(t.name)
+                            continue
+                        if inp.startswith("/resources"):
+                            parts = inp.split()
+                            srv = parts[1] if len(parts) > 1 else None
+                            ag = _Agent(
+                                name="chat-lister",
+                                instruction="list resources",
+                                server_names=[srv] if srv else (server_list or []),
+                                context=app_obj.context,
+                            )
+                            async with ag:
+                                res = (
+                                    await ag.list_resources(server_name=srv)
+                                    if srv
+                                    else await ag.list_resources()
+                                )
+                                for r in getattr(res, "resources", []):
+                                    try:
+                                        console.print(r.uri)
+                                    except Exception:
+                                        console.print(str(getattr(r, "uri", "")))
+                            continue
+                        if inp.startswith("/usage"):
+                            try:
+                                # Show per-model token usage if available
+                                any_shown = False
+                                for llm in llms:
+                                    try:
+                                        usage = await llm.get_token_usage()
+                                        if usage:
+                                            console.print(f"{llm.name}: {usage}")
+                                            any_shown = True
+                                    except Exception:
+                                        continue
+                                if not any_shown:
+                                    tc = getattr(app_obj.context, "token_counter", None)
+                                    if tc:
+                                        summary = await tc.get_summary()
+                                        console.print(
+                                            summary.model_dump()
+                                            if hasattr(summary, "model_dump")
+                                            else summary
+                                        )
+                            except Exception:
+                                console.print("(no usage)")
+                            continue
+
+                        # Broadcast input to all models and print results
+                        try:
+
+                            async def _gen(l):
+                                try:
+                                    return l.name, await l.generate_str(inp)
+                                except Exception as e:
+                                    return l.name, f"ERROR: {e}"
+
+                            results = await asyncio.gather(*[_gen(l) for l in llms])
+                            for model_name, out in results:
+                                console.print(f"\n[bold]{model_name}[/bold]:\n{out}")
+                            console.print()
+                        except Exception as e:
+                            console.print(f"ERROR: {e}")
+
+            asyncio.run(_parallel_repl())
+            return
+
+        # One-shot multi-model
+        results = []
+        for m in model_list:
+            try:
+                out = asyncio.run(
+                    _run_single_model(
+                        script=script or Path("agent.py"),
+                        servers=server_list,
+                        url_servers=url_servers,
+                        stdio_servers=stdio_servers,
+                        model=m,
+                        message=message,
+                        prompt_file=prompt_file,
+                        agent_name=name or m,
+                    )
+                )
+                results.append((m, out))
+            except Exception as e:
+                results.append((m, f"ERROR: {e}"))
+        for m, out in results:
+            console.print(f"\n[bold]{m}[/bold]:\n{out}")
+        return
+
+    # Single model path
     try:
-        asyncio.run(_run())
+        if (
+            not message
+            and not prompt_file
+            and not models
+            and not (list_servers or list_tools or list_resources)
+        ):
+            # Interactive loop
+            async def _repl():
+                app_obj = load_user_app(script or Path("agent.py"))
+                await app_obj.initialize()
+                attach_url_servers(app_obj, url_servers)
+                attach_stdio_servers(app_obj, stdio_servers)
+                async with app_obj.run():
+                    provider = None
+                    model_id = model
+                    if model_id and ":" not in model_id and "." in model_id:
+                        maybe_provider = model_id.split(".", 1)[0].lower()
+                        if maybe_provider in {
+                            "openai",
+                            "anthropic",
+                            "azure",
+                            "google",
+                            "bedrock",
+                            "ollama",
+                        }:
+                            provider = maybe_provider
+                    if model_id and ":" in model_id:
+                        provider = model_id.split(":", 1)[0]
+                    llm = create_llm(
+                        agent_name=(name or "chat"),
+                        server_names=server_list or [],
+                        provider=(provider or "openai"),
+                        model=model_id,
+                        context=app_obj.context,
+                    )
+                    console.print(
+                        "Interactive chat. Commands: /help, /servers, /tools [server], /resources [server], /prompt <name> [args-json], /apply <file>, /attach <server> <resource-uri>, /history [clear], /save <file>, /usage, /quit"
+                    )
+                    last_output: str | None = None
+                    attachments: list[str] = []
+                    while True:
+                        try:
+                            inp = input("> ")
+                        except (EOFError, KeyboardInterrupt):
+                            break
+                        if not inp:
+                            continue
+                        if inp.startswith("/quit"):
+                            break
+                        if inp.startswith("/help"):
+                            console.print(
+                                "/servers, /tools [server], /resources [server], /prompt <name> [args-json], /apply <file>, /attach <server> <resource-uri>, /history [clear], /save <file>, /usage, /quit"
+                            )
+                            continue
+                        if inp.startswith("/servers"):
+                            cfg = app_obj.context.config
+                            servers = (
+                                list((cfg.mcp.servers or {}).keys()) if cfg.mcp else []
+                            )
+                            for s in servers:
+                                console.print(s)
+                            continue
+                        if inp.startswith("/tools"):
+                            parts = inp.split()
+                            srv = parts[1] if len(parts) > 1 else None
+                            ag = Agent(
+                                name="chat-lister",
+                                instruction="list tools",
+                                server_names=[srv] if srv else (server_list or []),
+                                context=app_obj.context,
+                            )
+                            async with ag:
+                                res = (
+                                    await ag.list_tools(server_name=srv)
+                                    if srv
+                                    else await ag.list_tools()
+                                )
+                                for t in res.tools:
+                                    console.print(t.name)
+                            continue
+                        if inp.startswith("/resources"):
+                            parts = inp.split()
+                            srv = parts[1] if len(parts) > 1 else None
+                            ag = Agent(
+                                name="chat-lister",
+                                instruction="list resources",
+                                server_names=[srv] if srv else (server_list or []),
+                                context=app_obj.context,
+                            )
+                            async with ag:
+                                res = (
+                                    await ag.list_resources(server_name=srv)
+                                    if srv
+                                    else await ag.list_resources()
+                                )
+                                for r in getattr(res, "resources", []):
+                                    try:
+                                        console.print(r.uri)
+                                    except Exception:
+                                        console.print(str(getattr(r, "uri", "")))
+                            continue
+                        if inp.startswith("/prompt"):
+                            try:
+                                # Usage: /prompt <name> [args-json]
+                                parts = inp.split(maxsplit=2)
+                                if len(parts) < 2:
+                                    console.print("Usage: /prompt <name> [args-json]")
+                                    continue
+                                prompt_name = parts[1]
+                                args_json = parts[2] if len(parts) > 2 else None
+                                arguments = None
+                                if args_json:
+                                    import json as _json
+
+                                    try:
+                                        arguments = _json.loads(args_json)
+                                    except Exception as e:
+                                        console.print(f"Invalid JSON: {e}")
+                                        continue
+
+                                # Use Agent.create_prompt for flexibility
+                                ag = llm.agent
+                                prompt_msgs = await ag.create_prompt(
+                                    prompt_name=prompt_name,
+                                    arguments=arguments,
+                                    server_names=server_list or [],
+                                )
+                                # Generate with prompt messages
+                                out = await llm.generate_str(prompt_msgs)
+                                last_output = out
+                                console.print(out)
+                            except Exception as e:
+                                console.print(f"/prompt error: {e}")
+                            continue
+                        if inp.startswith("/apply"):
+                            # Load messages or text from file and send
+                            parts = inp.split(maxsplit=1)
+                            if len(parts) < 2:
+                                console.print("Usage: /apply <file>")
+                                continue
+                            from pathlib import Path as _Path
+
+                            p = _Path(parts[1]).expanduser()
+                            if not p.exists():
+                                console.print("File not found")
+                                continue
+                            text = p.read_text(encoding="utf-8")
+                            # Try JSON for structured messages, else treat as text
+                            try:
+                                import json as _json
+
+                                js = _json.loads(text)
+                                out = await llm.generate_str(js)
+                            except Exception:
+                                out = await llm.generate_str(text)
+                            last_output = out
+                            console.print(out)
+                            continue
+                        if inp.startswith("/attach"):
+                            # Attach a resource: /attach <server> <uri>
+                            parts = inp.split(maxsplit=2)
+                            if len(parts) < 3:
+                                console.print("Usage: /attach <server> <resource-uri>")
+                                continue
+                            srv, uri = parts[1], parts[2]
+                            try:
+                                res = await llm.read_resource(uri=uri, server_name=srv)
+                                # Try to extract text
+                                content_text = None
+                                try:
+                                    from mcp_agent.mcp.helpers.content_helpers import (
+                                        get_text,
+                                    )
+
+                                    if getattr(res, "contents", None):
+                                        for c in res.contents:
+                                            try:
+                                                content_text = get_text(c)
+                                                if content_text:
+                                                    break
+                                            except Exception:
+                                                continue
+                                except Exception:
+                                    pass
+                                if not content_text:
+                                    content_text = str(res)
+                                attachments.append(content_text)
+                                console.print(
+                                    f"Attached resource; size={len(content_text)} chars"
+                                )
+                            except Exception as e:
+                                console.print(f"/attach error: {e}")
+                            continue
+                        if inp.startswith("/history"):
+                            parts = inp.split()
+                            if len(parts) > 1 and parts[1] == "clear":
+                                try:
+                                    llm.history.clear()
+                                    console.print("History cleared")
+                                except Exception:
+                                    console.print("Could not clear history")
+                            else:
+                                try:
+                                    hist = llm.history.get()
+                                    console.print(f"{len(hist)} messages in memory")
+                                except Exception:
+                                    console.print("(no history)")
+                            continue
+                        if inp.startswith("/save"):
+                            parts = inp.split(maxsplit=1)
+                            if len(parts) < 2:
+                                console.print("Usage: /save <file>")
+                                continue
+                            if last_output is None:
+                                console.print("No output to save")
+                                continue
+                            from pathlib import Path as _Path
+
+                            _Path(parts[1]).expanduser().write_text(
+                                last_output, encoding="utf-8"
+                            )
+                            console.print("Saved")
+                            continue
+                        if inp.startswith("/usage"):
+                            try:
+                                tc = getattr(app_obj.context, "token_counter", None)
+                                if tc:
+                                    summary = await tc.get_summary()
+                                    console.print(
+                                        summary.model_dump()
+                                        if hasattr(summary, "model_dump")
+                                        else summary
+                                    )
+                            except Exception:
+                                console.print("(no usage)")
+                            continue
+                        # Regular message
+                        try:
+                            # Prepend any attachments once and then clear
+                            payload = inp
+                            if attachments:
+                                prefix = "\n\n".join(attachments) + "\n\n"
+                                payload = prefix + inp
+                                attachments.clear()
+                            out = await llm.generate_str(payload)
+                            last_output = out
+                            console.print(out)
+                        except Exception as e:
+                            console.print(f"ERROR: {e}")
+
+            asyncio.run(_repl())
+        else:
+            out = asyncio.run(
+                _run_single_model(
+                    script=script or Path("agent.py"),
+                    servers=server_list,
+                    url_servers=url_servers,
+                    stdio_servers=stdio_servers,
+                    model=model,
+                    message=message,
+                    prompt_file=prompt_file,
+                    agent_name=name or "chat",
+                )
+            )
+            console.print(out)
     except KeyboardInterrupt:
         pass
-
-

--- a/src/mcp_agent/cli/commands/chat.py
+++ b/src/mcp_agent/cli/commands/chat.py
@@ -1,0 +1,40 @@
+"""
+Ephemeral REPL for quick iteration (scaffold).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+import typer
+from rich.console import Console
+
+from mcp_agent.app import MCPApp
+
+
+app = typer.Typer(help="Ephemeral REPL for quick iteration")
+console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def chat(
+    name: Optional[str] = typer.Option(None, "--name"),
+    model: Optional[str] = typer.Option(None, "--model"),
+    message: Optional[str] = typer.Option(None, "--message", "-m"),
+) -> None:
+    """Minimal placeholder: starts MCPApp and exits; full REPL later."""
+
+    async def _run():
+        app = MCPApp(name=name or "mcp-agent chat")
+        async with app.run():
+            if message:
+                # Placeholder: no LLM wired yet
+                console.print(message)
+
+    try:
+        asyncio.run(_run())
+    except KeyboardInterrupt:
+        pass
+
+

--- a/src/mcp_agent/cli/commands/check.py
+++ b/src/mcp_agent/cli/commands/check.py
@@ -1,0 +1,96 @@
+"""
+System/config check for mcp-agent.
+"""
+
+from __future__ import annotations
+
+import platform
+import sys
+from pathlib import Path
+from typing import Optional
+
+import typer
+import yaml
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from mcp_agent.config import Settings
+
+
+app = typer.Typer(help="Check and diagnose mcp-agent configuration")
+console = Console()
+
+
+def _find_files() -> dict[str, Optional[Path]]:
+    return {
+        "config": Settings.find_config(),
+        "secrets": Settings.find_secrets(),
+    }
+
+
+def _get_system_info() -> dict:
+    return {
+        "platform": platform.platform(),
+        "python": sys.version.split(" ")[0],
+        "python_path": sys.executable,
+    }
+
+
+def _config_summary(config_path: Optional[Path]) -> dict:
+    result = {"status": "not_found", "error": None, "mcp_servers": []}
+    if not config_path or not config_path.exists():
+        return result
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        result["status"] = "parsed"
+        mcp = (data or {}).get("mcp", {})
+        servers = (mcp or {}).get("servers", {})
+        for name, cfg in servers.items():
+            info = {
+                "name": name,
+                "transport": (cfg or {}).get("transport", "stdio").upper(),
+                "command": (cfg or {}).get("command", ""),
+                "url": (cfg or {}).get("url", ""),
+            }
+            result["mcp_servers"].append(info)
+    except Exception as e:
+        result["status"] = "error"
+        result["error"] = str(e)
+    return result
+
+
+@app.callback(invoke_without_command=True)
+def check() -> None:
+    files = _find_files()
+    sysinfo = _get_system_info()
+    summary = _config_summary(files["config"])
+
+    system_table = Table(show_header=False, box=None)
+    system_table.add_column("Key", style="cyan")
+    system_table.add_column("Value")
+    system_table.add_row("Platform", sysinfo["platform"])
+    system_table.add_row("Python", sysinfo["python"])
+    system_table.add_row("Python Path", sysinfo["python_path"])
+    console.print(Panel(system_table, title="System"))
+
+    files_table = Table(show_header=False, box=None)
+    files_table.add_column("Setting", style="cyan")
+    files_table.add_column("Value")
+    cfg = files["config"]
+    sec = files["secrets"]
+    files_table.add_row("Config", str(cfg) if cfg else "[yellow]Not found[/yellow]")
+    files_table.add_row("Secrets", str(sec) if sec else "[yellow]Not found[/yellow]")
+    console.print(Panel(files_table, title="Files"))
+
+    servers = summary.get("mcp_servers", [])
+    if servers:
+        srv_table = Table(show_header=True, header_style="bold")
+        srv_table.add_column("Name")
+        srv_table.add_column("Transport")
+        srv_table.add_column("Command/URL")
+        for s in servers:
+            target = s["url"] or s["command"]
+            srv_table.add_row(s["name"], s["transport"], target)
+        console.print(Panel(srv_table, title="MCP Servers"))

--- a/src/mcp_agent/cli/commands/config.py
+++ b/src/mcp_agent/cli/commands/config.py
@@ -1,0 +1,95 @@
+"""
+Config command group: show, check, edit (scaffold).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+import yaml
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from mcp_agent.config import Settings
+
+
+app = typer.Typer(help="Configuration utilities")
+console = Console()
+
+
+def _find_config_file() -> Optional[Path]:
+    return Settings.find_config()
+
+
+def _find_secrets_file() -> Optional[Path]:
+    return Settings.find_secrets()
+
+
+@app.command("show")
+def show(
+    secrets: bool = typer.Option(False, "--secrets", "-s", help="Show secrets file"),
+    path: Optional[Path] = typer.Argument(None, help="Optional explicit path"),
+) -> None:
+    """Print the current config or secrets file with YAML validation."""
+    file_path = path
+    if file_path is None:
+        file_path = _find_secrets_file() if secrets else _find_config_file()
+    if not file_path or not file_path.exists():
+        typer.secho("Config file not found", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+
+    console.print(f"\n[bold]{'secrets' if secrets else 'config'}:[/bold] {file_path}\n")
+    try:
+        text = file_path.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(text)
+        console.print("[green]YAML syntax is valid[/green]")
+        if parsed is None:
+            console.print("[yellow]Warning: file empty[/yellow]")
+        console.print(text)
+    except Exception as e:
+        typer.secho(f"Error parsing YAML: {e}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(5)
+
+
+@app.command("check")
+def check() -> None:
+    """Summarize system+config+keys quickly."""
+    cfg = _find_config_file()
+    sec = _find_secrets_file()
+
+    table = Table(show_header=False, box=None)
+    table.add_column("Key", style="cyan")
+    table.add_column("Value")
+    table.add_row("Config", str(cfg) if cfg else "[red]not found[/red]")
+    table.add_row("Secrets", str(sec) if sec else "[yellow]not found[/yellow]")
+
+    # Basic settings load (merges secrets if next to config via Settings.get)
+    try:
+        settings = Settings() if cfg is None else Settings(**yaml.safe_load(cfg.read_text()))
+        # Show a small summary
+        table.add_row("Execution Engine", settings.execution_engine)
+        if settings.logger:
+            table.add_row("Logger.level", settings.logger.level)
+            table.add_row("Logger.type", settings.logger.type)
+        mcp_servers = list((settings.mcp.servers or {}).keys()) if settings.mcp else []
+        table.add_row("MCP servers", ", ".join(mcp_servers) or "(none)")
+    except Exception as e:
+        table.add_row("Load error", f"[red]{e}[/red]")
+
+    console.print(Panel(table, title="mcp-agent config"))
+
+
+@app.command("edit")
+def edit(secrets: bool = typer.Option(False, "--secrets", "-s")) -> None:
+    """Open config or secrets in $EDITOR (scaffold)."""
+    # Minimal scaffold: print path and exit; full EDITOR support can be added later
+    target = _find_secrets_file() if secrets else _find_config_file()
+    if not target:
+        typer.secho("No file found", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    console.print(str(target))
+
+

--- a/src/mcp_agent/cli/commands/configure.py
+++ b/src/mcp_agent/cli/commands/configure.py
@@ -1,0 +1,31 @@
+"""
+Client integration helpers (scaffold).
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+
+
+app = typer.Typer(help="Client integration helpers")
+console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def configure(
+    server_url: str = typer.Argument(...),
+    client: str = typer.Option(..., "--client", help="cursor|claude|vscode|..."),
+    write: bool = typer.Option(False, "--write"),
+    open: bool = typer.Option(False, "--open"),
+    format: str = typer.Option("text", "--format"),
+) -> None:
+    console.print({
+        "server_url": server_url,
+        "client": client,
+        "write": write,
+        "open": open,
+        "format": format,
+    })
+
+

--- a/src/mcp_agent/cli/commands/configure.py
+++ b/src/mcp_agent/cli/commands/configure.py
@@ -1,31 +1,133 @@
 """
-Client integration helpers (scaffold).
+Client integration helpers: generate client config snippets and optionally write them.
+
+Supported clients:
+ - cursor: writes ~/.cursor/mcp.json
+ - claude: writes ~/.claude/mcp.json
+ - vscode: writes .vscode/mcp.json in project
+
+Behavior:
+ - Prints a JSON snippet for the provided server_url.
+ - If --write is specified, merges into the appropriate config file.
+ - --open prints the target file path (portable alternative to opening file manager).
 """
 
 from __future__ import annotations
 
 import typer
 from rich.console import Console
+from pathlib import Path
+import json
+
+from mcp_agent.cli.utils.url_parser import generate_server_name, parse_server_url
 
 
 app = typer.Typer(help="Client integration helpers")
 console = Console()
 
 
+def _build_server_entry(url: str, name: str | None = None) -> dict:
+    # Distinguish http vs sse based on path suffix
+    try:
+        _name, transport, fixed_url = parse_server_url(url)
+        server_name = name or _name
+    except Exception:
+        server_name = name or generate_server_name(url)
+        fixed_url = url
+        transport = "sse" if url.rstrip("/").endswith("/sse") else "http"
+    entry = {
+        server_name: {
+            "url": fixed_url,
+            "transport": transport,
+        }
+    }
+    return entry
+
+
+def _merge_mcp_json(existing: dict, addition: dict) -> dict:
+    # Accept a few common shapes and always emit {"mcp":{"servers":{...}}}
+    servers: dict = {}
+    if isinstance(existing, dict):
+        if "mcp" in existing and isinstance(existing.get("mcp"), dict):
+            servers = dict(existing["mcp"].get("servers") or {})
+        elif "servers" in existing and isinstance(existing.get("servers"), dict):
+            servers = dict(existing.get("servers") or {})
+        else:
+            # Or treat top-level mapping as servers if it looks like name->obj
+            for k, v in existing.items():
+                if isinstance(v, dict) and ("url" in v or "transport" in v):
+                    servers[k] = v
+    # Merge
+    servers.update(addition)
+    return {"mcp": {"servers": servers}}
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _print_output(data: dict, fmt: str) -> None:
+    if fmt.lower() == "json":
+        console.print_json(data=data)
+    else:
+        # Text summary
+        try:
+            name = next(iter(data["mcp"]["servers"].keys()))
+        except Exception:
+            name = "server"
+        console.print(f"Add this to your client's mcp.json under servers: '{name}'")
+        console.print_json(data=data)
+
+
 @app.callback(invoke_without_command=True)
 def configure(
     server_url: str = typer.Argument(...),
-    client: str = typer.Option(..., "--client", help="cursor|claude|vscode|..."),
+    client: str = typer.Option(
+        ..., "--client", help="cursor|claude|vscode|smithery|mcp.run"
+    ),
     write: bool = typer.Option(False, "--write"),
     open: bool = typer.Option(False, "--open"),
-    format: str = typer.Option("text", "--format"),
+    format: str = typer.Option("text", "--format", help="text|json"),
+    name: str | None = typer.Option(
+        None, "--name", help="Optional server name override"
+    ),
 ) -> None:
-    console.print({
-        "server_url": server_url,
-        "client": client,
-        "write": write,
-        "open": open,
-        "format": format,
-    })
+    client_lc = client.lower()
+    entry = _build_server_entry(server_url, name=name)
+    snippet = {"mcp": {"servers": entry}}
 
+    target: Path | None = None
+    if client_lc == "cursor":
+        target = Path.home() / ".cursor" / "mcp.json"
+    elif client_lc == "claude":
+        target = Path.home() / ".claude" / "mcp.json"
+    elif client_lc == "vscode":
+        target = Path.cwd() / ".vscode" / "mcp.json"
+    else:
+        # Unknown/unsupported: print snippet only
+        _print_output(snippet, format)
+        return
 
+    if write:
+        try:
+            if target.exists():
+                existing = json.loads(target.read_text(encoding="utf-8"))
+            else:
+                existing = {}
+        except Exception:
+            existing = {}
+        merged = _merge_mcp_json(existing, entry)
+        try:
+            _write_json(target, merged)
+            console.print(f"Wrote config to {target}")
+        except Exception as e:
+            typer.secho(f"Failed to write: {e}", err=True, fg=typer.colors.RED)
+            raise typer.Exit(5)
+        if open:
+            console.print(str(target))
+        else:
+            # Also print snippet for visibility
+            _print_output(merged, format)
+    else:
+        _print_output(snippet, format)

--- a/src/mcp_agent/cli/commands/dev.py
+++ b/src/mcp_agent/cli/commands/dev.py
@@ -1,16 +1,22 @@
 """
-Run app locally with (future) live reload and diagnostics (scaffold).
+Run the user's app with live reload and diagnostics.
+Loads the user's MCPApp from --script, performs simple preflight checks,
+then starts the app. If watchdog is available, watches files and restarts on changes.
 """
 
 from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+import shutil
+import time
 
 import typer
 from rich.console import Console
 
 from mcp_agent.app import MCPApp
+from mcp_agent.cli.core.utils import load_user_app
+from mcp_agent.config import get_settings
 
 
 app = typer.Typer(help="Run app locally with diagnostics")
@@ -19,17 +25,83 @@ console = Console()
 
 @app.callback(invoke_without_command=True)
 def dev(script: Path = typer.Option(Path("agent.py"), "--script")) -> None:
-    """Start the user's app from a script (basic run)."""
+    """Run the user's app script with optional live reload and preflight checks."""
 
-    async def _run():
-        # For now, just initialize an empty MCPApp; later we will import the script
-        mcp_app = MCPApp(name="mcp-agent dev")
-        async with mcp_app.run():
-            console.print(f"Running {script} (scaffold)")
+    def _preflight_ok() -> bool:
+        settings = get_settings()
+        ok = True
+        # check stdio commands
+        servers = (settings.mcp.servers if settings.mcp else {}) or {}
+        for name, s in servers.items():
+            if s.transport == "stdio" and s.command and not shutil.which(s.command):
+                console.print(
+                    f"[yellow]Missing command for server '{name}': {s.command}[/yellow]"
+                )
+                ok = False
+        return ok
 
+    async def _run_once():
+        app_obj = load_user_app(script)
+        async with app_obj.run():
+            console.print(f"Running {script}")
+            # Sleep until cancelled
+            try:
+                while True:
+                    await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                pass
+
+    # Simple preflight
+    _ = _preflight_ok()
+
+    # Try to use watchdog for live reload
     try:
-        asyncio.run(_run())
-    except KeyboardInterrupt:
-        pass
+        from watchdog.observers import Observer  # type: ignore
+        from watchdog.events import FileSystemEventHandler  # type: ignore
 
+        class _Handler(FileSystemEventHandler):
+            def __init__(self):
+                self.touched = False
 
+            def on_modified(self, event):  # type: ignore
+                self.touched = True
+
+            def on_created(self, event):  # type: ignore
+                self.touched = True
+
+        loop = asyncio.get_event_loop()
+        task = loop.create_task(_run_once())
+
+        handler = _Handler()
+        observer = Observer()
+        observer.schedule(handler, path=str(script.parent), recursive=True)
+        observer.start()
+        console.print("Live reload enabled (watchdog)")
+        try:
+            while True:
+                time.sleep(0.5)
+                if handler.touched:
+                    handler.touched = False
+                    console.print("Change detected. Restarting...")
+                    task.cancel()
+                    try:
+                        loop.run_until_complete(task)
+                    except Exception:
+                        pass
+                    task = loop.create_task(_run_once())
+        except KeyboardInterrupt:
+            pass
+        finally:
+            observer.stop()
+            observer.join()
+            task.cancel()
+            try:
+                loop.run_until_complete(task)
+            except Exception:
+                pass
+    except Exception:
+        # Fallback: run once
+        try:
+            asyncio.run(_run_once())
+        except KeyboardInterrupt:
+            pass

--- a/src/mcp_agent/cli/commands/dev.py
+++ b/src/mcp_agent/cli/commands/dev.py
@@ -1,0 +1,35 @@
+"""
+Run app locally with (future) live reload and diagnostics (scaffold).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from mcp_agent.app import MCPApp
+
+
+app = typer.Typer(help="Run app locally with diagnostics")
+console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def dev(script: Path = typer.Option(Path("agent.py"), "--script")) -> None:
+    """Start the user's app from a script (basic run)."""
+
+    async def _run():
+        # For now, just initialize an empty MCPApp; later we will import the script
+        mcp_app = MCPApp(name="mcp-agent dev")
+        async with mcp_app.run():
+            console.print(f"Running {script} (scaffold)")
+
+    try:
+        asyncio.run(_run())
+    except KeyboardInterrupt:
+        pass
+
+

--- a/src/mcp_agent/cli/commands/doctor.py
+++ b/src/mcp_agent/cli/commands/doctor.py
@@ -1,28 +1,92 @@
 """
-Doctor: diagnostics (scaffold).
+Doctor: comprehensive diagnostics for config/secrets/keys/servers/network.
 """
 
 from __future__ import annotations
 
 import platform
 import sys
+import shutil
+import socket
 
 import typer
 from rich.console import Console
 from rich.table import Table
+from mcp_agent.config import get_settings
 
 
 app = typer.Typer(help="Comprehensive diagnostics")
 console = Console()
 
 
+def _check_host(url: str, timeout: float = 1.5) -> bool:
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        host = parsed.hostname
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        if not host:
+            return False
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except Exception:
+        return False
+
+
 @app.callback(invoke_without_command=True)
 def doctor() -> None:
-    table = Table(show_header=False, box=None)
-    table.add_column("Key", style="cyan")
-    table.add_column("Value")
-    table.add_row("OS", platform.platform())
-    table.add_row("Python", sys.version.split(" ")[0])
-    console.print(table)
+    sys_table = Table(show_header=False, box=None)
+    sys_table.add_column("Key", style="cyan")
+    sys_table.add_column("Value")
+    sys_table.add_row("OS", platform.platform())
+    sys_table.add_row("Python", sys.version.split(" ")[0])
+    sys_table.add_row("Typer", "present")
+    console.print(sys_table)
 
+    settings = get_settings()
 
+    # Providers
+    prov_table = Table(show_header=True)
+    prov_table.add_column("Provider")
+    prov_table.add_column("Configured")
+    for name in ["openai", "anthropic", "google", "azure", "bedrock"]:
+        obj = getattr(settings, name, None)
+        key = getattr(obj, "api_key", None) if obj else None
+        prov_table.add_row(name, "yes" if key else "no")
+    console.print(prov_table)
+
+    # Servers
+    srv_table = Table(show_header=True)
+    srv_table.add_column("Name")
+    srv_table.add_column("Transport")
+    srv_table.add_column("Target")
+    srv_table.add_column("OK")
+    servers = (settings.mcp.servers if settings.mcp else {}) or {}
+    for name, s in servers.items():
+        ok = True
+        tgt = s.url or s.command or ""
+        if s.transport == "stdio":
+            ok = bool(s.command and shutil.which(s.command))
+        else:
+            ok = bool(s.url and _check_host(s.url))
+        srv_table.add_row(name, s.transport, tgt, "yes" if ok else "no")
+    console.print(srv_table)
+
+    # Logger/OTEL summary
+    misc_table = Table(show_header=False, box=None)
+    misc_table.add_column("Setting", style="cyan")
+    misc_table.add_column("Value")
+    if settings.logger:
+        misc_table.add_row("Logger.level", settings.logger.level)
+        misc_table.add_row("Logger.type", settings.logger.type)
+        misc_table.add_row("Logger.path", getattr(settings.logger, "path", ""))
+    if settings.otel and settings.otel.enabled:
+        exporters = settings.otel.exporters or []
+        types = []
+        for e in exporters:
+            t = getattr(e, "type", None) or str(e)
+            types.append(t)
+        misc_table.add_row("OTEL.enabled", "true")
+        misc_table.add_row("OTEL.exporters", ", ".join(types))
+    console.print(misc_table)

--- a/src/mcp_agent/cli/commands/doctor.py
+++ b/src/mcp_agent/cli/commands/doctor.py
@@ -1,0 +1,28 @@
+"""
+Doctor: diagnostics (scaffold).
+"""
+
+from __future__ import annotations
+
+import platform
+import sys
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+
+app = typer.Typer(help="Comprehensive diagnostics")
+console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def doctor() -> None:
+    table = Table(show_header=False, box=None)
+    table.add_column("Key", style="cyan")
+    table.add_column("Value")
+    table.add_row("OS", platform.platform())
+    table.add_row("Python", sys.version.split(" ")[0])
+    console.print(table)
+
+

--- a/src/mcp_agent/cli/commands/go.py
+++ b/src/mcp_agent/cli/commands/go.py
@@ -1,0 +1,345 @@
+"""
+Run an interactive agent quickly.
+This will load the user's MCPApp from a script (if provided), attach dynamic servers
+from URLs or stdio launchers, and run a one-shot message or interactive session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import typer
+from rich.console import Console
+
+from mcp_agent.cli.core.utils import (
+    attach_stdio_servers,
+    attach_url_servers,
+    load_user_app,
+)
+from mcp_agent.cli.utils.url_parser import generate_server_configs, parse_server_urls
+from mcp_agent.workflows.factory import create_llm
+
+
+app = typer.Typer(
+    help="Run an interactive agent quickly",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+console = Console()
+
+
+def _resolve_instruction_arg(instruction: Optional[str]) -> Optional[str]:
+    if not instruction:
+        return None
+    try:
+        if instruction.startswith("text:"):
+            return instruction[len("text:") :]
+        if instruction.startswith("http://") or instruction.startswith("https://"):
+            try:
+                import httpx  # type: ignore
+
+                r = httpx.get(instruction, timeout=10.0)
+                r.raise_for_status()
+                return r.text
+            except Exception:
+                # Fallback to urllib
+                try:
+                    from urllib.request import urlopen
+
+                    with urlopen(instruction, timeout=10) as resp:  # type: ignore
+                        return resp.read().decode("utf-8")
+                except Exception as e:
+                    raise typer.Exit(6) from e
+        p = Path(instruction).expanduser()
+        if p.exists() and p.is_file():
+            return p.read_text(encoding="utf-8")
+        # Otherwise treat as raw text
+        return instruction
+    except Exception:
+        return instruction
+
+
+async def _run_agent(
+    *,
+    app_script: Optional[Path],
+    server_list: Optional[List[str]],
+    model: Optional[str],
+    message: Optional[str],
+    prompt_file: Optional[Path],
+    url_servers: Optional[Dict[str, Dict[str, str]]],
+    stdio_servers: Optional[Dict[str, Dict[str, str]]],
+    agent_name: Optional[str],
+    instruction: Optional[str],
+):
+    # Placeholder: future structured prompt parsing will use PromptMessageMultipart
+
+    app_obj = load_user_app(app_script) if app_script else None
+    if app_obj is None:
+        raise typer.Exit(2)
+
+    # Initialize app to have context
+    await app_obj.initialize()
+
+    # Attach dynamic servers
+    attach_url_servers(app_obj, url_servers)
+    attach_stdio_servers(app_obj, stdio_servers)
+
+    async with app_obj.run():
+        # Prepare LLM in the app context
+        provider = None
+        model_id = model
+        # Heuristic: allow provider prefix like "anthropic.model" or "openai:model"
+        if model_id and ":" not in model_id and "." in model_id:
+            maybe_provider = model_id.split(".", 1)[0].lower()
+            if maybe_provider in {
+                "openai",
+                "anthropic",
+                "azure",
+                "google",
+                "bedrock",
+                "ollama",
+            }:
+                provider = maybe_provider
+        if model_id and ":" in model_id:
+            # provider:model pattern
+            provider = model_id.split(":", 1)[0]
+
+        llm = create_llm(
+            agent_name=agent_name or "cli-agent",
+            server_names=server_list or [],
+            provider=(provider or "openai"),
+            model=model_id,
+            instruction=_resolve_instruction_arg(instruction) if instruction else None,
+            context=app_obj.context,
+        )
+
+        if message:
+            try:
+                result = await llm.generate_str(message)
+                console.print(result)
+            except Exception as e:
+                typer.secho(f"Generation failed: {e}", err=True, fg=typer.colors.RED)
+                raise typer.Exit(5)
+        elif prompt_file:
+            try:
+                from mcp.types import TextContent
+                from mcp_agent.utils.prompt_message_multipart import (
+                    PromptMessageMultipart,
+                )
+
+                text = prompt_file.read_text(encoding="utf-8")
+                # Convert to a single multipart user message for downstream LLM/workflow
+                multipart_messages = [
+                    PromptMessageMultipart(
+                        role="user", content=[TextContent(type="text", text=text)]
+                    )
+                ]
+                # Flatten to standard PromptMessage sequence
+                prompt_messages = []
+                for mp in multipart_messages:
+                    prompt_messages.extend(mp.from_multipart())
+                result = await llm.generate_str(prompt_messages)
+                console.print(result)
+            except Exception as e:
+                typer.secho(
+                    f"Failed to read prompt file: {e}", err=True, fg=typer.colors.RED
+                )
+                raise typer.Exit(6)
+        else:
+            # Interactive REPL similar to chat
+            console.print(
+                "Interactive chat. Commands: /help, /servers, /tools [server], /resources [server], /usage, /quit"
+            )
+            from mcp_agent.agents.agent import Agent as _Agent
+
+            while True:
+                try:
+                    inp = input("> ")
+                except (EOFError, KeyboardInterrupt):
+                    break
+                if not inp:
+                    continue
+                if inp.startswith("/quit"):
+                    break
+                if inp.startswith("/help"):
+                    console.print(
+                        "/servers, /tools [server], /resources [server], /usage, /quit"
+                    )
+                    continue
+                if inp.startswith("/servers"):
+                    cfg = app_obj.context.config
+                    svrs = list((cfg.mcp.servers or {}).keys()) if cfg.mcp else []
+                    for s in svrs:
+                        console.print(s)
+                    continue
+                if inp.startswith("/tools"):
+                    parts = inp.split()
+                    srv = parts[1] if len(parts) > 1 else None
+                    ag = _Agent(
+                        name="go-lister",
+                        instruction="list tools",
+                        server_names=[srv] if srv else (server_list or []),
+                        context=app_obj.context,
+                    )
+                    async with ag:
+                        res = (
+                            await ag.list_tools(server_name=srv)
+                            if srv
+                            else await ag.list_tools()
+                        )
+                        for t in res.tools:
+                            console.print(t.name)
+                    continue
+                if inp.startswith("/resources"):
+                    parts = inp.split()
+                    srv = parts[1] if len(parts) > 1 else None
+                    ag = _Agent(
+                        name="go-lister",
+                        instruction="list resources",
+                        server_names=[srv] if srv else (server_list or []),
+                        context=app_obj.context,
+                    )
+                    async with ag:
+                        res = (
+                            await ag.list_resources(server_name=srv)
+                            if srv
+                            else await ag.list_resources()
+                        )
+                        for r in getattr(res, "resources", []):
+                            try:
+                                console.print(r.uri)
+                            except Exception:
+                                console.print(str(getattr(r, "uri", "")))
+                    continue
+                if inp.startswith("/usage"):
+                    try:
+                        tc = getattr(app_obj.context, "token_counter", None)
+                        if tc:
+                            summary = await tc.get_summary()
+                            console.print(
+                                summary.model_dump()
+                                if hasattr(summary, "model_dump")
+                                else summary
+                            )
+                    except Exception:
+                        console.print("(no usage)")
+                    continue
+                # Regular prompt
+                try:
+                    result = await llm.generate_str(inp)
+                    console.print(result)
+                except Exception as e:
+                    typer.secho(
+                        f"Generation failed: {e}", err=True, fg=typer.colors.RED
+                    )
+                    continue
+
+
+def _parse_stdio_commands(cmds: List[str] | None) -> Dict[str, Dict[str, str]] | None:
+    if not cmds:
+        return None
+    servers: Dict[str, Dict[str, str]] = {}
+    for i, cmd in enumerate(cmds):
+        parts = shlex.split(cmd)
+        if not parts:
+            continue
+        command, args = parts[0], parts[1:]
+        name = command.replace("/", "_").replace("@", "").replace(".", "_")
+        if len(cmds) > 1:
+            name = f"{name}_{i + 1}"
+        servers[name] = {"transport": "stdio", "command": command, "args": args}
+    return servers
+
+
+@app.callback(invoke_without_command=True, no_args_is_help=False)
+def go(
+    ctx: typer.Context,
+    name: str = typer.Option("mcp-agent", "--name"),
+    instruction: Optional[str] = typer.Option(None, "--instruction", "-i"),
+    config_path: Optional[str] = typer.Option(None, "--config-path", "-c"),
+    servers: Optional[str] = typer.Option(None, "--servers"),
+    urls: Optional[str] = typer.Option(None, "--url"),
+    auth: Optional[str] = typer.Option(None, "--auth"),
+    model: Optional[str] = typer.Option(None, "--model", "--models"),
+    message: Optional[str] = typer.Option(None, "--message", "-m"),
+    prompt_file: Optional[Path] = typer.Option(None, "--prompt-file", "-p"),
+    npx: Optional[str] = typer.Option(None, "--npx"),
+    uvx: Optional[str] = typer.Option(None, "--uvx"),
+    stdio: Optional[str] = typer.Option(None, "--stdio"),
+    script: Optional[Path] = typer.Option(Path("agent.py"), "--script"),
+) -> None:
+    # Parse server names from config if provided
+    server_list = servers.split(",") if servers else None
+
+    # Parse URLs
+    url_servers = None
+    if urls:
+        try:
+            parsed = parse_server_urls(urls, auth)
+            url_servers = generate_server_configs(parsed)
+            if url_servers and not server_list:
+                server_list = list(url_servers.keys())
+            elif url_servers and server_list:
+                server_list.extend(list(url_servers.keys()))
+        except ValueError as e:
+            typer.secho(f"Error parsing URLs: {e}", err=True, fg=typer.colors.RED)
+            raise typer.Exit(6)
+
+    # Parse stdio launchers
+    stdio_cmds: List[str] = []
+    if npx:
+        stdio_cmds.append(f"npx {npx}")
+    if uvx:
+        stdio_cmds.append(f"uvx {uvx}")
+    if stdio:
+        stdio_cmds.append(stdio)
+    stdio_servers = _parse_stdio_commands(stdio_cmds)
+    if stdio_servers:
+        if not server_list:
+            server_list = list(stdio_servers.keys())
+        else:
+            server_list.extend(list(stdio_servers.keys()))
+
+    # Multi-model support if comma-separated
+    if model and "," in model:
+        models = [m.strip() for m in model.split(",") if m.strip()]
+        results: list[tuple[str, str | Exception]] = []
+        for m in models:
+            try:
+                asyncio.run(
+                    _run_agent(
+                        app_script=script,
+                        server_list=server_list,
+                        model=m,
+                        message=message,
+                        prompt_file=prompt_file,
+                        url_servers=url_servers,
+                        stdio_servers=stdio_servers,
+                        agent_name=name,
+                        instruction=instruction,
+                    )
+                )
+            except Exception as e:
+                results.append((m, e))
+        # No consolidated pretty-print; leave to chat for advanced
+        return
+
+    # Run under asyncio
+    try:
+        asyncio.run(
+            _run_agent(
+                app_script=script,
+                server_list=server_list,
+                model=model,
+                message=message,
+                prompt_file=prompt_file,
+                url_servers=url_servers,
+                stdio_servers=stdio_servers,
+                agent_name=name,
+                instruction=instruction,
+            )
+        )
+    except KeyboardInterrupt:
+        pass

--- a/src/mcp_agent/cli/commands/init.py
+++ b/src/mcp_agent/cli/commands/init.py
@@ -1,0 +1,77 @@
+"""
+Project scaffolding: mcp-agent init (scaffold minimal version).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.prompt import Confirm
+
+
+app = typer.Typer(help="Scaffold a new mcp-agent project")
+console = Console()
+
+
+DEFAULT_CONFIG = """# mcp-agent configuration
+mcp:
+  servers: {}
+logger:
+  level: info
+  type: console
+"""
+
+DEFAULT_SECRETS = """# mcp-agent secrets (do not commit)
+openai:
+  api_key: ""
+anthropic:
+  api_key: ""
+"""
+
+DEFAULT_AGENT = (
+    """from mcp_agent.app import MCPApp
+
+app = MCPApp(name="my_agent")
+
+if __name__ == "__main__":
+    import asyncio
+
+    async def main():
+        async with app.run():
+            pass
+
+    asyncio.run(main())
+"""
+)
+
+
+def _write(path: Path, content: str, force: bool) -> None:
+    if path.exists() and not force:
+        if not Confirm.ask(f"{path} exists. Overwrite?", default=False):
+            return
+    path.write_text(content, encoding="utf-8")
+    console.print(f"[green]Created[/green] {path}")
+
+
+@app.callback(invoke_without_command=True)
+def init(
+    dir: Path = typer.Option(Path("."), "--dir", "-d", help="Target directory"),
+    template: str = typer.Option("basic", "--template", help="Template name"),
+    force: bool = typer.Option(False, "--force", "-f"),
+    no_gitignore: bool = typer.Option(False, "--no-gitignore"),
+) -> None:
+    """Create config, secrets, and an example agent.py."""
+    dir = dir.resolve()
+    dir.mkdir(parents=True, exist_ok=True)
+
+    _write(dir / "mcp_agent.config.yaml", DEFAULT_CONFIG, force)
+    _write(dir / "mcp_agent.secrets.yaml", DEFAULT_SECRETS, force)
+    _write(dir / "agent.py", DEFAULT_AGENT, force)
+    if not no_gitignore:
+        _write(dir / ".gitignore", "mcp_agent.secrets.yaml\n", force)
+
+    console.print("\n[bold]Next:[/bold] uv run agent.py")
+
+

--- a/src/mcp_agent/cli/commands/invoke.py
+++ b/src/mcp_agent/cli/commands/invoke.py
@@ -1,0 +1,51 @@
+"""
+Invoke an agent or workflow programmatically (scaffold).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Optional
+
+import typer
+from rich.console import Console
+
+from mcp_agent.app import MCPApp
+
+
+app = typer.Typer(help="Invoke an agent or workflow programmatically")
+console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def invoke(
+    agent: Optional[str] = typer.Option(None, "--agent"),
+    workflow: Optional[str] = typer.Option(None, "--workflow"),
+    message: Optional[str] = typer.Option(None, "--message", "-m"),
+    vars: Optional[str] = typer.Option(None, "--vars", help="JSON structured inputs"),
+    script: Optional[str] = typer.Option(None, "--script"),
+    model: Optional[str] = typer.Option(None, "--model"),
+) -> None:
+    """Minimal execution placeholder; resolves and prints inputs."""
+    try:
+        payload = json.loads(vars) if vars else None
+    except Exception as e:
+        typer.secho(f"Invalid --vars JSON: {e}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(6)
+
+    async def _run():
+        app = MCPApp(name="mcp-agent invoke")
+        async with app.run():
+            console.print({
+                "agent": agent,
+                "workflow": workflow,
+                "message": message,
+                "vars": payload,
+                "script": script,
+                "model": model,
+            })
+
+    asyncio.run(_run())
+
+

--- a/src/mcp_agent/cli/commands/invoke.py
+++ b/src/mcp_agent/cli/commands/invoke.py
@@ -1,5 +1,5 @@
 """
-Invoke an agent or workflow programmatically (scaffold).
+Invoke an agent or workflow programmatically.
 """
 
 from __future__ import annotations
@@ -11,7 +11,8 @@ from typing import Optional
 import typer
 from rich.console import Console
 
-from mcp_agent.app import MCPApp
+from mcp_agent.cli.core.utils import load_user_app
+from mcp_agent.workflows.factory import create_llm
 
 
 app = typer.Typer(help="Invoke an agent or workflow programmatically")
@@ -27,25 +28,81 @@ def invoke(
     script: Optional[str] = typer.Option(None, "--script"),
     model: Optional[str] = typer.Option(None, "--model"),
 ) -> None:
-    """Minimal execution placeholder; resolves and prints inputs."""
+    """Run either an agent (LLM) or a workflow from the user's app script."""
+    if not agent and not workflow:
+        typer.secho("Specify --agent or --workflow", err=True, fg=typer.colors.RED)
+        raise typer.Exit(6)
+    if agent and workflow:
+        typer.secho(
+            "Specify only one of --agent or --workflow", err=True, fg=typer.colors.RED
+        )
+        raise typer.Exit(6)
+
     try:
-        payload = json.loads(vars) if vars else None
+        payload = json.loads(vars) if vars else {}
     except Exception as e:
         typer.secho(f"Invalid --vars JSON: {e}", err=True, fg=typer.colors.RED)
         raise typer.Exit(6)
 
     async def _run():
-        app = MCPApp(name="mcp-agent invoke")
-        async with app.run():
-            console.print({
-                "agent": agent,
-                "workflow": workflow,
-                "message": message,
-                "vars": payload,
-                "script": script,
-                "model": model,
-            })
+        app_obj = load_user_app(Path(script) if script else Path("agent.py"))
+        await app_obj.initialize()
+        async with app_obj.run():
+            if agent:
+                # Run via LLM
+                llm = create_llm(
+                    agent_name=agent,
+                    server_names=[],
+                    provider=None,
+                    model=model,
+                    context=app_obj.context,
+                )
+                if message:
+                    res = await llm.generate_str(message)
+                    console.print(res)
+                    return
+                if payload:
+                    # If structured vars contain messages, prefer that key; else stringify
+                    msg = (
+                        payload.get("message")
+                        or payload.get("input")
+                        or json.dumps(payload)
+                    )
+                    res = await llm.generate_str(msg)
+                    console.print(res)
+                    return
+                typer.secho("No input provided", err=True, fg=typer.colors.YELLOW)
+                return
 
-    asyncio.run(_run())
+            # Workflow path
+            wname = workflow
+            wf_cls = app_obj.workflows.get(wname) if wname else None
+            if not wf_cls:
+                raise RuntimeError(f"Workflow '{wname}' not found in app")
 
+            # Create instance with context
+            wf = await wf_cls.create(name=wname, context=app_obj.context)
+            # Try running with provided vars
+            try:
+                if message and "input" not in payload and "message" not in payload:
+                    payload["input"] = message
+                result = await wf.run(**payload)
+            except TypeError:
+                # Retry with 'message' key if 'input' didn't fit
+                if "message" not in payload and message:
+                    result = await wf.run(message=message)
+                else:
+                    raise
+            # If result is a WorkflowResult object, unwrap if possible
+            try:
+                val = getattr(result, "value", result)
+            except Exception:
+                val = result
+            console.print(val)
 
+    from pathlib import Path
+
+    try:
+        asyncio.run(_run())
+    except KeyboardInterrupt:
+        pass

--- a/src/mcp_agent/cli/commands/keys.py
+++ b/src/mcp_agent/cli/commands/keys.py
@@ -1,0 +1,54 @@
+"""
+Keys management (scaffold): show/set/unset.
+"""
+
+from __future__ import annotations
+
+import os
+import typer
+from rich.console import Console
+
+
+app = typer.Typer(help="Manage provider API keys")
+console = Console()
+
+
+PROVIDERS = [
+    ("openai", "OPENAI_API_KEY"),
+    ("anthropic", "ANTHROPIC_API_KEY"),
+    ("google", "GOOGLE_API_KEY"),
+]
+
+
+@app.command("show")
+def show() -> None:
+    """Show keys from environment (scaffold)."""
+    for prov, env in PROVIDERS:
+        val = os.environ.get(env)
+        tail = f"…{val[-4:]}" if val else ""
+        console.print(f"{prov}: {tail}")
+
+
+@app.command("set")
+def set_key(provider: str, key: str) -> None:
+    """Scaffold: export to environment for current process only."""
+    mapping = {p: e for p, e in PROVIDERS}
+    env = mapping.get(provider)
+    if not env:
+        typer.secho("Unknown provider", fg=typer.colors.RED, err=True)
+        raise typer.Exit(6)
+    os.environ[env] = key
+    console.print(f"Set {provider} key (session)")
+
+
+@app.command("unset")
+def unset(provider: str) -> None:
+    mapping = {p: e for p, e in PROVIDERS}
+    env = mapping.get(provider)
+    if not env:
+        typer.secho("Unknown provider", fg=typer.colors.RED, err=True)
+        raise typer.Exit(6)
+    os.environ.pop(env, None)
+    console.print(f"Unset {provider} key (session)")
+
+

--- a/src/mcp_agent/cli/commands/keys.py
+++ b/src/mcp_agent/cli/commands/keys.py
@@ -22,33 +22,85 @@ PROVIDERS = [
 
 @app.command("show")
 def show() -> None:
-    """Show keys from environment (scaffold)."""
+    """Show keys from environment and config (masked)."""
+    from mcp_agent.config import get_settings
+
+    settings = get_settings()
     for prov, env in PROVIDERS:
-        val = os.environ.get(env)
-        tail = f"…{val[-4:]}" if val else ""
-        console.print(f"{prov}: {tail}")
+        env_val = os.environ.get(env)
+        cfg = getattr(settings, prov, None)
+        cfg_val = getattr(cfg, "api_key", None) if cfg else None
+        active = cfg_val or env_val
+        tail = f"…{active[-4:]}" if active else ""
+        source = "config" if cfg_val else ("env" if env_val else "none")
+        console.print(f"{prov}: {tail} ({source})")
 
 
 @app.command("set")
 def set_key(provider: str, key: str) -> None:
-    """Scaffold: export to environment for current process only."""
+    """Set key in secrets file (and session env)."""
+    import yaml
+    from mcp_agent.config import Settings
+
     mapping = {p: e for p, e in PROVIDERS}
     env = mapping.get(provider)
     if not env:
         typer.secho("Unknown provider", fg=typer.colors.RED, err=True)
         raise typer.Exit(6)
+
+    # Update environment for current process
     os.environ[env] = key
-    console.print(f"Set {provider} key (session)")
+
+    # Persist to secrets yaml
+    sec_path = Settings.find_secrets()
+    if not sec_path:
+        # create under .mcp-agent
+        from pathlib import Path as _Path
+
+        sec_dir = _Path.cwd() / ".mcp-agent"
+        sec_dir.mkdir(exist_ok=True)
+        sec_path = sec_dir / "mcp_agent.secrets.yaml"
+        data = {}
+    else:
+        try:
+            data = yaml.safe_load(sec_path.read_text()) or {}
+        except Exception:
+            data = {}
+
+    if provider not in data or not isinstance(data.get(provider), dict):
+        data[provider] = {}
+    data[provider]["api_key"] = key
+
+    try:
+        sec_path.write_text(yaml.safe_dump(data, sort_keys=False))
+        console.print(f"Persisted {provider} key to {sec_path}")
+    except Exception as e:
+        typer.secho(f"Failed to write secrets: {e}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(5)
 
 
 @app.command("unset")
 def unset(provider: str) -> None:
+    import yaml
+    from mcp_agent.config import Settings
+
     mapping = {p: e for p, e in PROVIDERS}
     env = mapping.get(provider)
     if not env:
         typer.secho("Unknown provider", fg=typer.colors.RED, err=True)
         raise typer.Exit(6)
     os.environ.pop(env, None)
+
+    sec_path = Settings.find_secrets()
+    if sec_path and sec_path.exists():
+        try:
+            data = yaml.safe_load(sec_path.read_text()) or {}
+            sect = data.get(provider)
+            if isinstance(sect, dict) and "api_key" in sect:
+                sect.pop("api_key", None)
+                data[provider] = sect
+                sec_path.write_text(yaml.safe_dump(data, sort_keys=False))
+                console.print(f"Removed {provider} key from {sec_path}")
+        except Exception:
+            pass
     console.print(f"Unset {provider} key (session)")
-
-

--- a/src/mcp_agent/cli/commands/logs.py
+++ b/src/mcp_agent/cli/commands/logs.py
@@ -1,0 +1,32 @@
+"""
+Local logs tailing (scaffold).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import typer
+from rich.console import Console
+
+
+app = typer.Typer(help="Tail local logs")
+console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def logs(
+    file: Path = typer.Option(Path("mcp-agent.jsonl"), "--file"),
+    follow: bool = typer.Option(False, "--follow"),
+    limit: int = typer.Option(200, "--limit"),
+) -> None:
+    """Minimal file tailer (scaffold)."""
+    try:
+        lines = file.read_text(encoding="utf-8").splitlines()[-limit:]
+    except Exception:
+        lines = []
+    for line in lines:
+        console.print(line)
+    if follow:
+        console.print("--follow not implemented yet (scaffold)")
+
+

--- a/src/mcp_agent/cli/commands/logs.py
+++ b/src/mcp_agent/cli/commands/logs.py
@@ -1,32 +1,297 @@
 """
-Local logs tailing (scaffold).
+Local logs tailing with basic filters.
+Resolves log file from Settings.logger.path or path_settings pattern.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+import re
+import glob
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Tuple
+
 import typer
 from rich.console import Console
+from mcp_agent.config import get_settings
 
 
 app = typer.Typer(help="Tail local logs")
 console = Console()
 
 
+def _resolve_log_file(explicit: Path | None) -> Path | None:
+    if explicit:
+        return explicit if explicit.exists() else None
+    cfg = get_settings()
+    if cfg.logger and cfg.logger.path:
+        p = Path(cfg.logger.path)
+        if p.exists():
+            return p
+    # Try resolving pattern
+    try:
+        if (
+            cfg.logger
+            and cfg.logger.path_settings
+            and cfg.logger.path_settings.path_pattern
+        ):
+            pattern = cfg.logger.path_settings.path_pattern.replace("{unique_id}", "*")
+            paths = glob.glob(pattern)
+            if paths:
+                paths = sorted(
+                    paths, key=lambda p: Path(p).stat().st_mtime, reverse=True
+                )
+                return Path(paths[0])
+    except Exception:
+        pass
+    return None
+
+
+def _parse_rfc3339(ts: str) -> datetime | None:
+    try:
+        # Support trailing Z
+        if ts.endswith("Z"):
+            ts = ts[:-1] + "+00:00"
+        return datetime.fromisoformat(ts)
+    except Exception:
+        return None
+
+
+def _parse_duration(s: str) -> timedelta | None:
+    if not s:
+        return None
+    try:
+        s = s.strip().lower()
+        # Support composite like 1h30m (optional)
+        total = 0.0
+        num = ""
+        for ch in s:
+            if ch.isdigit() or ch == ".":
+                num += ch
+                continue
+            if not num:
+                return None
+            val = float(num)
+            if ch == "s":
+                total += val
+            elif ch == "m":
+                total += val * 60
+            elif ch == "h":
+                total += val * 3600
+            elif ch == "d":
+                total += val * 86400
+            elif ch == "w":
+                total += val * 604800
+            else:
+                return None
+            num = ""
+        if num:
+            # Bare number defaults to seconds
+            total += float(num)
+        return timedelta(seconds=total)
+    except Exception:
+        return None
+
+
+def _level_value(level: str | None) -> int:
+    if not level:
+        return 0
+    lvl = str(level).upper()
+    mapping = {"DEBUG": 10, "INFO": 20, "WARNING": 30, "ERROR": 40}
+    return mapping.get(lvl, 0)
+
+
+def _extract_tokens(data: Any) -> int:
+    """Best-effort token count extractor from a log entry's data field.
+
+    Looks for common keys like total_tokens, tokens, input_tokens+output_tokens, or nested fields.
+    """
+
+    def from_dict(d: Dict[str, Any]) -> int:
+        # Direct fields
+        if "total_tokens" in d and isinstance(d["total_tokens"], (int, float)):
+            return int(d["total_tokens"])
+        if "tokens" in d and isinstance(d["tokens"], (int, float)):
+            return int(d["tokens"])
+        # Sum input/output if present
+        it = d.get("input_tokens")
+        ot = d.get("output_tokens")
+        if isinstance(it, (int, float)) or isinstance(ot, (int, float)):
+            return int((it or 0) + (ot or 0))
+        # Nested common containers
+        for key in ("usage", "total_usage", "token_usage", "summary"):
+            v = d.get(key)
+            if isinstance(v, dict):
+                val = from_dict(v)
+                if val:
+                    return val
+        return 0
+
+    try:
+        if isinstance(data, dict):
+            return from_dict(data)
+        return 0
+    except Exception:
+        return 0
+
+
+def _filter_time(
+    entry_ts: datetime | None,
+    since_dt: datetime | None,
+    from_dt: datetime | None,
+    to_dt: datetime | None,
+) -> bool:
+    if entry_ts is None:
+        # If no timestamp, keep unless strict window specified (stay permissive)
+        return True
+    if since_dt and entry_ts < since_dt:
+        return False
+    if from_dt and entry_ts < from_dt:
+        return False
+    if to_dt and entry_ts > to_dt:
+        return False
+    return True
+
+
 @app.callback(invoke_without_command=True)
 def logs(
-    file: Path = typer.Option(Path("mcp-agent.jsonl"), "--file"),
+    file: Path = typer.Option(Path(""), "--file"),
     follow: bool = typer.Option(False, "--follow"),
     limit: int = typer.Option(200, "--limit"),
+    grep: str | None = typer.Option(None, "--grep"),
+    desc: bool = typer.Option(True, "--desc/--asc"),
+    since: str | None = typer.Option(
+        None, "--since", help="Relative window (e.g., 1h, 30m, 7d)"
+    ),
+    from_time: str | None = typer.Option(None, "--from", help="RFC3339 start time"),
+    to_time: str | None = typer.Option(None, "--to", help="RFC3339 end time"),
+    orderby: str = typer.Option(
+        "time", "--orderby", help="Sort by: time|severity|tokens"
+    ),
 ) -> None:
-    """Minimal file tailer (scaffold)."""
+    """Tail local logs with filtering and sorting (time/severity/tokens)."""
+    resolved = _resolve_log_file(file if str(file) else None)
+    if not resolved:
+        typer.secho("No log file found", err=True, fg=typer.colors.RED)
+        raise typer.Exit(2)
     try:
-        lines = file.read_text(encoding="utf-8").splitlines()[-limit:]
-    except Exception:
-        lines = []
-    for line in lines:
-        console.print(line)
-    if follow:
-        console.print("--follow not implemented yet (scaffold)")
+        # Parse time window boundaries
+        now = datetime.now(timezone.utc)
+        since_dt = None
+        if since:
+            delta = _parse_duration(since)
+            if delta:
+                since_dt = now - delta
+        from_dt = _parse_rfc3339(from_time) if from_time else None
+        to_dt = _parse_rfc3339(to_time) if to_time else None
 
+        # Normalize to aware UTC if naive
+        def _norm(dt: datetime | None) -> datetime | None:
+            if not dt:
+                return None
+            if dt.tzinfo is None:
+                return dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
 
+        since_dt = _norm(since_dt)
+        from_dt = _norm(from_dt)
+        to_dt = _norm(to_dt)
+
+        raw_lines = resolved.read_text(encoding="utf-8").splitlines()
+        if grep:
+            rx = re.compile(grep)
+            raw_lines = [ln for ln in raw_lines if rx.search(ln)]
+
+        entries: List[Tuple[Dict[str, Any] | None, str]] = []
+        for ln in raw_lines:
+            obj = None
+            if ln and ln[0] == "{":
+                try:
+                    obj = json.loads(ln)
+                except Exception:
+                    obj = None
+            entries.append((obj, ln))
+
+        # Apply time filters where possible; keep non-JSON lines permissively
+        filtered: List[
+            Tuple[Dict[str, Any] | None, str, datetime | None, int, int]
+        ] = []
+        for obj, ln in entries:
+            ts = None
+            lvl = 0
+            toks = 0
+            if isinstance(obj, dict):
+                # timestamp
+                ts_raw = obj.get("timestamp") or (obj.get("data", {}) or {}).get(
+                    "timestamp"
+                )
+                if isinstance(ts_raw, str):
+                    ts = _parse_rfc3339(ts_raw)
+                    if ts and ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                # level
+                lvl = _level_value(obj.get("level"))
+                # tokens
+                toks = _extract_tokens(obj.get("data"))
+            if _filter_time(ts, since_dt, from_dt, to_dt):
+                filtered.append((obj, ln, ts, lvl, toks))
+
+        key = orderby.strip().lower() if orderby else "time"
+        if key not in ("time", "severity", "tokens"):
+            key = "time"
+
+        def sort_key(item):
+            _obj, _ln, ts, lvl, toks = item
+            if key == "severity":
+                return lvl
+            if key == "tokens":
+                return toks
+            # default time
+            # None timestamps sort as oldest
+            return ts or datetime.fromtimestamp(0, tz=timezone.utc)
+
+        sorted_entries = sorted(filtered, key=sort_key, reverse=desc)
+        if limit > 0:
+            sorted_entries = sorted_entries[:limit]
+
+        for _obj, ln, *_ in sorted_entries:
+            console.print(ln)
+
+        if follow:
+            import time
+
+            console.print("Following... (Ctrl+C to stop)")
+            with resolved.open("r", encoding="utf-8") as f:
+                f.seek(0, 2)
+                try:
+                    while True:
+                        line = f.readline()
+                        if not line:
+                            time.sleep(0.5)
+                            continue
+                        if grep and not re.search(grep, line):
+                            continue
+                        obj = None
+                        if line and line[0] == "{":
+                            try:
+                                obj = json.loads(line)
+                            except Exception:
+                                obj = None
+                        ts = None
+                        if isinstance(obj, dict):
+                            ts_raw = obj.get("timestamp") or (
+                                obj.get("data", {}) or {}
+                            ).get("timestamp")
+                            if isinstance(ts_raw, str):
+                                ts = _parse_rfc3339(ts_raw)
+                                if ts and ts.tzinfo is None:
+                                    ts = ts.replace(tzinfo=timezone.utc)
+                        if not _filter_time(ts, since_dt, from_dt, to_dt):
+                            continue
+                        console.print(line.rstrip("\n"))
+                except KeyboardInterrupt:
+                    pass
+    except Exception as e:
+        typer.secho(f"Error reading logs: {e}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(5)

--- a/src/mcp_agent/cli/commands/models.py
+++ b/src/mcp_agent/cli/commands/models.py
@@ -30,7 +30,9 @@ def list_models(format: str = typer.Option("text", "--format")) -> None:
         try:
             import yaml  # type: ignore
 
-            console.print(yaml.safe_dump([m.model_dump() for m in models], sort_keys=False))
+            console.print(
+                yaml.safe_dump([m.model_dump() for m in models], sort_keys=False)
+            )
             return
         except Exception:
             pass
@@ -41,14 +43,48 @@ def list_models(format: str = typer.Option("text", "--format")) -> None:
     table.add_column("Context")
     table.add_column("Tool use")
     for m in models:
-        table.add_row(m.provider, m.name, str(m.context_window or ""), "✔" if m.tool_calling else "")
+        table.add_row(
+            m.provider,
+            m.name,
+            str(m.context_window or ""),
+            "✔" if m.tool_calling else "",
+        )
     console.print(table)
 
 
 @app.command("set-default")
-def set_default(name: str = typer.Argument(..., help="Provider-qualified name")) -> None:
-    """Scaffold for setting default model (to be implemented)."""
-    # Full implementation will update config.yaml; for now just acknowledge.
-    console.print(f"Setting default model to: {name} (scaffold)")
+def set_default(
+    name: str = typer.Argument(..., help="Provider-qualified name"),
+) -> None:
+    """Set provider default model in config, writing to discovered file."""
+    from pathlib import Path
+    import yaml
+    from mcp_agent.config import Settings
 
+    cfg_path = Settings.find_config()
+    if not cfg_path or not cfg_path.exists():
+        typer.secho("Config file not found", err=True, fg=typer.colors.RED)
+        raise typer.Exit(2)
 
+    try:
+        data = yaml.safe_load(cfg_path.read_text()) or {}
+        # name may be provider.model or provider:model
+        prov = None
+        model_name = name
+        if ":" in name:
+            prov, model_name = name.split(":", 1)
+        elif "." in name:
+            parts = name.split(".", 1)
+            prov, model_name = parts[0], parts[1]
+        prov = (prov or "openai").lower()
+
+        # Ensure provider section exists, set default_model
+        if prov not in data:
+            data[prov] = {}
+        data[prov]["default_model"] = model_name
+
+        cfg_path.write_text(yaml.safe_dump(data, sort_keys=False))
+        console.print(f"Updated {cfg_path} -> {prov}.default_model = {model_name}")
+    except Exception as e:
+        typer.secho(f"Failed to update config: {e}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(5)

--- a/src/mcp_agent/cli/commands/models.py
+++ b/src/mcp_agent/cli/commands/models.py
@@ -1,0 +1,54 @@
+"""
+Models command group: list and set-default (scaffold).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from mcp_agent.workflows.llm.llm_selector import load_default_models
+
+
+app = typer.Typer(help="List and manage models")
+console = Console()
+
+
+@app.command("list")
+def list_models(format: str = typer.Option("text", "--format")) -> None:
+    """List known model catalog (from embedded benchmarks)."""
+    models = load_default_models()
+    if format.lower() == "json":
+        data = [m.model_dump() for m in models]
+        console.print_json(json.dumps(data))
+        return
+    if format.lower() == "yaml":
+        try:
+            import yaml  # type: ignore
+
+            console.print(yaml.safe_dump([m.model_dump() for m in models], sort_keys=False))
+            return
+        except Exception:
+            pass
+
+    table = Table(show_header=True, header_style="bold", title="Models")
+    table.add_column("Provider")
+    table.add_column("Name")
+    table.add_column("Context")
+    table.add_column("Tool use")
+    for m in models:
+        table.add_row(m.provider, m.name, str(m.context_window or ""), "✔" if m.tool_calling else "")
+    console.print(table)
+
+
+@app.command("set-default")
+def set_default(name: str = typer.Argument(..., help="Provider-qualified name")) -> None:
+    """Scaffold for setting default model (to be implemented)."""
+    # Full implementation will update config.yaml; for now just acknowledge.
+    console.print(f"Setting default model to: {name} (scaffold)")
+
+

--- a/src/mcp_agent/cli/commands/quickstart.py
+++ b/src/mcp_agent/cli/commands/quickstart.py
@@ -48,10 +48,56 @@ def overview() -> None:
 
 
 @app.command()
-def workflow(dir: Path = typer.Argument(Path(".")), force: bool = typer.Option(False, "--force", "-f")) -> None:
+def workflow(
+    dir: Path = typer.Argument(Path(".")),
+    force: bool = typer.Option(False, "--force", "-f"),
+) -> None:
     src = EXAMPLE_ROOT / "workflows"
     dst = dir.resolve() / "workflow"
     copied = _copy_tree(src, dst, force)
     console.print(f"Copied {copied} set(s) to {dst}")
 
 
+@app.command()
+def researcher(
+    dir: Path = typer.Argument(Path(".")),
+    force: bool = typer.Option(False, "--force", "-f"),
+) -> None:
+    src = EXAMPLE_ROOT / "usecases" / "mcp_researcher"
+    dst = dir.resolve() / "researcher"
+    copied = _copy_tree(src, dst, force)
+    console.print(f"Copied {copied} set(s) to {dst}")
+
+
+@app.command("elicitations")
+def elicitations_qs(
+    dir: Path = typer.Argument(Path(".")),
+    force: bool = typer.Option(False, "--force", "-f"),
+) -> None:
+    src = EXAMPLE_ROOT.parent / "mcp" / "elicitations"
+    dst = dir.resolve() / "elicitations"
+    copied = _copy_tree(src, dst, force)
+    console.print(f"Copied {copied} set(s) to {dst}")
+
+
+@app.command("state-transfer")
+def state_transfer(
+    dir: Path = typer.Argument(Path(".")),
+    force: bool = typer.Option(False, "--force", "-f"),
+) -> None:
+    src = EXAMPLE_ROOT / "workflows" / "workflow_router"
+    dst = dir.resolve() / "state-transfer"
+    copied = _copy_tree(src, dst, force)
+    console.print(f"Copied {copied} set(s) to {dst}")
+
+
+@app.command("data-analysis")
+def data_analysis(
+    dir: Path = typer.Argument(Path(".")),
+    force: bool = typer.Option(False, "--force", "-f"),
+) -> None:
+    # Map to financial analyzer example as the closest match
+    src = EXAMPLE_ROOT / "usecases" / "mcp_financial_analyzer"
+    dst = dir.resolve() / "data-analysis"
+    copied = _copy_tree(src, dst, force)
+    console.print(f"Copied {copied} set(s) to {dst}")

--- a/src/mcp_agent/cli/commands/quickstart.py
+++ b/src/mcp_agent/cli/commands/quickstart.py
@@ -1,0 +1,57 @@
+"""
+Quickstart examples: scaffolded adapters over repository examples.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+
+app = typer.Typer(help="Copy curated examples")
+console = Console()
+
+
+EXAMPLE_ROOT = Path(__file__).parents[4] / "examples"
+
+
+def _copy_tree(src: Path, dst: Path, force: bool) -> int:
+    if not src.exists():
+        typer.echo(f"Source not found: {src}", err=True)
+        return 0
+    if dst.exists() and force:
+        shutil.rmtree(dst)
+    if not dst.exists():
+        shutil.copytree(src, dst)
+        return 1
+    return 0
+
+
+@app.callback(invoke_without_command=True)
+def overview() -> None:
+    table = Table(title="Quickstarts")
+    table.add_column("Name")
+    table.add_column("Path")
+    rows = [
+        ("workflow", "examples/workflows"),
+        ("researcher", "examples/usecases/mcp_researcher"),
+        ("data-analysis", "examples/usecases/mcp_financial_analyzer"),
+        ("state-transfer", "examples/workflows/workflow_router"),
+    ]
+    for n, p in rows:
+        table.add_row(n, p)
+    console.print(table)
+
+
+@app.command()
+def workflow(dir: Path = typer.Argument(Path(".")), force: bool = typer.Option(False, "--force", "-f")) -> None:
+    src = EXAMPLE_ROOT / "workflows"
+    dst = dir.resolve() / "workflow"
+    copied = _copy_tree(src, dst, force)
+    console.print(f"Copied {copied} set(s) to {dst}")
+
+

--- a/src/mcp_agent/cli/commands/serve.py
+++ b/src/mcp_agent/cli/commands/serve.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 
 import asyncio
 from typing import Optional
+from pathlib import Path
 
 import typer
 from rich.console import Console
 
 from mcp_agent.app import MCPApp
 from mcp_agent.server.app_server import create_mcp_server_for_app
+from mcp_agent.cli.core.utils import load_user_app
 
 
 app = typer.Typer(help="Serve app as an MCP server")
@@ -23,31 +25,32 @@ def serve(
     script: Optional[str] = typer.Option(None, "--script"),
     transport: str = typer.Option("stdio", "--transport"),
     port: Optional[int] = typer.Option(None, "--port"),
+    host: str = typer.Option("0.0.0.0", "--host"),
 ) -> None:
     """Start an MCP server for the user's app (minimal stdio/http)."""
 
     async def _run():
-        mcp_app = MCPApp(name="mcp-agent server")
-        await mcp_app.initialize()
-        mcp = create_mcp_server_for_app(mcp_app)
+        app_obj = load_user_app(Path(script) if script else Path("agent.py"))
+        await app_obj.initialize()
+        mcp = create_mcp_server_for_app(app_obj)
         if transport == "stdio":
-            # FastMCP will manage stdio run within its own runner when launched by client
-            console.print("MCP server (stdio) initialized.")
+            await mcp.run_stdio_async()
         else:
             # http/sse: run uvicorn inside this process if requested
             try:
                 import uvicorn  # type: ignore
 
-                host = "0.0.0.0"
-                uvicorn_config = uvicorn.Config(mcp.app, host=host, port=port or 8000, log_level="info")
+                uvicorn_config = uvicorn.Config(
+                    mcp.app, host=host, port=port or 8000, log_level="info"
+                )
                 server = uvicorn.Server(uvicorn_config)
                 await server.serve()
             except Exception as e:
-                typer.secho(f"Failed to start HTTP server: {e}", fg=typer.colors.RED, err=True)
+                typer.secho(
+                    f"Failed to start HTTP server: {e}", fg=typer.colors.RED, err=True
+                )
 
     try:
         asyncio.run(_run())
     except KeyboardInterrupt:
         pass
-
-

--- a/src/mcp_agent/cli/commands/serve.py
+++ b/src/mcp_agent/cli/commands/serve.py
@@ -1,0 +1,53 @@
+"""
+Serve your app as an MCP server (scaffold).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+import typer
+from rich.console import Console
+
+from mcp_agent.app import MCPApp
+from mcp_agent.server.app_server import create_mcp_server_for_app
+
+
+app = typer.Typer(help="Serve app as an MCP server")
+console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def serve(
+    script: Optional[str] = typer.Option(None, "--script"),
+    transport: str = typer.Option("stdio", "--transport"),
+    port: Optional[int] = typer.Option(None, "--port"),
+) -> None:
+    """Start an MCP server for the user's app (minimal stdio/http)."""
+
+    async def _run():
+        mcp_app = MCPApp(name="mcp-agent server")
+        await mcp_app.initialize()
+        mcp = create_mcp_server_for_app(mcp_app)
+        if transport == "stdio":
+            # FastMCP will manage stdio run within its own runner when launched by client
+            console.print("MCP server (stdio) initialized.")
+        else:
+            # http/sse: run uvicorn inside this process if requested
+            try:
+                import uvicorn  # type: ignore
+
+                host = "0.0.0.0"
+                uvicorn_config = uvicorn.Config(mcp.app, host=host, port=port or 8000, log_level="info")
+                server = uvicorn.Server(uvicorn_config)
+                await server.serve()
+            except Exception as e:
+                typer.secho(f"Failed to start HTTP server: {e}", fg=typer.colors.RED, err=True)
+
+    try:
+        asyncio.run(_run())
+    except KeyboardInterrupt:
+        pass
+
+

--- a/src/mcp_agent/cli/commands/server.py
+++ b/src/mcp_agent/cli/commands/server.py
@@ -11,10 +11,70 @@ from rich.console import Console
 from rich.table import Table
 
 from mcp_agent.config import Settings, MCPServerSettings, MCPSettings
+from mcp_agent.cli.utils.importers import import_servers_from_mcp_json
 
 
 app = typer.Typer(help="Local server helpers")
 console = Console()
+
+
+def _load_config_yaml(path: Settings | None = None):
+    import yaml
+
+    cfg_path = Settings.find_config()
+    data = {}
+    if cfg_path and cfg_path.exists():
+        try:
+            data = yaml.safe_load(cfg_path.read_text()) or {}
+        except Exception:
+            data = {}
+    return cfg_path, data
+
+
+def _persist_server_entry(name: str, settings: MCPServerSettings) -> None:
+    import yaml
+
+    cfg_path, data = _load_config_yaml()
+    # Ensure structure
+    if "mcp" not in data:
+        data["mcp"] = {}
+    if "servers" not in data["mcp"] or data["mcp"]["servers"] is None:
+        data["mcp"]["servers"] = {}
+    # Build plain dict from settings
+    entry = {
+        "transport": settings.transport,
+    }
+    if settings.transport == "stdio":
+        if settings.command:
+            entry["command"] = settings.command
+        if settings.args:
+            entry["args"] = settings.args
+        if settings.env:
+            entry["env"] = settings.env
+    else:
+        if settings.url:
+            entry["url"] = settings.url
+        if settings.headers:
+            entry["headers"] = settings.headers
+
+    data["mcp"]["servers"][name] = entry
+
+    # Decide path to write
+    if not cfg_path:
+        cfg_path = Settings.find_config() or Settings.find_config()  # try discovery
+        if not cfg_path:
+            cfg_path = Settings.find_config()
+    # If discovery failed, write to default file in CWD
+    if not cfg_path:
+        cfg_path = Settings.find_config() or None
+    # Fallback path in CWD
+    from pathlib import Path as _Path
+
+    if not cfg_path:
+        cfg_path = _Path("mcp_agent.config.yaml")
+
+    cfg_path.write_text(yaml.safe_dump(data, sort_keys=False))
+    console.print(f"Wrote server '{name}' to {cfg_path}")
 
 
 @app.command("list")
@@ -33,17 +93,107 @@ def list_servers() -> None:
 
 @app.command("add")
 def add(
-    kind: str = typer.Argument(..., help="http|sse|stdio|npx|uvx"),
-    value: str = typer.Argument(..., help="url or quoted command"),
+    kind: str = typer.Argument(..., help="http|sse|stdio|npx|uvx|dxt|recipe"),
+    value: str = typer.Argument(..., help="url or quoted command or recipe name"),
     name: Optional[str] = typer.Option(None, "--name"),
     auth: Optional[str] = typer.Option(None, "--auth"),
+    write: bool = typer.Option(
+        True, "--write/--no-write", help="Persist to config file"
+    ),
 ) -> None:
     settings = Settings()
     if settings.mcp is None:
         settings.mcp = MCPSettings()
     servers = settings.mcp.servers
     entry = MCPServerSettings()
-    if kind in ("http", "sse"):
+    if kind == "dxt":
+        # Treat value as path to .dxt (zip) or manifest directory
+        try:
+            import zipfile
+            from pathlib import Path as _Path
+            import json
+
+            p = _Path(value).expanduser().resolve()
+            extract_dir = _Path(".mcp-agent") / "extensions"
+            extract_dir.mkdir(parents=True, exist_ok=True)
+            target_dir = None
+            if p.suffix.lower() == ".dxt" and p.is_file():
+                with zipfile.ZipFile(p, "r") as zf:
+                    base = p.stem
+                    target_dir = extract_dir / base
+                    if target_dir.exists():
+                        # Overwrite
+                        import shutil
+
+                        shutil.rmtree(target_dir)
+                    zf.extractall(target_dir)
+            elif p.is_dir():
+                target_dir = p
+            else:
+                raise ValueError("DXT path must be a .dxt file or a directory")
+
+            manifest = None
+            for cand in [target_dir / "manifest.json", target_dir / "package.json"]:
+                if cand.exists():
+                    manifest = json.loads(cand.read_text())
+                    break
+            if not manifest:
+                raise ValueError("manifest.json not found in DXT package")
+
+            server_name = name or manifest.get("name") or target_dir.name
+            # Try common fields
+            stdio = manifest.get("stdio") or {}
+            cmd = stdio.get("command") or manifest.get("command")
+            args = stdio.get("args") or manifest.get("args") or []
+            env = stdio.get("env") or manifest.get("env") or {}
+            if not cmd:
+                raise ValueError("DXT manifest missing stdio command")
+            entry.transport = "stdio"
+            entry.command = cmd
+            entry.args = args
+            entry.env = env
+            servers[server_name] = entry
+            if write:
+                _persist_server_entry(server_name, entry)
+            console.print(f"Added DXT server '{server_name}' => {cmd} {args}")
+            return
+        except Exception as e:
+            typer.secho(f"Failed to add dxt server: {e}", err=True, fg=typer.colors.RED)
+            raise typer.Exit(5)
+    elif kind == "recipe":
+        recipes = {
+            "filesystem": {
+                "transport": "stdio",
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+            },
+            "fetch": {
+                "transport": "stdio",
+                "command": "uvx",
+                "args": ["mcp-server-fetch"],
+            },
+            # Add a safe 'roots' recipe using server-filesystem with roots mapping
+            # Users can later edit config to customize
+            "roots": {
+                "transport": "stdio",
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+            },
+        }
+        rec = recipes.get(value)
+        if not rec:
+            typer.secho("Unknown recipe", err=True, fg=typer.colors.RED)
+            raise typer.Exit(6)
+        entry.transport = rec["transport"]
+        entry.command = rec.get("command")
+        entry.args = rec.get("args") or []
+        srv_name = name or value
+        servers[srv_name] = entry
+        if write:
+            _persist_server_entry(srv_name, entry)
+        console.print(f"Added recipe server '{srv_name}'")
+        return
+    elif kind in ("http", "sse"):
         entry.transport = kind
         entry.url = value
         if auth:
@@ -56,12 +206,148 @@ def add(
         entry.args = parts[1:]
     srv_name = name or (value.split("/")[-1] if kind in ("http", "sse") else parts[0])
     servers[srv_name] = entry
+    if write:
+        _persist_server_entry(srv_name, entry)
     console.print(f"Added server '{srv_name}' (not yet persisted)")
 
 
 @app.command("test")
 def test(name: str, timeout: float = typer.Option(10.0, "--timeout")) -> None:
-    """Scaffold for server health probe: lists tools if reachable (future)."""
-    console.print(f"Testing server {name} (timeout={timeout}) - scaffold")
+    """Initialize app context, connect to server, and print capabilities/tools."""
+    import asyncio
+    from mcp_agent.app import MCPApp
+    from mcp_agent.agents.agent import Agent
+
+    async def _probe():
+        app_obj = MCPApp(name="server-test")
+        async with app_obj.run():
+            agent = Agent(name="probe", server_names=[name], context=app_obj.context)
+            async with agent:
+                caps = await agent.get_capabilities(server_name=name)
+                console.print("Capabilities:")
+                console.print(caps)
+                tools = await agent.list_tools(server_name=name)
+                console.print("Tools:")
+                for t in tools.tools:
+                    console.print(f"- {t.name}")
+                resources = await agent.list_resources(server_name=name)
+                console.print("Resources:")
+                for r in resources.resources:
+                    console.print(f"- {r.uri}")
+
+    try:
+        asyncio.run(_probe())
+    except Exception as e:
+        typer.secho(f"Server test failed: {e}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(5)
 
 
+# Import subcommands
+import_app = typer.Typer(help="Import server configs from common sources")
+
+
+@import_app.command("dxt")
+def import_dxt(path: str, name: Optional[str] = typer.Option(None, "--name")) -> None:
+    """Import a Desktop Extension (.dxt or manifest dir) and persist server entry."""
+    add(kind="dxt", value=path, name=name, write=True)
+
+
+@import_app.command("mcp-json")
+def import_mcp_json(path: str) -> None:
+    """Import servers from a cursor/vscode style mcp.json and persist entries."""
+    from pathlib import Path as _Path
+
+    p = _Path(path).expanduser().resolve()
+    if not p.exists():
+        typer.secho("mcp.json not found", err=True, fg=typer.colors.RED)
+        raise typer.Exit(2)
+    try:
+        imported = import_servers_from_mcp_json(p)
+        if not imported:
+            console.print("No servers found in mcp.json")
+            return
+        for name, cfg in imported.items():
+            _persist_server_entry(name, cfg)
+        console.print(f"Imported {len(imported)} servers from {p}")
+    except Exception as e:
+        typer.secho(f"Import failed: {e}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(5)
+
+
+app.add_typer(import_app, name="import")
+
+
+# Convenience imports for common client configs
+@import_app.command("cursor")
+def import_cursor() -> None:
+    """Import servers from common Cursor locations (mcp.json)."""
+    from pathlib import Path as _Path
+
+    candidates = [
+        _Path(".cursor/mcp.json").resolve(),
+        _Path.home() / ".cursor/mcp.json",
+    ]
+    imported_any = False
+    for p in candidates:
+        if p.exists():
+            try:
+                imported = import_servers_from_mcp_json(p)
+                for name, cfg in imported.items():
+                    _persist_server_entry(name, cfg)
+                    imported_any = True
+            except Exception:
+                continue
+    if imported_any:
+        console.print("Imported servers from Cursor mcp.json")
+    else:
+        console.print("No Cursor mcp.json found")
+
+
+@import_app.command("vscode")
+def import_vscode() -> None:
+    """Import servers from common VSCode locations (mcp.json)."""
+    from pathlib import Path as _Path
+
+    candidates = [
+        _Path(".vscode/mcp.json").resolve(),
+        _Path.cwd() / "mcp.json",
+    ]
+    imported_any = False
+    for p in candidates:
+        if p.exists():
+            try:
+                imported = import_servers_from_mcp_json(p)
+                for name, cfg in imported.items():
+                    _persist_server_entry(name, cfg)
+                    imported_any = True
+            except Exception:
+                continue
+    if imported_any:
+        console.print("Imported servers from VSCode mcp.json")
+    else:
+        console.print("No VSCode mcp.json found")
+
+
+@import_app.command("claude")
+def import_claude() -> None:
+    """Import servers from common Claude Code locations (mcp.json)."""
+    from pathlib import Path as _Path
+
+    candidates = [
+        _Path(".claude/mcp.json").resolve(),
+        _Path.home() / ".claude/mcp.json",
+    ]
+    imported_any = False
+    for p in candidates:
+        if p.exists():
+            try:
+                imported = import_servers_from_mcp_json(p)
+                for name, cfg in imported.items():
+                    _persist_server_entry(name, cfg)
+                    imported_any = True
+            except Exception:
+                continue
+    if imported_any:
+        console.print("Imported servers from Claude mcp.json")
+    else:
+        console.print("No Claude mcp.json found")

--- a/src/mcp_agent/cli/commands/server.py
+++ b/src/mcp_agent/cli/commands/server.py
@@ -1,0 +1,67 @@
+"""
+Local server helpers: add/import/list/test (initial scaffolding for add/list/test).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from mcp_agent.config import Settings, MCPServerSettings, MCPSettings
+
+
+app = typer.Typer(help="Local server helpers")
+console = Console()
+
+
+@app.command("list")
+def list_servers() -> None:
+    settings = Settings()
+    servers = (settings.mcp.servers if settings.mcp else {}) or {}
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name")
+    table.add_column("Transport")
+    table.add_column("URL/Command")
+    for name, s in servers.items():
+        target = s.url or s.command or ""
+        table.add_row(name, s.transport, target)
+    console.print(table)
+
+
+@app.command("add")
+def add(
+    kind: str = typer.Argument(..., help="http|sse|stdio|npx|uvx"),
+    value: str = typer.Argument(..., help="url or quoted command"),
+    name: Optional[str] = typer.Option(None, "--name"),
+    auth: Optional[str] = typer.Option(None, "--auth"),
+) -> None:
+    settings = Settings()
+    if settings.mcp is None:
+        settings.mcp = MCPSettings()
+    servers = settings.mcp.servers
+    entry = MCPServerSettings()
+    if kind in ("http", "sse"):
+        entry.transport = kind
+        entry.url = value
+        if auth:
+            entry.headers = {"Authorization": f"Bearer {auth}"}
+    else:
+        entry.transport = "stdio"
+        # naive split; robust parsing can be added later
+        parts = value.split()
+        entry.command = parts[0]
+        entry.args = parts[1:]
+    srv_name = name or (value.split("/")[-1] if kind in ("http", "sse") else parts[0])
+    servers[srv_name] = entry
+    console.print(f"Added server '{srv_name}' (not yet persisted)")
+
+
+@app.command("test")
+def test(name: str, timeout: float = typer.Option(10.0, "--timeout")) -> None:
+    """Scaffold for server health probe: lists tools if reachable (future)."""
+    console.print(f"Testing server {name} (timeout={timeout}) - scaffold")
+
+

--- a/src/mcp_agent/cli/core/utils.py
+++ b/src/mcp_agent/cli/core/utils.py
@@ -1,4 +1,11 @@
 import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+from mcp_agent.app import MCPApp
+from mcp_agent.config import MCPServerSettings, MCPSettings
 
 
 def run_async(coro):
@@ -17,3 +24,87 @@ def run_async(coro):
             loop = asyncio.get_event_loop()
             return loop.run_until_complete(coro)
         raise
+
+
+def load_user_app(script_path: Path | None) -> MCPApp:
+    """Import a user script and return an MCPApp instance.
+
+    Resolution order within module globals:
+      1) variable named 'app' that is MCPApp
+      2) callable 'create_app' or 'get_app' that returns MCPApp
+      3) first MCPApp instance found in globals
+    """
+    if script_path is None:
+        raise FileNotFoundError("No script specified")
+    script_path = script_path.resolve()
+    if not script_path.exists():
+        raise FileNotFoundError(f"Script not found: {script_path}")
+
+    module_name = script_path.stem
+    spec = importlib.util.spec_from_file_location(module_name, str(script_path))
+    if spec is None or spec.loader is None:  # pragma: no cover
+        raise ImportError(f"Cannot load module from {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+
+    # 1) app variable
+    app_obj = getattr(module, "app", None)
+    if isinstance(app_obj, MCPApp):
+        return app_obj
+
+    # 2) factory
+    for fname in ("create_app", "get_app"):
+        fn = getattr(module, fname, None)
+        if callable(fn):
+            res = fn()
+            if isinstance(res, MCPApp):
+                return res
+
+    # 3) scan globals
+    for val in module.__dict__.values():
+        if isinstance(val, MCPApp):
+            return val
+
+    raise RuntimeError(
+        f"No MCPApp instance found in {script_path}. Define 'app = MCPApp(...)' or a create_app()."
+    )
+
+
+def ensure_mcp_servers(app: MCPApp) -> None:
+    """Ensure app.context.config has mcp servers dict initialized."""
+    cfg = app.context.config
+    if cfg.mcp is None:
+        cfg.mcp = MCPSettings()
+    if cfg.mcp.servers is None:
+        cfg.mcp.servers = {}
+
+
+def attach_url_servers(app: MCPApp, servers: Dict[str, Dict[str, Any]] | None) -> None:
+    """Attach URL-based servers (http/sse/streamable_http) to app config."""
+    if not servers:
+        return
+    ensure_mcp_servers(app)
+    for name, desc in servers.items():
+        settings = MCPServerSettings(
+            transport=desc.get("transport", "http"),
+            url=desc.get("url"),
+            headers=desc.get("headers"),
+        )
+        app.context.config.mcp.servers[name] = settings
+
+
+def attach_stdio_servers(
+    app: MCPApp, servers: Dict[str, Dict[str, Any]] | None
+) -> None:
+    """Attach stdio/npx/uvx servers to app config."""
+    if not servers:
+        return
+    ensure_mcp_servers(app)
+    for name, desc in servers.items():
+        settings = MCPServerSettings(
+            transport="stdio",
+            command=desc.get("command"),
+            args=desc.get("args", []),
+        )
+        app.context.config.mcp.servers[name] = settings

--- a/src/mcp_agent/cli/main.py
+++ b/src/mcp_agent/cli/main.py
@@ -9,8 +9,6 @@ progressively.
 
 from __future__ import annotations
 
-import sys
-from typing import Optional
 
 import typer
 from rich.console import Console
@@ -38,6 +36,8 @@ from mcp_agent.cli.commands import (
     logs as logs_cmd,
     doctor as doctor_cmd,
     configure as configure_cmd,
+    go as go_cmd,
+    check as check_cmd,
 )
 
 
@@ -66,12 +66,18 @@ def _print_version() -> None:
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output"),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose output"
+    ),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Reduce output"),
-    color: bool = typer.Option(True, "--color/--no-color", help="Enable/disable color output"),
+    color: bool = typer.Option(
+        True, "--color/--no-color", help="Enable/disable color output"
+    ),
     version: bool = typer.Option(False, "--version", help="Show version and exit"),
     format: str = typer.Option(
-        "text", "--format", help="Output format for list/describe commands",
+        "text",
+        "--format",
+        help="Output format for list/describe commands",
         show_default=True,
         case_sensitive=False,
     ),
@@ -103,15 +109,21 @@ def main(
 # Mount non-cloud command groups
 app.add_typer(init_cmd.app, name="init", help="Scaffold a new mcp-agent project")
 app.add_typer(quickstart_cmd.app, name="quickstart", help="Copy curated examples")
+app.add_typer(go_cmd.app, name="go", help="Quick interactive agent")
+app.add_typer(check_cmd.app, name="check", help="Check configuration and environment")
 app.add_typer(config_cmd.app, name="config", help="Manage and inspect configuration")
 app.add_typer(keys_cmd.app, name="keys", help="Manage provider API keys")
 app.add_typer(models_cmd.app, name="models", help="List and manage models")
 app.add_typer(chat_cmd.app, name="chat", help="Ephemeral REPL for quick iteration")
 app.add_typer(dev_cmd.app, name="dev", help="Run app locally with live reload")
-app.add_typer(invoke_cmd.app, name="invoke", help="Invoke agent/workflow programmatically")
+app.add_typer(
+    invoke_cmd.app, name="invoke", help="Invoke agent/workflow programmatically"
+)
 app.add_typer(serve_cmd.app, name="serve", help="Serve app as an MCP server")
 app.add_typer(server_cmd.app, name="server", help="Local server helpers")
-app.add_typer(build_cmd.app, name="build", help="Preflight and bundle prep for deployment")
+app.add_typer(
+    build_cmd.app, name="build", help="Preflight and bundle prep for deployment"
+)
 app.add_typer(logs_cmd.app, name="logs", help="Tail local logs")
 app.add_typer(doctor_cmd.app, name="doctor", help="Comprehensive diagnostics")
 app.add_typer(configure_cmd.app, name="configure", help="Client integration helpers")
@@ -158,5 +170,3 @@ def run() -> None:
 
 if __name__ == "__main__":
     run()
-
-

--- a/src/mcp_agent/cli/main.py
+++ b/src/mcp_agent/cli/main.py
@@ -1,0 +1,162 @@
+"""
+Top-level CLI entrypoint for mcp-agent (non-cloud + cloud groups).
+
+Uses Typer and Rich. This module wires together all non-cloud command groups
+and mounts the existing cloud CLI under the `cloud` namespace. Initial
+implementation provides scaffolding; individual commands can be implemented
+progressively.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+import typer
+from rich.console import Console
+
+# Mount existing cloud CLI
+try:
+    from mcp_agent.cli.cloud.main import app as cloud_app  # type: ignore
+except Exception:  # pragma: no cover - cloud is optional for non-cloud development
+    cloud_app = typer.Typer(help="Cloud commands (unavailable)")
+
+
+# Local command groups (scaffolded)
+from mcp_agent.cli.commands import (
+    chat as chat_cmd,
+    dev as dev_cmd,
+    invoke as invoke_cmd,
+    serve as serve_cmd,
+    init as init_cmd,
+    quickstart as quickstart_cmd,
+    config as config_cmd,
+    keys as keys_cmd,
+    models as models_cmd,
+    server as server_cmd,
+    build as build_cmd,
+    logs as logs_cmd,
+    doctor as doctor_cmd,
+    configure as configure_cmd,
+)
+
+
+app = typer.Typer(
+    help="mcp-agent CLI",
+    add_completion=False,
+    no_args_is_help=False,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+
+
+console = Console(stderr=False)
+err_console = Console(stderr=True)
+
+
+def _print_version() -> None:
+    try:
+        import importlib.metadata as _im
+
+        ver = _im.version("mcp-agent")
+    except Exception:
+        ver = "unknown"
+    console.print(f"mcp-agent {ver}")
+
+
+@app.callback(invoke_without_command=True)
+def main(
+    ctx: typer.Context,
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output"),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Reduce output"),
+    color: bool = typer.Option(True, "--color/--no-color", help="Enable/disable color output"),
+    version: bool = typer.Option(False, "--version", help="Show version and exit"),
+    format: str = typer.Option(
+        "text", "--format", help="Output format for list/describe commands",
+        show_default=True,
+        case_sensitive=False,
+    ),
+) -> None:
+    """mcp-agent command line interface."""
+    # Persist global options on context for subcommands
+    ctx.obj = {
+        "verbose": verbose,
+        "quiet": quiet,
+        "color": color,
+        "format": format.lower(),
+    }
+
+    if not color:
+        # Disable colors globally for both std and err consoles
+        console.no_color = True
+        err_console.no_color = True
+
+    if version:
+        _print_version()
+        raise typer.Exit(0)
+
+    # If no subcommand given, show brief overview
+    if ctx.invoked_subcommand is None:
+        console.print("mcp-agent - Model Context Protocol agent CLI\n")
+        console.print("Run 'mcp-agent --help' to see all commands.")
+
+
+# Mount non-cloud command groups
+app.add_typer(init_cmd.app, name="init", help="Scaffold a new mcp-agent project")
+app.add_typer(quickstart_cmd.app, name="quickstart", help="Copy curated examples")
+app.add_typer(config_cmd.app, name="config", help="Manage and inspect configuration")
+app.add_typer(keys_cmd.app, name="keys", help="Manage provider API keys")
+app.add_typer(models_cmd.app, name="models", help="List and manage models")
+app.add_typer(chat_cmd.app, name="chat", help="Ephemeral REPL for quick iteration")
+app.add_typer(dev_cmd.app, name="dev", help="Run app locally with live reload")
+app.add_typer(invoke_cmd.app, name="invoke", help="Invoke agent/workflow programmatically")
+app.add_typer(serve_cmd.app, name="serve", help="Serve app as an MCP server")
+app.add_typer(server_cmd.app, name="server", help="Local server helpers")
+app.add_typer(build_cmd.app, name="build", help="Preflight and bundle prep for deployment")
+app.add_typer(logs_cmd.app, name="logs", help="Tail local logs")
+app.add_typer(doctor_cmd.app, name="doctor", help="Comprehensive diagnostics")
+app.add_typer(configure_cmd.app, name="configure", help="Client integration helpers")
+
+# Mount cloud commands
+app.add_typer(cloud_app, name="cloud", help="MCP Agent Cloud commands")
+
+
+# Back-compat top-level aliases -> cloud
+@app.command("deploy")
+def alias_deploy(*args: str) -> None:
+    """Alias for 'mcp-agent cloud deploy'."""
+    # Defer execution to cloud app main
+    from mcp_agent.cli.cloud.main import app as _cloud
+
+    # Re-invoke Typer subcommand programmatically
+    # Simple message to guide user
+    console.print("Use 'mcp-agent cloud deploy' (alias invoked).")
+    _cloud(
+        prog_name=f"{typer.get_app_dir('mcp-agent')}",
+        standalone_mode=False,
+    )
+
+
+@app.command("login")
+def alias_login() -> None:
+    console.print("Use 'mcp-agent cloud auth login' (alias).")
+
+
+@app.command("whoami")
+def alias_whoami() -> None:
+    console.print("Use 'mcp-agent cloud auth whoami' (alias).")
+
+
+@app.command("logout")
+def alias_logout() -> None:
+    console.print("Use 'mcp-agent cloud auth logout' (alias).")
+
+
+def run() -> None:
+    """Entry for __main__."""
+    app()
+
+
+if __name__ == "__main__":
+    run()
+
+

--- a/src/mcp_agent/cli/utils/importers.py
+++ b/src/mcp_agent/cli/utils/importers.py
@@ -1,0 +1,82 @@
+"""
+Import helpers to convert external client configs (mcp.json, etc.) into
+MCPServerSettings entries usable by mcp-agent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Any
+import json
+
+from mcp_agent.config import MCPServerSettings
+
+
+def _detect_transport(obj: dict) -> str:
+    url = obj.get("url")
+    if url:
+        # Determine sse vs http by path suffix
+        return "sse" if str(url).rstrip("/").endswith("/sse") else "http"
+    return obj.get("transport") or "stdio"
+
+
+def _to_settings(obj: dict) -> MCPServerSettings:
+    transport = _detect_transport(obj)
+    if transport == "stdio":
+        return MCPServerSettings(
+            transport="stdio",
+            command=obj.get("command"),
+            args=obj.get("args") or [],
+            env=obj.get("env") or None,
+        )
+    else:
+        return MCPServerSettings(
+            transport=transport,
+            url=obj.get("url"),
+            headers=obj.get("headers") or None,
+        )
+
+
+def import_servers_from_mcp_json(path: Path) -> Dict[str, MCPServerSettings]:
+    """
+    Parse a cursor/vscode style mcp.json into a mapping of name -> MCPServerSettings.
+    Supports a variety of simple schemas:
+      - { "mcp": { "servers": { name: { ... } } } }
+      - { name: { ... } }
+      - [ { "name": str, ... }, ... ]
+    """
+    text = path.read_text(encoding="utf-8")
+    data: Any = json.loads(text)
+    servers: Dict[str, MCPServerSettings] = {}
+
+    # mcp.servers mapping
+    if isinstance(data, dict) and "mcp" in data and isinstance(data["mcp"], dict):
+        mcp = data["mcp"]
+        s_map = mcp.get("servers") or {}
+        if isinstance(s_map, dict):
+            for name, cfg in s_map.items():
+                if isinstance(cfg, dict):
+                    servers[str(name)] = _to_settings(cfg)
+            return servers
+
+    # direct mapping name -> cfg
+    if isinstance(data, dict):
+        # Filter out non-server-like keys
+        for name, cfg in data.items():
+            if isinstance(cfg, dict) and (
+                "command" in cfg or "url" in cfg or "transport" in cfg
+            ):
+                servers[str(name)] = _to_settings(cfg)
+        if servers:
+            return servers
+
+    # list of servers with name
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict) and "name" in item:
+                servers[str(item["name"])] = _to_settings(item)
+        if servers:
+            return servers
+
+    # No recognized structure
+    return {}

--- a/src/mcp_agent/cli/utils/url_parser.py
+++ b/src/mcp_agent/cli/utils/url_parser.py
@@ -1,0 +1,93 @@
+"""
+Utilities to parse MCP server URLs and generate config entries.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Dict, List, Literal, Tuple
+from urllib.parse import urlparse
+
+
+def parse_server_url(url: str) -> Tuple[str, Literal["http", "sse"], str]:
+    """
+    Parse a server URL and determine the transport type and normalized URL.
+
+    Returns (server_name, transport_type, normalized_url)
+    """
+    if not url:
+        raise ValueError("URL cannot be empty")
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"URL must be http/https: {url}")
+    if not parsed.netloc:
+        raise ValueError(f"URL must include a hostname: {url}")
+
+    transport: Literal["http", "sse"] = "http"
+    if parsed.path.endswith("/sse"):
+        transport = "sse"
+        normalized = url
+    elif parsed.path.endswith("/mcp"):
+        normalized = url
+    else:
+        base = url if url.endswith("/") else f"{url}/"
+        normalized = f"{base}mcp"
+
+    name = generate_server_name(normalized)
+    return name, transport, normalized
+
+
+def generate_server_name(url: str) -> str:
+    parsed = urlparse(url)
+    host = parsed.netloc.split(":")[0]
+    clean = re.sub(r"[^a-zA-Z0-9]", "_", host)
+    if len(clean) > 15:
+        clean = clean[:9] + clean[-5:]
+    if clean in ("localhost", "127_0_0_1") or re.match(r"^(\d+_){3}\d+$", clean):
+        path = parsed.path.strip("/")
+        path = re.sub(r"[^a-zA-Z0-9]", "_", path)
+        port = ""
+        if ":" in parsed.netloc:
+            port = f"_{parsed.netloc.split(':')[1]}"
+        if path:
+            return f"{clean}{port}_{path[:20]}"
+        url_hash = hashlib.md5(url.encode()).hexdigest()[:8]
+        return f"{clean}{port}_{url_hash}"
+    return clean
+
+
+def parse_server_urls(
+    urls_param: str, auth_token: str | None = None
+) -> List[Tuple[str, Literal["http", "sse"], str, Dict[str, str] | None]]:
+    if not urls_param:
+        return []
+    url_list = [u.strip() for u in urls_param.split(",") if u.strip()]
+    headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
+    result = []
+    for raw in url_list:
+        name, transport, normalized = parse_server_url(raw)
+        result.append((name, transport, normalized, headers))
+    return result
+
+
+def generate_server_configs(
+    parsed_urls: List[Tuple[str, Literal["http", "sse"], str, Dict[str, str] | None]],
+) -> Dict[str, Dict[str, str | Dict[str, str]]]:
+    configs: Dict[str, Dict[str, str | Dict[str, str]]] = {}
+    name_counts: Dict[str, int] = {}
+    for name, transport, url, headers in parsed_urls:
+        final = name
+        if final in configs:
+            cnt = name_counts.get(name, 1)
+            final = f"{name}_{cnt}"
+            name_counts[name] = cnt + 1
+            while final in configs:
+                cnt = name_counts.get(name, 1)
+                final = f"{name}_{cnt}"
+                name_counts[name] = cnt + 1
+        cfg: Dict[str, str | Dict[str, str]] = {"transport": transport, "url": url}
+        if headers:
+            cfg["headers"] = headers
+        configs[final] = cfg
+    return configs


### PR DESCRIPTION
Here's the CLI spec we are working off of. This PR focuses on all the commands unrelated to MCP Agent Cloud.

### MCP Agent CLI Specification


This CLI enables you to:
- Scaffold mcp-agent projects
- Chat and iterate quickly (ephemeral REPL)
- Run your app locally (with live reload), invoke agents/workflows, and serve as an MCP server
- Manage configuration, servers, models, and keys
- Deploy and operate on MCP Agent Cloud (auth, deploy, list, describe, workflows, logs)


The design takes cues from gcloud (noun-verb; list/describe/delete; filters/formatting) and docker (clear resource groups).


---


### Global Behavior


- Global options: `--verbose|-v`, `--quiet|-q`, `--color/--no-color`, `--version`, `--format <text|json|yaml>`


- Config discovery: search upward for `mcp_agent.config.yaml` and `mcp_agent.secrets.yaml`.


- TTY-aware UX: Charm gum if available for prompts/spinners/tables; Rich fallback. Non-TTY prints results to stdout; progress to stderr.


- Exit codes: 0 success; 2 config/secrets missing; 3 deploy failed; 4 auth required/expired; 5 runtime error; 6 invalid args.


---


### Quick Start


#### mcp-agent init
Scaffold a project.


- Creates: `mcp_agent.config.yaml`, `mcp_agent.secrets.yaml`, `agent.py`, `.gitignore` (secrets ignored)
- Options:
 - `--dir|-d <path>` (default: `.`)
 - `--template <basic|server|streamlit|claude|notebook>` (default: `basic`)
 - `--force|-f`
 - `--no-gitignore`
- Examples:
```bash
mcp-agent init
mcp-agent init --template server -d apps/my_agent
```


#### mcp-agent quickstart
Copy curated examples (adapted from repo and fast-agent):


- Names: `workflow`, `researcher`, `data-analysis`, `state-transfer`, `elicitations`, `tensorzero`


- Usage:
```bash
mcp-agent quickstart workflow [DIR] [--force]
mcp-agent quickstart researcher [DIR] [--force]
```


---


### Configuration, Keys, Models


#### mcp-agent config
- `config show [--secrets] [PATH]` (print and YAML-validate)
- `config check` (system+config+servers+logger+keys summary)
- `config edit [--secrets]` (open in `$EDITOR`; gum fallback)
- Formatting: `--format <text|json|yaml>`


#### mcp-agent keys
- `keys show`
- `keys set <provider> <key>`
- `keys unset <provider>`


#### mcp-agent models
- `models list`
- `models set-default <name>`


---


### Local Development (Your App)


#### mcp-agent dev
Run your app with live reload and diagnostics.


- Options:
 - `--script <file>` (default: `agent.py`)
- Behavior:
 - File watch (restart on changes)
 - Preflight: servers resolvable; keys present
 - Pretty progress (gum when TTY)
- Examples:
```bash
mcp-agent dev
mcp-agent dev --script apps/my_agent.py
```


#### mcp-agent invoke
Programmatic, non-interactive execution of a named Agent/Workflow from your app.


- Targets:
 - `--agent <name>` or `--workflow <name>`
- Options:
 - `--message|-m <text>`, `--prompt-file|-p <file>`
 - `--model <name>` (override)
 - `--vars <json>` (structured inputs; e.g. orchestrator/router)
 - `--script <file>` (defaults to `agent.py`)
- Examples:
```bash
mcp-agent invoke --agent finder -m "Read README.md"
mcp-agent invoke --workflow orchestrator --vars '{"task":"grade short_story.md"}'
```


#### mcp-agent serve
Serve your app as an MCP server locally.


- Options:
 - `--script <file>` (default: `agent.py`)
 - `--transport <stdio|http|sse>` (default: `stdio`)
 - `--port <port>` (for http/sse)
- Example:
```bash
mcp-agent serve --transport http --port 8080
```


---


### Quick Experimentation (Ephemeral)


#### mcp-agent chat
Ephemeral REPL for fast iteration (replaces "run").


- Options:
 - `--name <text>`
 - `--instruction|-i <file|url|text:...>`
 - `--model <name>` or `--models <name1,name2,...>` (multi-model fan-out; pretty aggregation)
 - `--message|-m <text>` (one-shot; print result; exit)
 - `--prompt-file|-p <file>` (text/json/jsonl)
 - `--servers <name1,name2>` (enable subset from config)
 - `--url <u1,u2>` (attach HTTP/SSE; auto `/mcp` vs `/sse`)
 - `--auth <token>` (bearer; provider-specific helpers)
 - `--npx "<pkg ...>"`, `--uvx "<pkg ...>"`, `--stdio "<cmd ...>"` (attach stdio servers)
 - `--pretty-parallel`, `--no-chat` (final result only)


- REPL slash-commands: `/help`, `/model <name>`, `/tools`, `/resources`, `/servers`, `/prompt <name> [args-json]`, `/apply <file>`, `/attach <server> <resource-uri>`, `/history [clear]`, `/save <file>`, `/quit`


- Addressing: `@agent-name`, `:workflow-name`
- Examples:
```bash
mcp-agent chat --model anthropic.haiku --servers=filesystem,fetch
mcp-agent chat --models "anthropic.haiku,openai.gpt-4o" -m "Write a haiku about MCP"
mcp-agent chat --uvx "mcp-server-fetch" --npx "@modelcontextprotocol/server-filesystem ."
```


---


### Local Server Management (Config Helpers)


#### mcp-agent server add
Add servers to `mcp_agent.config.yaml`.


- Forms:
 - `server add http <url> [--auth <token>]`
 - `server add sse <url> [--auth <token>]`
 - `server add stdio "<cmd ...>"`
 - `server add npx "<pkg ...>"`
 - `server add uvx "<pkg ...>"`
 - `server add dxt <path-to.dxt> [--name <alias>] [--extract-to <dir>]`
   - Installs a Desktop Extension (.dxt): unpacks, reads `manifest.json`, configures stdio command and env, and writes a server entry. Defaults to extracting under `.mcp-agent/extensions/`.


 - `server add recipe <filesystem|fetch|roots|gmail|qdrant|brave|...> [--options ...]`


- Examples:
```bash
mcp-agent server add http https://api.example.com/mcp --auth $TOKEN
mcp-agent server add stdio "python my_server.py --config settings.json"
mcp-agent server add dxt ~/Downloads/my-local-server.dxt --name my_local
```


#### mcp-agent server import
Import server configs from common sources (Claude Code, Cursor, VSCode, DXT manifest-only).


- Forms:
 - `server import claude [--profile <name>]`
 - `server import cursor`
 - `server import vscode`
- Writes entries to `mcp_agent.config.yaml` with minimal prompts.


#### mcp-agent server (local)
- `server list [--filter <expr>] [--format <text|json|yaml>]`
- `server test <name> [--timeout <s>]` (start/probe health; show tools/resources/prompts detected)


---


### Diagnostics & Build


#### mcp-agent build
Preflight and bundle prep for deployment.


- Checks: Python/uv/npx presence; server reachability/commands; key/env availability
- Output: `.mcp-agent/manifest.json` for deploy
- Options: `--check-only`, `--fix`


#### mcp-agent logs
Tail local logs.


- Options: `--file <path>`, `--follow`, `--since <duration>`, `--from <RFC3339>`, `--to <RFC3339>`, `--limit <N>`, `--orderby <time|severity|tokens>`, `--desc/--asc`, `--grep <pattern>`


#### mcp-agent doctor
Comprehensive diagnostics: config/secrets, keys, servers, versions, network reachability, gum presence, TTY, shell hints. Actionable suggestions.


---


## Cloud (MCP Agent Cloud) – P0


All cloud commands live under `mcp-agent cloud ...`. Top-level aliases exist for convenience:
- `mcp-agent login|whoami|logout` = `mcp-agent cloud auth login|whoami|logout`
- `mcp-agent deploy` = `mcp-agent cloud deploy`


Auth stored at `~/.config/mcp-agent/credentials.json`. 


### mcp-agent cloud auth
- `cloud auth login [--org <id>] [--device] [--no-open]`
- `cloud auth whoami`
- `cloud auth logout`


### mcp-agent cloud deploy
Deploy current project as a managed MCP server.


- Options:
 - `--name <display-name>`, `--region <slug>`
 - `--env <K=V>` (repeatable), `--exclude <glob>` (repeatable)
 - `--async` (do not wait), `--wait` (default), `--open`
 - `--format <text|json|yaml>`
- Flow:
 - “Uploading… Building… Deploying… Verifying…”
 - Success: endpoint URL, ID, exposed tools/resources/prompts/workflows
 - Failure: auto-tail build logs; non-zero exit


### mcp-agent cloud servers
- `cloud servers list [--org <id>] [--limit <N>] [--filter <expr>] [--sort-by <field>] [--format <text|json|yaml>]`
- `cloud servers describe <id|url> [--format <text|json|yaml>]` (alias: `status`)
- `cloud servers delete <id|url> [--force]`
- `cloud servers stats <id|url> [--range <1h|24h|7d>] [--format <text|json|yaml>]`
- `cloud servers workflows <id|url> [--limit <N>] [--status <running|paused|failed|completed>] [--format <text|json|yaml>]`
- Alias group: `mcp-agent cloud apps ...` (identical to `cloud servers ...`)


### mcp-agent cloud workflows
- `cloud workflows describe <run-id> [--format <text|json|yaml>]` (alias: `status`)
- `cloud workflows suspend <run-id>`
- `cloud workflows resume <run-id> --payload "<json-or-text>"`
- `cloud workflows cancel <run-id>`


### mcp-agent cloud logger
- `cloud logger configure <id|url>` (set OTEL endpoint/headers; test/apply)
- `cloud logger tail <id|url> [--follow] [--since <duration>] [--from <RFC3339>] [--to <RFC3339>] [--limit <N>] [--orderby <time|severity|tokens>] [--desc/--asc] [--grep <pattern>] [--format <text|json|yaml>]`


### mcp-agent cloud open
- `cloud open` ⇒ portal home
- `cloud open --server <id|url>` ⇒ deployment details


---


### Client Integration (Consumers)


#### mcp-agent configure
Assist consumers in configuring a client for a given server URL.


- `configure <server_url> --client <cursor|claude|vscode|smithery|mcp.run> [--write] [--open] [--format <text|json|yaml>]`
- Guides auth and secrets, generates unique secret-bound URL where applicable, writes to known client config (if supported), prints tailored snippets.


---


### Examples


- Chat quickly:
```bash
mcp-agent chat --model anthropic.haiku --servers=filesystem,fetch
mcp-agent --model o3-mini.low -m "hi"                       # auto-routes to chat
```


- Run app with live reload:
```bash
mcp-agent dev
```


- Invoke a workflow from your app:
```bash
mcp-agent invoke --workflow orchestrator --vars '{"task":"grade short_story.md"}'
```


- Serve app as MCP server:
```bash
mcp-agent serve --transport http --port 8080
```


- Add servers:
```bash
mcp-agent add server dxt ~/Downloads/my-local-server.dxt --name my_local
mcp-agent add server http https://my-cloud/servers/doc-svc/mcp --auth $TOKEN
```


- Cloud deploy and manage:
```bash
mcp-agent cloud auth login
mcp-agent cloud deploy --name "docs-summarizer" --wait --open
mcp-agent cloud servers list --format json
mcp-agent cloud servers describe <id>
mcp-agent cloud logger tail <id> --since 1h --limit 500 --orderby time --desc
```


---


### Command Reference (Concise)


- Project
 - `mcp-agent init [--template ...] [--dir DIR] [--force]`
 - `mcp-agent quickstart (workflow|researcher|data-analysis|state-transfer|elicitations|tensorzero) [DIR] [--force]`
- Config/Keys/Models
 - `mcp-agent config show|check|edit`
 - `mcp-agent keys show|set|unset`
 - `mcp-agent models list|set-default`
- Local dev
 - `mcp-agent chat [REPL flags…]`
 - `mcp-agent dev [--script agent.py]`
 - `mcp-agent invoke (--agent NAME | --workflow NAME) [--message|--prompt-file|--vars JSON]`
 - `mcp-agent serve [--script agent.py] [--transport ...] [--port ...]`
 - `mcp-agent build [--check-only] [--fix]`
 - `mcp-agent logs [--file PATH] [--follow] [--since|--from|--to] [--limit] [--orderby] [--grep]`
 - `mcp-agent doctor`
- Local server helpers
 - `mcp-agent server add (http|sse|stdio|npx|uvx|dxt|recipe) ...`
 - `mcp-agent server import (claude|cursor|vscode|dxt) ...`
 - `mcp-agent server list|test <name>`
- Cloud
 - `mcp-agent cloud auth login|whoami|logout`
 - `mcp-agent cloud deploy [--name] [--region] [--env K=V] [--exclude GLOB] [--async|--wait] [--open]`
 - `mcp-agent cloud servers list|describe|delete|stats|workflows`
 - `mcp-agent cloud workflows describe|suspend|resume|cancel`
 - `mcp-agent cloud logger configure|tail`
 - `mcp-agent cloud apps ...` (alias of `cloud servers`)
 - `mcp-agent cloud open [--server <id|url>]`
- Client integration
 - `mcp-agent configure <server_url> --client <cursor|claude|...> [--write] [--open]`


---


### Notes on Implementation


- Keep final answers on stdout; progress on stderr. Support `--format text|json|yaml` for list/describe/stats/tail.
- DXT support:
 - `add server dxt` unpacks and writes a stdio server entry from `manifest.json`.
 - `import server dxt` can operate directly from `.dxt` or `manifest.json`.
- Back-compat aliases:
 - `mcp-agent deploy` ⇒ `mcp-agent cloud deploy`
 - `mcp-agent login|whoami|logout` ⇒ `mcp-agent cloud auth ...`
- Ergonomics:
 - “chat” = ephemeral REPL, “dev” = run your app, “invoke” = execute defined agent/workflow, “serve” = host as MCP server.
```


- Added DXT support to `add server` and `import server`.
- All cloud commands now live under `mcp-agent cloud ...`; kept convenient top-level aliases.
- `logger tail` supports `--limit`, `--from/--to` (RFC3339), `--since`, and `--orderby` with sort direction.

