### PR TITLE
remove logger configure for now since implementation is not ready

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-agent"
-version = "0.1.15"
+version = "0.1.16"
 description = "Build effective agents with Model Context Protocol (MCP) using simple, composable patterns."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/mcp_agent/cli/cloud/commands/logger/__init__.py
+++ b/src/mcp_agent/cli/cloud/commands/logger/__init__.py
@@ -4,7 +4,6 @@ This package contains functionality for configuring observability and retrieving
 from deployed MCP apps.
 """
 
-from .configure.main import configure_logger
 from .tail.main import tail_logs
 
-__all__ = ["configure_logger", "tail_logs"]
+__all__ = ["tail_logs"]

--- a/src/mcp_agent/cli/cloud/main.py
+++ b/src/mcp_agent/cli/cloud/main.py
@@ -14,7 +14,7 @@ from rich.panel import Panel
 from typer.core import TyperGroup
 
 from mcp_agent.cli.cloud.commands import configure_app, deploy_config, login, logout, whoami
-from mcp_agent.cli.cloud.commands.logger import configure_logger, tail_logs
+from mcp_agent.cli.cloud.commands.logger import tail_logs
 from mcp_agent.cli.cloud.commands.app import (
     delete_app,
     get_app_status,
@@ -166,10 +166,6 @@ app_cmd_cloud_logger = typer.Typer(
     cls=HelpfulTyperGroup,
 )
 # Register logger commands under cloud logger
-app_cmd_cloud_logger.command(
-    name="configure",
-    help="Configure OTEL endpoint and headers for log collection",
-)(configure_logger)
 app_cmd_cloud_logger.command(
     name="tail",
     help="Retrieve and stream logs from deployed MCP apps",


### PR DESCRIPTION
### TL;DR

Removed the `configure_logger` command from the cloud CLI.

### What changed?

- Removed the `configure_logger` function import and reference from `src/mcp_agent/cli/cloud/commands/logger/__init__.py`
- Removed the `configure_logger` import from `src/mcp_agent/cli/cloud/main.py`
- Removed the command registration for `configure` under the cloud logger command group

### How to test?

1. Run `mcp cloud logger --help` and verify that the `configure` subcommand is no longer listed
2. Verify that the `tail` command still works as expected with `mcp cloud logger tail`

### Why make this change?

The `configure_logger` command was likely deprecated or is no longer needed in the current implementation of the cloud logging functionality. This change streamlines the CLI interface by removing an unused command.