### PR TITLE
feat: mcp tool allowlist

### DIFF
--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -726,6 +726,23 @@
           "default": null,
           "title": "Env",
           "description": "Environment variables to pass to the server process."
+        },
+        "allowed_tools": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "uniqueItems": true
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Allowed Tools",
+          "description": "Allow list for tools of given server"
         }
       },
       "title": "MCPServerSettings",
@@ -1031,6 +1048,17 @@
           ],
           "default": null,
           "title": "Rpc Metadata"
+        },
+        "id_reuse_policy": {
+          "default": "allow_duplicate",
+          "enum": [
+            "allow_duplicate",
+            "allow_duplicate_failed_only",
+            "reject_duplicate",
+            "terminate_if_running"
+          ],
+          "title": "Id Reuse Policy",
+          "type": "string"
         }
       },
       "required": [

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -106,7 +106,8 @@ class MCPServerSettings(BaseModel):
     """Environment variables to pass to the server process."""
 
     allowed_tools: Set[str] | None = None
-    """Set of tool names to allow from this server. If specified, only these tools will be exposed to agents. Tool names should match exactly."""
+    """Set of tool names to allow from this server. If specified, only these tools will be exposed to agents. 
+    Tool names should match exactly. [WARNING] Empty list will result LLM have no access to tools."""
 
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 

--- a/src/mcp_agent/mcp/mcp_aggregator.py
+++ b/src/mcp_agent/mcp/mcp_aggregator.py
@@ -347,13 +347,22 @@ class MCPAggregator(ContextDependent):
                 self._server_to_tool_map[server_name] = []
                 
                 # Get server configuration to check for tool filtering
-                server_config = self.context.server_registry.get_server_config(server_name)
-                allowed_tools = server_config.allowed_tools if server_config else None
+                allowed_tools = None
+                disabled_tool_count = 0
+                if (self.context is None or self.context.server_registry is None
+                        or not hasattr(self.context.server_registry, "get_server_config")):
+                    logger.warning(f"No config found for server '{server_name}', no tool filter will be applied...")
+                else:
+                    allowed_tools = self.context.server_registry.get_server_config(server_name).allowed_tools
+
+                    if allowed_tools is not None and len(allowed_tools) == 0:
+                        logger.warning(f"Allowed tool list is explicitly empty for server '{server_name}'")
                 
                 for tool in tools:
                     # Apply tool filtering if configured - O(1) lookup with set
                     if allowed_tools is not None and tool.name not in allowed_tools:
                         logger.debug(f"Filtering out tool '{tool.name}' from server '{server_name}' (not in allowed_tools)")
+                        disabled_tool_count += 1
                         continue
                         
                     namespaced_tool_name = f"{server_name}{SEP}{tool.name}"
@@ -404,6 +413,7 @@ class MCPAggregator(ContextDependent):
                 "server_name": server_name,
                 "agent_name": self.agent_name,
                 "tool_count": len(tools),
+                "disabled_tool_count": disabled_tool_count,
                 "prompt_count": len(prompts),
                 "resource_count": len(resources),
             }


### PR DESCRIPTION
### TL;DR

Added the ability to filter which tools are exposed from an MCP server to agents.

### What changed?

- Added a new `allowed_tools` configuration option to `MCPServerSettings` that accepts a set of tool names
- Modified the server loading logic in `mcp_aggregator.py` to filter tools based on the `allowed_tools` configuration
- When `allowed_tools` is specified, only tools with names that exactly match entries in the set will be exposed to agents

### How to test?

1. Configure a server with the `allowed_tools` option in your configuration:
   ```yaml
   servers:
     my_server:
       allowed_tools: 
         - "tool_one"
         - "tool_two"
   ```
2. Start the MCP agent with this configuration
3. Verify that only the specified tools are available to agents
4. Try accessing a tool that's not in the allowed list and confirm it's not available

### Why make this change?

This change provides more granular control over which tools are exposed to agents from each server. This is useful for:
- Security purposes - limiting access to potentially dangerous tools
- Simplifying the agent experience by only exposing relevant tools
- Creating different tool configurations for different agent scenarios without needing separate server instances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-server allow-list to restrict which tools agents can see (exact name matching).
  * New configuration option for ID reuse policy to control temporal task ID behavior.

* **Behavior**
  * Discovery filters tools so only permitted tools are indexed and shown; an explicitly empty allow-list exposes no tools.
  * Metrics/reporting include a per-server filtered-tools count.

* **Tests**
  * Added comprehensive tests covering per-server tool filtering and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolving: https://github.com/lastmile-ai/mcp-agent/issues/183, https://github.com/lastmile-ai/mcp-agent/issues/206

Related: https://github.com/lastmile-ai/mcp-agent/pull/236