### PR TITLE
refactor logger tail http requests to api_client

### DIFF
--- a/examples/basic/mcp_basic_agent/requirements.txt
+++ b/examples/basic/mcp_basic_agent/requirements.txt
@@ -1,5 +1,5 @@
 # Core framework dependency
-mcp-agent==0.1.16
+mcp-agent @ file://../../../  # Link to the local mcp-agent project root
 
 # Additional dependencies specific to this example
 anthropic

--- a/examples/basic/mcp_basic_agent/requirements.txt
+++ b/examples/basic/mcp_basic_agent/requirements.txt
@@ -1,5 +1,5 @@
 # Core framework dependency
-mcp-agent @ file://../../../  # Link to the local mcp-agent project root
+mcp-agent==0.1.16
 
 # Additional dependencies specific to this example
 anthropic

--- a/src/mcp_agent/cli/mcp_app/api_client.py
+++ b/src/mcp_agent/cli/mcp_app/api_client.py
@@ -104,6 +104,28 @@ def is_valid_server_url_format(server_url: str) -> bool:
     return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 
 
+class LogEntry(BaseModel):
+    """Represents a single log entry."""
+    timestamp: Optional[str] = None
+    level: Optional[str] = None
+    message: Optional[str] = None
+    # Allow additional fields that might be present
+    
+    class Config:
+        extra = "allow"
+
+
+class GetAppLogsResponse(BaseModel):
+    """Response from get_app_logs API endpoint."""
+    logEntries: Optional[List[LogEntry]] = []
+    log_entries: Optional[List[LogEntry]] = []
+    
+    @property
+    def log_entries_list(self) -> List[LogEntry]:
+        """Get log entries regardless of field name format."""
+        return self.logEntries or self.log_entries or []
+
+
 class MCPAppClient(APIClient):
     """Client for interacting with the MCP App API service over HTTP."""
 
@@ -586,3 +608,62 @@ class MCPAppClient(APIClient):
             resource_name=f"MCP_APP_CONFIG:{app_config_id}",
             action="MANAGE:MCP_APP_CONFIG",
         )
+
+    async def get_app_logs(
+        self,
+        app_id: Optional[str] = None,
+        app_configuration_id: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: Optional[int] = None,
+        order_by: Optional[str] = None,
+        order: Optional[str] = None,
+    ) -> GetAppLogsResponse:
+        """Get logs for an MCP App or App Configuration via the API.
+
+        Args:
+            app_id: The UUID of the app to get logs for (mutually exclusive with app_configuration_id)
+            app_configuration_id: The UUID of the app configuration to get logs for (mutually exclusive with app_id)
+            since: Time filter for logs (e.g., "1h", "24h", "7d")
+            limit: Maximum number of log entries to return
+            order_by: Field to order by ("LOG_ORDER_BY_TIMESTAMP" or "LOG_ORDER_BY_LEVEL")
+            order: Log ordering direction ("LOG_ORDER_ASC" or "LOG_ORDER_DESC")
+
+        Returns:
+            GetAppLogsResponse: The retrieved log entries
+
+        Raises:
+            ValueError: If neither or both app_id and app_configuration_id are provided, or if IDs are invalid
+            httpx.HTTPStatusError: If the API returns an error (e.g., 404, 403)
+            httpx.HTTPError: If the request fails
+        """
+        # Validate inputs
+        if not app_id and not app_configuration_id:
+            raise ValueError("Either app_id or app_configuration_id must be provided")
+        if app_id and app_configuration_id:
+            raise ValueError("Only one of app_id or app_configuration_id can be provided")
+        
+        if app_id and not is_valid_app_id_format(app_id):
+            raise ValueError(f"Invalid app ID format: {app_id}")
+        if app_configuration_id and not is_valid_app_config_id_format(app_configuration_id):
+            raise ValueError(f"Invalid app configuration ID format: {app_configuration_id}")
+
+        # Prepare request payload
+        payload = {}
+        if app_id:
+            payload["app_id"] = app_id
+        if app_configuration_id:
+            payload["app_configuration_id"] = app_configuration_id
+        if since:
+            payload["since"] = since
+        if limit:
+            payload["limit"] = limit
+        if order_by:
+            payload["order_by"] = order_by
+        if order:
+            payload["order"] = order
+
+        response = await self.post("/mcp_app/get_app_logs", payload)
+
+        # Parse the response
+        data = response.json()
+        return GetAppLogsResponse(**data)


### PR DESCRIPTION
### TL;DR

Refactored the log fetching functionality to use the API client and added a new `get_app_logs` method to the `MCPAppClient` class.

### What changed?

- Updated the `mcp_basic_agent` example to use the published package version 0.1.16 instead of a local file reference
- Refactored the `_fetch_logs` function in the logger tail command to use the API client instead of making direct HTTP requests
- Added new models `LogEntry` and `GetAppLogsResponse` to properly type and handle log data
- Implemented a new `get_app_logs` method in the `MCPAppClient` class to fetch logs from the API

### How to test?

1. Run `mcp-agent cloud logger tail <app-id>` to verify logs are fetched correctly
2. Test with various parameters like `--since`, `--limit`, `--order-by`, and `--asc`/`--desc` flags
3. Verify error handling for invalid app IDs or authentication issues

### Why make this change?

This change improves code maintainability by centralizing API interactions in the client class rather than implementing them directly in command handlers. It also provides proper typing for log entries and standardizes the approach to API requests, making the codebase more consistent and easier to maintain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced log viewing: fetch application logs with authenticated access.
  - Support for sorting by timestamp or severity, ascending/descending.
  - Optional filters: since and limit; works with app ID or configuration ID.
  - Improved display compatibility for log entries.

- Bug Fixes
  - Clearer error messages for authentication failures and missing apps/configurations (404/401).
  - More robust handling of API errors to prevent unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->