### PR TITLE
add workflow list and runs

### DIFF
--- a/src/mcp_agent/cli/cloud/commands/servers/__init__.py
+++ b/src/mcp_agent/cli/cloud/commands/servers/__init__.py
@@ -3,11 +3,9 @@
 from .list.main import list_servers
 from .describe.main import describe_server
 from .delete.main import delete_server
-from .workflows.main import list_workflows_for_server
 
 __all__ = [
     "list_servers",
-    "describe_server", 
+    "describe_server",
     "delete_server",
-    "list_workflows_for_server",
 ]

--- a/src/mcp_agent/cli/cloud/commands/servers/delete/main.py
+++ b/src/mcp_agent/cli/cloud/commands/servers/delete/main.py
@@ -1,4 +1,3 @@
-
 import typer
 from rich.panel import Panel
 
@@ -17,21 +16,25 @@ from mcp_agent.cli.utils.ux import console, print_info
 
 @handle_server_api_errors
 def delete_server(
-    id_or_url: str = typer.Argument(..., help="Server ID or app configuration ID to delete"),
-    force: bool = typer.Option(False, "--force", "-f", help="Force deletion without confirmation prompt"),
+    id_or_url: str = typer.Argument(
+        ..., help="Server ID or app configuration ID to delete"
+    ),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Force deletion without confirmation prompt"
+    ),
 ) -> None:
     """Delete a specific MCP Server."""
     client = setup_authenticated_client()
     server = resolve_server(client, id_or_url)
-    
+
     # Determine server type and delete function
     if isinstance(server, MCPApp):
         server_type = "Deployed Server"
         delete_function = client.delete_app
     else:
-        server_type = "Configured Server" 
+        server_type = "Configured Server"
         delete_function = client.delete_app_configuration
-        
+
     server_name = get_server_name(server)
     server_id = get_server_id(server)
 
@@ -47,8 +50,10 @@ def delete_server(
                 expand=False,
             )
         )
-        
-        confirm = typer.confirm(f"\nAre you sure you want to delete this {server_type.lower()}?")
+
+        confirm = typer.confirm(
+            f"\nAre you sure you want to delete this {server_type.lower()}?"
+        )
         if not confirm:
             print_info("Deletion cancelled.")
             return
@@ -57,14 +62,14 @@ def delete_server(
         can_delete = run_async(client.can_delete_app(server_id))
     else:
         can_delete = run_async(client.can_delete_app_configuration(server_id))
-        
+
     if not can_delete:
         raise CLIError(
             f"You do not have permission to delete this {server_type.lower()}. "
             f"You can only delete servers that you created."
         )
     deleted_id = run_async(delete_function(server_id))
-    
+
     console.print(
         Panel(
             f"[green]✅ Successfully deleted {server_type.lower()}[/green]\n\n"
@@ -75,4 +80,3 @@ def delete_server(
             expand=False,
         )
     )
-

--- a/src/mcp_agent/cli/cloud/commands/servers/describe/main.py
+++ b/src/mcp_agent/cli/cloud/commands/servers/describe/main.py
@@ -9,7 +9,7 @@ from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.mcp_app.api_client import MCPApp, MCPAppConfiguration
 from ...utils import (
     setup_authenticated_client,
-    validate_output_format, 
+    validate_output_format,
     resolve_server,
     handle_server_api_errors,
     clean_server_status,
@@ -17,10 +17,14 @@ from ...utils import (
 from mcp_agent.cli.utils.ux import console
 
 
-@handle_server_api_errors 
+@handle_server_api_errors
 def describe_server(
-    id_or_url: str = typer.Argument(..., help="Server ID or app configuration ID to describe"),
-    format: Optional[str] = typer.Option("text", "--format", help="Output format (text|json|yaml)"),
+    id_or_url: str = typer.Argument(
+        ..., help="Server ID or app configuration ID to describe"
+    ),
+    format: Optional[str] = typer.Option(
+        "text", "--format", help="Output format (text|json|yaml)"
+    ),
 ) -> None:
     """Describe a specific MCP Server."""
     validate_output_format(format)
@@ -29,13 +33,17 @@ def describe_server(
     print_server_description(server, format)
 
 
-def print_server_description(server: Union[MCPApp, MCPAppConfiguration], output_format: str = "text") -> None:
+def print_server_description(
+    server: Union[MCPApp, MCPAppConfiguration], output_format: str = "text"
+) -> None:
     """Print detailed description information for a server."""
-    
+
     valid_formats = ["text", "json", "yaml"]
     if output_format not in valid_formats:
-        raise CLIError(f"Invalid format '{output_format}'. Valid options are: {', '.join(valid_formats)}")
-    
+        raise CLIError(
+            f"Invalid format '{output_format}'. Valid options are: {', '.join(valid_formats)}"
+        )
+
     if output_format == "json":
         _print_server_json(server)
     elif output_format == "yaml":
@@ -73,14 +81,15 @@ def _server_to_dict(server: Union[MCPApp, MCPAppConfiguration]) -> dict:
         server_description = server.app.description if server.app else None
         created_at = server.createdAt
         server_info = server.appServerInfo
-        underlying_app = {
-            "app_id": server.app.appId,
-            "name": server.app.name
-        } if server.app else None
+        underlying_app = (
+            {"app_id": server.app.appId, "name": server.app.name}
+            if server.app
+            else None
+        )
 
     status_raw = server_info.status if server_info else "APP_SERVER_STATUS_OFFLINE"
     server_url = server_info.serverUrl if server_info else None
-    
+
     data = {
         "id": server_id,
         "name": server_name,
@@ -88,15 +97,13 @@ def _server_to_dict(server: Union[MCPApp, MCPAppConfiguration]) -> dict:
         "status": clean_server_status(status_raw),
         "server_url": server_url,
         "description": server_description,
-        "created_at": created_at.isoformat() if created_at else None
+        "created_at": created_at.isoformat() if created_at else None,
     }
-    
+
     if underlying_app:
         data["underlying_app"] = underlying_app
-        
+
     return data
-
-
 
 
 def _print_server_text(server: Union[MCPApp, MCPAppConfiguration]) -> None:
@@ -118,7 +125,7 @@ def _print_server_text(server: Union[MCPApp, MCPAppConfiguration]) -> None:
 
     status_text = "❓ Unknown"
     server_url = "N/A"
-    
+
     if server_info:
         status_text = _server_status_text(server_info.status)
         server_url = server_info.serverUrl
@@ -129,20 +136,24 @@ def _print_server_text(server: Union[MCPApp, MCPAppConfiguration]) -> None:
         f"Status: {status_text}",
         f"Server URL: [cyan]{server_url}[/cyan]",
     ]
-    
+
     if server_description:
         content_lines.append(f"Description: [cyan]{server_description}[/cyan]")
-    
+
     if created_at:
-        content_lines.append(f"Created: [cyan]{created_at.strftime('%Y-%m-%d %H:%M:%S')}[/cyan]")
+        content_lines.append(
+            f"Created: [cyan]{created_at.strftime('%Y-%m-%d %H:%M:%S')}[/cyan]"
+        )
 
     if isinstance(server, MCPAppConfiguration) and server.app:
-        content_lines.extend([
-            "",
-            "[bold]Underlying App:[/bold]",
-            f"  App ID: [cyan]{server.app.appId}[/cyan]",
-            f"  App Name: [cyan]{server.app.name}[/cyan]",
-        ])
+        content_lines.extend(
+            [
+                "",
+                "[bold]Underlying App:[/bold]",
+                f"  App ID: [cyan]{server.app.appId}[/cyan]",
+                f"  App Name: [cyan]{server.app.name}[/cyan]",
+            ]
+        )
 
     console.print(
         Panel(

--- a/src/mcp_agent/cli/cloud/commands/servers/workflows/__init__.py
+++ b/src/mcp_agent/cli/cloud/commands/servers/workflows/__init__.py
@@ -1,7 +1,0 @@
-"""Workflows subcommand for servers."""
-
-from .main import list_workflows_for_server
-
-__all__ = [
-    "list_workflows_for_server",
-]

--- a/src/mcp_agent/cli/cloud/commands/utils.py
+++ b/src/mcp_agent/cli/cloud/commands/utils.py
@@ -17,60 +17,60 @@ from mcp_agent.cli.mcp_app.api_client import (
 
 def setup_authenticated_client() -> MCPAppClient:
     """Setup authenticated MCP App client.
-    
+
     Returns:
         Configured MCPAppClient instance
-        
+
     Raises:
         CLIError: If authentication fails
     """
     effective_api_key = load_api_key_credentials()
 
     if not effective_api_key:
-        raise CLIError(
-            "Must be logged in to access servers. Run 'mcp-agent login'."
-        )
+        raise CLIError("Must be logged in to access servers. Run 'mcp-agent login'.")
 
-    return MCPAppClient(
-        api_url=DEFAULT_API_BASE_URL, api_key=effective_api_key
-    )
+    return MCPAppClient(api_url=DEFAULT_API_BASE_URL, api_key=effective_api_key)
 
 
 def validate_output_format(format: str) -> None:
     """Validate output format parameter.
-    
+
     Args:
         format: Output format to validate
-        
+
     Raises:
         CLIError: If format is invalid
     """
     valid_formats = ["text", "json", "yaml"]
     if format not in valid_formats:
-        raise CLIError(f"Invalid format '{format}'. Valid options are: {', '.join(valid_formats)}")
+        raise CLIError(
+            f"Invalid format '{format}'. Valid options are: {', '.join(valid_formats)}"
+        )
 
 
-def resolve_server(client: MCPAppClient, id_or_url: str) -> Union[MCPApp, MCPAppConfiguration]:
+def resolve_server(
+    client: MCPAppClient, id_or_url: str
+) -> Union[MCPApp, MCPAppConfiguration]:
     """Resolve server from ID.
-    
+
     Args:
         client: Authenticated MCP App client
         id_or_url: Server identifier (app ID or app config ID)
-        
+
     Returns:
         Server object (MCPApp or MCPAppConfiguration)
-        
+
     Raises:
         CLIError: If server resolution fails
     """
     try:
         app_id, config_id = parse_app_identifier(id_or_url)
-        
+
         if config_id:
             return run_async(client.get_app_configuration(app_config_id=config_id))
         else:
             return run_async(client.get_app(app_id=app_id))
-            
+
     except ValueError as e:
         raise CLIError(str(e)) from e
     except Exception as e:
@@ -79,13 +79,14 @@ def resolve_server(client: MCPAppClient, id_or_url: str) -> Union[MCPApp, MCPApp
 
 def handle_server_api_errors(func):
     """Decorator to handle common API errors for server commands.
-    
+
     Args:
         func: Function to wrap with error handling
-        
+
     Returns:
         Wrapped function with error handling
     """
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
@@ -99,18 +100,18 @@ def handle_server_api_errors(func):
             raise
         except Exception as e:
             # Get the original function name for better error messages
-            func_name = func.__name__.replace('_', ' ')
+            func_name = func.__name__.replace("_", " ")
             raise CLIError(f"Error in {func_name}: {str(e)}") from e
-    
+
     return wrapper
 
 
 def get_server_name(server: Union[MCPApp, MCPAppConfiguration]) -> str:
     """Get display name for a server.
-    
+
     Args:
         server: Server object
-        
+
     Returns:
         Server display name
     """
@@ -122,10 +123,10 @@ def get_server_name(server: Union[MCPApp, MCPAppConfiguration]) -> str:
 
 def get_server_id(server: Union[MCPApp, MCPAppConfiguration]) -> str:
     """Get ID for a server.
-    
+
     Args:
         server: Server object
-        
+
     Returns:
         Server ID
     """
@@ -137,10 +138,10 @@ def get_server_id(server: Union[MCPApp, MCPAppConfiguration]) -> str:
 
 def clean_server_status(status: str) -> str:
     """Convert server status from API format to clean format.
-    
+
     Args:
         status: API status string
-        
+
     Returns:
         Clean status string
     """

--- a/src/mcp_agent/cli/cloud/commands/workflows/__init__.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/__init__.py
@@ -3,10 +3,14 @@
 from .describe import describe_workflow
 from .resume import resume_workflow, suspend_workflow
 from .cancel import cancel_workflow
+from .list import list_workflows
+from .runs import list_workflow_runs
 
 __all__ = [
     "describe_workflow",
     "resume_workflow",
     "suspend_workflow",
     "cancel_workflow",
+    "list_workflows",
+    "list_workflow_runs",
 ]

--- a/src/mcp_agent/cli/cloud/commands/workflows/cancel/main.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/cancel/main.py
@@ -10,53 +10,63 @@ from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.utils.ux import console
 from mcp_agent.config import MCPServerSettings, Settings, LoggerSettings
 from mcp_agent.mcp.gen_client import gen_client
-from ...utils import setup_authenticated_client, resolve_server, handle_server_api_errors
+from ...utils import (
+    setup_authenticated_client,
+    resolve_server,
+    handle_server_api_errors,
+)
 
 
 async def _cancel_workflow_async(
-    server_id_or_url: str,
-    run_id: str,
-    reason: Optional[str] = None
+    server_id_or_url: str, run_id: str, reason: Optional[str] = None
 ) -> None:
     """Cancel a workflow using MCP tool calls to a deployed server."""
-    if server_id_or_url.startswith(('http://', 'https://')):
+    if server_id_or_url.startswith(("http://", "https://")):
         server_url = server_id_or_url
     else:
         client = setup_authenticated_client()
         server = resolve_server(client, server_id_or_url)
-        
-        if hasattr(server, 'appServerInfo') and server.appServerInfo:
+
+        if hasattr(server, "appServerInfo") and server.appServerInfo:
             server_url = server.appServerInfo.serverUrl
         else:
-            raise CLIError(f"Server '{server_id_or_url}' is not deployed or has no server URL")
-        
+            raise CLIError(
+                f"Server '{server_id_or_url}' is not deployed or has no server URL"
+            )
+
         if not server_url:
             raise CLIError(f"No server URL found for server '{server_id_or_url}'")
-    
+
     quiet_settings = Settings(logger=LoggerSettings(level="error"))
     app = MCPApp(name="workflows_cli", settings=quiet_settings)
-    
+
     try:
         async with app.run() as workflow_app:
             context = workflow_app.context
-            
-            sse_url = f"{server_url.rstrip('/')}/sse" if not server_url.endswith('/sse') else server_url
+
+            sse_url = (
+                f"{server_url.rstrip('/')}/sse"
+                if not server_url.endswith("/sse")
+                else server_url
+            )
             context.server_registry.registry["workflow_server"] = MCPServerSettings(
                 name="workflow_server",
                 description=f"Deployed MCP server {server_url}",
                 url=sse_url,
-                transport="sse"
+                transport="sse",
             )
-            
-            async with gen_client("workflow_server", server_registry=context.server_registry) as client:
+
+            async with gen_client(
+                "workflow_server", server_registry=context.server_registry
+            ) as client:
                 tool_params = {"run_id": run_id}
-                
+
                 result = await client.call_tool("workflows-cancel", tool_params)
-                
+
                 success = result.content[0].text if result.content else False
                 if isinstance(success, str):
-                    success = success.lower() == 'true'
-                
+                    success = success.lower() == "true"
+
                 if success:
                     console.print("[yellow]⚠[/yellow] Successfully cancelled workflow")
                     console.print(f"  Run ID: [cyan]{run_id}[/cyan]")
@@ -64,26 +74,32 @@ async def _cancel_workflow_async(
                         console.print(f"  Reason: [dim]{reason}[/dim]")
                 else:
                     raise CLIError(f"Failed to cancel workflow with run ID {run_id}")
-                    
+
     except Exception as e:
-        raise CLIError(f"Error cancelling workflow with run ID {run_id}: {str(e)}") from e
+        raise CLIError(
+            f"Error cancelling workflow with run ID {run_id}: {str(e)}"
+        ) from e
 
 
 @handle_server_api_errors
 def cancel_workflow(
-    server_id_or_url: str = typer.Argument(..., help="Server ID or URL hosting the workflow"),
+    server_id_or_url: str = typer.Argument(
+        ..., help="Server ID or URL hosting the workflow"
+    ),
     run_id: str = typer.Argument(..., help="Run ID of the workflow to cancel"),
-    reason: Optional[str] = typer.Option(None, "--reason", help="Optional reason for cancellation"),
+    reason: Optional[str] = typer.Option(
+        None, "--reason", help="Optional reason for cancellation"
+    ),
 ) -> None:
     """Cancel a workflow execution.
-    
+
     Permanently stops a workflow execution. Unlike suspend, a cancelled workflow
     cannot be resumed and will be marked as cancelled.
-    
+
     Examples:
-    
+
         mcp-agent cloud workflows cancel app_abc123 run_xyz789
-        
+
         mcp-agent cloud workflows cancel app_abc123 run_xyz789 --reason "User requested"
     """
     run_async(_cancel_workflow_async(server_id_or_url, run_id, reason))

--- a/src/mcp_agent/cli/cloud/commands/workflows/describe/main.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/describe/main.py
@@ -13,53 +13,61 @@ from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.utils.ux import console
 from mcp_agent.config import MCPServerSettings, Settings, LoggerSettings
 from mcp_agent.mcp.gen_client import gen_client
-from ...utils import setup_authenticated_client, resolve_server, handle_server_api_errors
+from ...utils import (
+    setup_authenticated_client,
+    resolve_server,
+    handle_server_api_errors,
+)
 
 
 async def _describe_workflow_async(
-    server_id_or_url: str,
-    run_id: str,
-    format: str = "text"
+    server_id_or_url: str, run_id: str, format: str = "text"
 ) -> None:
     """Describe a workflow using MCP tool calls to a deployed server."""
-    if server_id_or_url.startswith(('http://', 'https://')):
+    if server_id_or_url.startswith(("http://", "https://")):
         server_url = server_id_or_url
     else:
         client = setup_authenticated_client()
         server = resolve_server(client, server_id_or_url)
-        
-        if hasattr(server, 'appServerInfo') and server.appServerInfo:
+
+        if hasattr(server, "appServerInfo") and server.appServerInfo:
             server_url = server.appServerInfo.serverUrl
         else:
-            raise CLIError(f"Server '{server_id_or_url}' is not deployed or has no server URL")
-        
+            raise CLIError(
+                f"Server '{server_id_or_url}' is not deployed or has no server URL"
+            )
+
         if not server_url:
             raise CLIError(f"No server URL found for server '{server_id_or_url}'")
-    
+
     quiet_settings = Settings(logger=LoggerSettings(level="error"))
     app = MCPApp(name="workflows_cli", settings=quiet_settings)
-    
+
     try:
         async with app.run() as workflow_app:
             context = workflow_app.context
 
-            sse_url = f"{server_url}/sse" if not server_url.endswith('/sse') else server_url
+            sse_url = (
+                f"{server_url}/sse" if not server_url.endswith("/sse") else server_url
+            )
             context.server_registry.registry["workflow_server"] = MCPServerSettings(
                 name="workflow_server",
                 description=f"Deployed MCP server {server_url}",
                 url=sse_url,
-                transport="sse"
+                transport="sse",
             )
-            
-            async with gen_client("workflow_server", server_registry=context.server_registry) as client:
-                result = await client.call_tool("workflows-get_status", {
-                    "run_id": run_id
-                })
-                
+
+            async with gen_client(
+                "workflow_server", server_registry=context.server_registry
+            ) as client:
+                result = await client.call_tool(
+                    "workflows-get_status", {"run_id": run_id}
+                )
+
                 workflow_status = result.content[0].text if result.content else {}
                 if isinstance(workflow_status, str):
                     workflow_status = json.loads(workflow_status)
-                
+
                 if not workflow_status:
                     raise CLIError(f"Workflow with run ID '{run_id}' not found.")
 
@@ -69,26 +77,32 @@ async def _describe_workflow_async(
                     print(yaml.dump(workflow_status, default_flow_style=False))
                 else:  # text format
                     print_workflow_status(workflow_status)
-                    
+
     except Exception as e:
-        raise CLIError(f"Error describing workflow with run ID {run_id}: {str(e)}") from e
+        raise CLIError(
+            f"Error describing workflow with run ID {run_id}: {str(e)}"
+        ) from e
 
 
 @handle_server_api_errors
 def describe_workflow(
-    server_id_or_url: str = typer.Argument(..., help="Server ID or URL hosting the workflow"),
+    server_id_or_url: str = typer.Argument(
+        ..., help="Server ID or URL hosting the workflow"
+    ),
     run_id: str = typer.Argument(..., help="Run ID of the workflow to describe"),
-    format: Optional[str] = typer.Option("text", "--format", help="Output format (text|json|yaml)"),
+    format: Optional[str] = typer.Option(
+        "text", "--format", help="Output format (text|json|yaml)"
+    ),
 ) -> None:
     """Describe a workflow execution (alias: status).
-    
+
     Shows detailed information about a workflow execution including its current status,
     creation time, and other metadata.
-    
+
     Examples:
-    
+
         mcp-agent cloud workflows describe app_abc123 run_xyz789
-        
+
         mcp-agent cloud workflows describe app_abc123 run_xyz789 --format json
     """
     if format not in ["text", "json", "yaml"]:
@@ -101,19 +115,24 @@ def describe_workflow(
 def print_workflow_status(workflow_status: dict) -> None:
     """Print workflow status information in text format."""
     name = workflow_status.get("name", "N/A")
-    workflow_id = workflow_status.get("workflow_id", workflow_status.get("workflowId", "N/A"))
+    workflow_id = workflow_status.get(
+        "workflow_id", workflow_status.get("workflowId", "N/A")
+    )
     run_id = workflow_status.get("run_id", workflow_status.get("runId", "N/A"))
     status = workflow_status.get("status", "N/A")
-    
-    created_at = workflow_status.get("created_at", workflow_status.get("createdAt", "N/A"))
+
+    created_at = workflow_status.get(
+        "created_at", workflow_status.get("createdAt", "N/A")
+    )
     if created_at != "N/A" and isinstance(created_at, str):
         try:
             from datetime import datetime
-            created_dt = datetime.fromisoformat(created_at.replace('Z', '+00:00'))
-            created_at = created_dt.strftime('%Y-%m-%d %H:%M:%S')
+
+            created_dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+            created_at = created_dt.strftime("%Y-%m-%d %H:%M:%S")
         except (ValueError, TypeError):
             pass  # Keep original format if parsing fails
-    
+
     console.print(
         Panel(
             f"Name: [cyan]{name}[/cyan]\n"
@@ -131,7 +150,7 @@ def print_workflow_status(workflow_status: dict) -> None:
 def _format_status(status: str) -> str:
     """Format the execution status text."""
     status_lower = str(status).lower()
-    
+
     if "running" in status_lower:
         return "🔄 Running"
     elif "failed" in status_lower or "error" in status_lower:

--- a/src/mcp_agent/cli/cloud/commands/workflows/list/__init__.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/list/__init__.py
@@ -1,0 +1,5 @@
+"""Workflow list command module."""
+
+from .main import list_workflows
+
+__all__ = ["list_workflows"]

--- a/src/mcp_agent/cli/cloud/commands/workflows/list/main.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/list/main.py
@@ -1,0 +1,155 @@
+"""Workflow list command implementation."""
+
+import json
+from typing import Optional
+
+import typer
+import yaml
+from rich.table import Table
+
+from mcp_agent.app import MCPApp
+from mcp_agent.cli.core.utils import run_async
+from mcp_agent.cli.exceptions import CLIError
+from mcp_agent.cli.utils.ux import console, print_info
+from mcp_agent.config import MCPServerSettings, Settings, LoggerSettings
+from mcp_agent.mcp.gen_client import gen_client
+from ...utils import (
+    setup_authenticated_client,
+    resolve_server,
+    handle_server_api_errors,
+    validate_output_format,
+)
+
+
+async def _list_workflows_async(server_id_or_url: str, format: str = "text") -> None:
+    """List available workflows using MCP tool calls to a deployed server."""
+    if server_id_or_url.startswith(("http://", "https://")):
+        server_url = server_id_or_url
+    else:
+        client = setup_authenticated_client()
+        server = resolve_server(client, server_id_or_url)
+
+        if hasattr(server, "appServerInfo") and server.appServerInfo:
+            server_url = server.appServerInfo.serverUrl
+        else:
+            raise CLIError(
+                f"Server '{server_id_or_url}' is not deployed or has no server URL"
+            )
+
+        if not server_url:
+            raise CLIError(f"No server URL found for server '{server_id_or_url}'")
+
+    quiet_settings = Settings(logger=LoggerSettings(level="error"))
+    app = MCPApp(name="workflows_cli", settings=quiet_settings)
+
+    try:
+        async with app.run() as workflow_app:
+            context = workflow_app.context
+
+            sse_url = (
+                f"{server_url}/sse" if not server_url.endswith("/sse") else server_url
+            )
+            context.server_registry.registry["workflow_server"] = MCPServerSettings(
+                name="workflow_server",
+                description=f"Deployed MCP server {server_url}",
+                url=sse_url,
+                transport="sse",
+            )
+
+            async with gen_client(
+                "workflow_server", server_registry=context.server_registry
+            ) as client:
+                result = await client.call_tool("workflows-list", {})
+
+                workflows_data = result.content[0].text if result.content else "{}"
+                if isinstance(workflows_data, str):
+                    workflows_data = json.loads(workflows_data)
+
+                if not workflows_data:
+                    workflows_data = {}
+
+                if format == "json":
+                    print(json.dumps(workflows_data, indent=2))
+                elif format == "yaml":
+                    print(yaml.dump(workflows_data, default_flow_style=False))
+                else:  # text format
+                    print_workflows_text(workflows_data, server_id_or_url)
+
+    except Exception as e:
+        raise CLIError(
+            f"Error listing workflows for server {server_id_or_url}: {str(e)}"
+        ) from e
+
+
+@handle_server_api_errors
+def list_workflows(
+    server_id_or_url: str = typer.Argument(
+        ..., help="Server ID or URL to list workflows for"
+    ),
+    format: Optional[str] = typer.Option(
+        "text", "--format", help="Output format (text|json|yaml)"
+    ),
+) -> None:
+    """List available workflow definitions for an MCP Server.
+
+    This command lists the workflow definitions that a server provides,
+    showing what workflows can be executed.
+
+    Examples:
+
+        mcp-agent cloud workflows list app_abc123
+
+        mcp-agent cloud workflows list https://server.example.com --format json
+    """
+    validate_output_format(format)
+    run_async(_list_workflows_async(server_id_or_url, format))
+
+
+def print_workflows_text(workflows_data: dict, server_id_or_url: str) -> None:
+    """Print workflows information in text format."""
+    server_name = server_id_or_url
+
+    console.print(
+        f"\n[bold blue]📋 Available Workflows for Server: {server_name}[/bold blue]"
+    )
+
+    if not workflows_data or not any(workflows_data.values()):
+        print_info("No workflows found for this server.")
+        return
+
+    total_workflows = sum(
+        len(workflow_list) if isinstance(workflow_list, list) else 1
+        for workflow_list in workflows_data.values()
+    )
+    console.print(f"\nFound {total_workflows} workflow definition(s):")
+
+    table = Table(show_header=True, header_style="bold blue")
+    table.add_column("Name", style="cyan", width=25)
+    table.add_column("Description", style="green", width=40)
+    table.add_column("Capabilities", style="yellow", width=25)
+    table.add_column("Tool Endpoints", style="dim", width=20)
+
+    for workflow_name, workflow_info in workflows_data.items():
+        if isinstance(workflow_info, dict):
+            name = workflow_info.get("name", workflow_name)
+            description = workflow_info.get("description", "N/A")
+            capabilities = ", ".join(workflow_info.get("capabilities", []))
+            tool_endpoints = ", ".join(
+                [ep.split("-")[-1] for ep in workflow_info.get("tool_endpoints", [])]
+            )
+
+            table.add_row(
+                _truncate_string(name, 25),
+                _truncate_string(description, 40),
+                _truncate_string(capabilities if capabilities else "N/A", 25),
+                _truncate_string(tool_endpoints if tool_endpoints else "N/A", 20),
+            )
+
+    console.print(table)
+
+
+def _truncate_string(text: str, max_length: int) -> str:
+    """Truncate string to max_length, adding ellipsis if truncated."""
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 3] + "..."

--- a/src/mcp_agent/cli/cloud/commands/workflows/resume/main.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/resume/main.py
@@ -11,86 +11,126 @@ from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.utils.ux import console
 from mcp_agent.config import MCPServerSettings, Settings, LoggerSettings
 from mcp_agent.mcp.gen_client import gen_client
-from ...utils import setup_authenticated_client, resolve_server, handle_server_api_errors
+from ...utils import (
+    setup_authenticated_client,
+    resolve_server,
+    handle_server_api_errors,
+)
 
 
 async def _signal_workflow_async(
     server_id_or_url: str,
     run_id: str,
     signal_name: str = "resume",
-    payload: Optional[str] = None
+    payload: Optional[str] = None,
 ) -> None:
     """Send a signal to a workflow using MCP tool calls to a deployed server."""
-    if server_id_or_url.startswith(('http://', 'https://')):
+    if server_id_or_url.startswith(("http://", "https://")):
         server_url = server_id_or_url
     else:
         client = setup_authenticated_client()
         server = resolve_server(client, server_id_or_url)
-        
-        if hasattr(server, 'appServerInfo') and server.appServerInfo:
+
+        if hasattr(server, "appServerInfo") and server.appServerInfo:
             server_url = server.appServerInfo.serverUrl
         else:
-            raise CLIError(f"Server '{server_id_or_url}' is not deployed or has no server URL")
-        
+            raise CLIError(
+                f"Server '{server_id_or_url}' is not deployed or has no server URL"
+            )
+
         if not server_url:
             raise CLIError(f"No server URL found for server '{server_id_or_url}'")
-    
+
     quiet_settings = Settings(logger=LoggerSettings(level="error"))
     app = MCPApp(name="workflows_cli", settings=quiet_settings)
-    
+
     try:
         async with app.run() as workflow_app:
             context = workflow_app.context
-            
-            sse_url = f"{server_url.rstrip('/')}/sse" if not server_url.endswith('/sse') else server_url
+
+            sse_url = (
+                f"{server_url.rstrip('/')}/sse"
+                if not server_url.endswith("/sse")
+                else server_url
+            )
             context.server_registry.registry["workflow_server"] = MCPServerSettings(
                 name="workflow_server",
                 description=f"Deployed MCP server {server_url}",
                 url=sse_url,
-                transport="sse"
+                transport="sse",
             )
-            
-            async with gen_client("workflow_server", server_registry=context.server_registry) as client:
+
+            async with gen_client(
+                "workflow_server", server_registry=context.server_registry
+            ) as client:
                 tool_params = {"run_id": run_id, "signal_name": signal_name}
                 if payload:
                     tool_params["payload"] = payload
-                
+
                 result = await client.call_tool("workflows-resume", tool_params)
-                
+
                 success = result.content[0].text if result.content else False
                 if isinstance(success, str):
-                    success = success.lower() == 'true'
-                
+                    success = success.lower() == "true"
+
                 if success:
-                    action_past = "resumed" if signal_name == "resume" else "suspended" if signal_name == "suspend" else f"signaled ({signal_name})"
-                    action_color = "green" if signal_name == "resume" else "yellow" if signal_name == "suspend" else "blue"
-                    action_icon = "✓" if signal_name == "resume" else "⏸" if signal_name == "suspend" else "📡"
-                    console.print(f"[{action_color}]{action_icon}[/{action_color}] Successfully {action_past} workflow")
+                    action_past = (
+                        "resumed"
+                        if signal_name == "resume"
+                        else "suspended"
+                        if signal_name == "suspend"
+                        else f"signaled ({signal_name})"
+                    )
+                    action_color = (
+                        "green"
+                        if signal_name == "resume"
+                        else "yellow"
+                        if signal_name == "suspend"
+                        else "blue"
+                    )
+                    action_icon = (
+                        "✓"
+                        if signal_name == "resume"
+                        else "⏸"
+                        if signal_name == "suspend"
+                        else "📡"
+                    )
+                    console.print(
+                        f"[{action_color}]{action_icon}[/{action_color}] Successfully {action_past} workflow"
+                    )
                     console.print(f"  Run ID: [cyan]{run_id}[/cyan]")
                 else:
-                    raise CLIError(f"Failed to {signal_name} workflow with run ID {run_id}")
-                    
+                    raise CLIError(
+                        f"Failed to {signal_name} workflow with run ID {run_id}"
+                    )
+
     except Exception as e:
-        raise CLIError(f"Error {signal_name}ing workflow with run ID {run_id}: {str(e)}") from e
+        raise CLIError(
+            f"Error {signal_name}ing workflow with run ID {run_id}: {str(e)}"
+        ) from e
 
 
 @handle_server_api_errors
 def resume_workflow(
-    server_id_or_url: str = typer.Argument(..., help="Server ID or URL hosting the workflow"),
+    server_id_or_url: str = typer.Argument(
+        ..., help="Server ID or URL hosting the workflow"
+    ),
     run_id: str = typer.Argument(..., help="Run ID of the workflow to resume"),
-    payload: Optional[str] = typer.Option(None, "--payload", help="JSON or text payload to pass to resumed workflow"),
+    payload: Optional[str] = typer.Option(
+        None, "--payload", help="JSON or text payload to pass to resumed workflow"
+    ),
 ) -> None:
     """Resume a suspended workflow execution.
-    
+
     Resumes execution of a previously suspended workflow. Optionally accepts
     a payload (JSON or text) to pass data to the resumed workflow.
-    
+
     Examples:
-    
+
         mcp-agent cloud workflows resume app_abc123 run_xyz789
-        
+
         mcp-agent cloud workflows resume app_abc123 run_xyz789 --payload '{"data": "value"}'
-        
+
         mcp-agent cloud workflows resume app_abc123 run_xyz789 --payload "simple text"
     """
     if payload:
@@ -105,15 +145,19 @@ def resume_workflow(
 
 @handle_server_api_errors
 def suspend_workflow(
-    server_id_or_url: str = typer.Argument(..., help="Server ID or URL hosting the workflow"),
+    server_id_or_url: str = typer.Argument(
+        ..., help="Server ID or URL hosting the workflow"
+    ),
     run_id: str = typer.Argument(..., help="Run ID of the workflow to suspend"),
-    payload: Optional[str] = typer.Option(None, "--payload", help="JSON or text payload to pass to suspended workflow"),
+    payload: Optional[str] = typer.Option(
+        None, "--payload", help="JSON or text payload to pass to suspended workflow"
+    ),
 ) -> None:
     """Suspend a workflow execution.
-    
+
     Temporarily pauses a workflow execution, which can later be resumed.
     Optionally accepts a payload (JSON or text) to pass data to the suspended workflow.
-    
+
     Examples:
         mcp-agent cloud workflows suspend app_abc123 run_xyz789
         mcp-agent cloud workflows suspend https://server.example.com run_xyz789 --payload '{"reason": "maintenance"}'

--- a/src/mcp_agent/cli/cloud/commands/workflows/runs/__init__.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/runs/__init__.py
@@ -1,0 +1,5 @@
+"""Workflow runs command module."""
+
+from .main import list_workflow_runs
+
+__all__ = ["list_workflow_runs"]

--- a/src/mcp_agent/cli/cloud/commands/workflows/runs/main.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/runs/main.py
@@ -1,4 +1,4 @@
-"""Server workflows command implementation."""
+"""Workflow runs command implementation."""
 
 import json
 from typing import Optional
@@ -19,39 +19,51 @@ from mcp_agent.cli.utils.ux import console, print_info
 
 
 @handle_server_api_errors
-def list_workflows_for_server(
-    server_id_or_url: str = typer.Argument(..., help="Server ID, app config ID, or server URL to list workflows for"),
-    limit: Optional[int] = typer.Option(None, "--limit", help="Maximum number of results to return"),
-    status: Optional[str] = typer.Option(None, "--status", help="Filter by status: running|failed|timed_out|canceled|terminated|completed|continued"),
-    format: Optional[str] = typer.Option("text", "--format", help="Output format (text|json|yaml)"),
+def list_workflow_runs(
+    server_id_or_url: str = typer.Argument(
+        ..., help="Server ID, app config ID, or server URL to list workflow runs for"
+    ),
+    limit: Optional[int] = typer.Option(
+        None, "--limit", help="Maximum number of results to return"
+    ),
+    status: Optional[str] = typer.Option(
+        None,
+        "--status",
+        help="Filter by status: running|failed|timed_out|canceled|terminated|completed|continued",
+    ),
+    format: Optional[str] = typer.Option(
+        "text", "--format", help="Output format (text|json|yaml)"
+    ),
 ) -> None:
-    """List workflows for an MCP Server.
-    
+    """List workflow runs for an MCP Server.
+
     Examples:
-    
-        mcp-agent cloud servers workflows app_abc123
-        
-        mcp-agent cloud servers workflows https://server.example.com --status running
-        
-        mcp-agent cloud servers workflows apcnf_xyz789 --limit 10 --format json
+
+        mcp-agent cloud workflows runs app_abc123
+
+        mcp-agent cloud workflows runs https://server.example.com --status running
+
+        mcp-agent cloud workflows runs apcnf_xyz789 --limit 10 --format json
     """
     validate_output_format(format)
     client = setup_authenticated_client()
-    
-    if server_id_or_url.startswith(('http://', 'https://')):
+
+    if server_id_or_url.startswith(("http://", "https://")):
         resolved_server = resolve_server(client, server_id_or_url)
-        
-        if hasattr(resolved_server, 'appId'):
+
+        if hasattr(resolved_server, "appId"):
             app_id_or_config_id = resolved_server.appId
-        elif hasattr(resolved_server, 'appConfigurationId'):
+        elif hasattr(resolved_server, "appConfigurationId"):
             app_id_or_config_id = resolved_server.appConfigurationId
         else:
-            raise ValueError(f"Could not extract app ID or config ID from server: {server_id_or_url}")
+            raise ValueError(
+                f"Could not extract app ID or config ID from server: {server_id_or_url}"
+            )
     else:
         app_id_or_config_id = server_id_or_url
-    
+
     max_results = limit or 100
-    
+
     status_filter = None
     if status:
         status_map = {
@@ -69,20 +81,21 @@ def list_workflows_for_server(
         status_filter = status_map.get(status.lower())
         if not status_filter:
             valid_statuses = "running|failed|timed_out|timeout|canceled|cancelled|terminated|completed|continued|continued_as_new"
-            raise typer.BadParameter(f"Invalid status '{status}'. Valid options: {valid_statuses}")
+            raise typer.BadParameter(
+                f"Invalid status '{status}'. Valid options: {valid_statuses}"
+            )
 
     async def list_workflows_async():
         return await client.list_workflows(
-            app_id_or_config_id=app_id_or_config_id,
-            max_results=max_results
+            app_id_or_config_id=app_id_or_config_id, max_results=max_results
         )
 
     response = run_async(list_workflows_async())
     workflows = response.workflows or []
-    
+
     if status_filter:
         workflows = [w for w in workflows if w.execution_status == status_filter]
-    
+
     if format == "json":
         _print_workflows_json(workflows)
     elif format == "yaml":
@@ -94,15 +107,17 @@ def list_workflows_for_server(
 def _print_workflows_text(workflows, status_filter, server_id_or_url):
     """Print workflows in text format."""
     server_name = server_id_or_url
-    
-    console.print(f"\n[bold blue]📊 Workflows for Server: {server_name}[/bold blue]")
-    
+
+    console.print(
+        f"\n[bold blue]📊 Workflow Runs for Server: {server_name}[/bold blue]"
+    )
+
     if not workflows:
-        print_info("No workflows found for this server.")
+        print_info("No workflow runs found for this server.")
         return
-    
-    console.print(f"\nFound {len(workflows)} workflow(s):")
-    
+
+    console.print(f"\nFound {len(workflows)} workflow run(s):")
+
     table = Table(show_header=True, header_style="bold blue")
     table.add_column("Workflow ID", style="cyan", width=20)
     table.add_column("Name", style="green", width=20)
@@ -110,12 +125,16 @@ def _print_workflows_text(workflows, status_filter, server_id_or_url):
     table.add_column("Run ID", style="dim", width=15)
     table.add_column("Created", style="dim", width=20)
     table.add_column("Principal", style="dim", width=15)
-    
+
     for workflow in workflows:
         status_display = _get_status_display(workflow.execution_status)
-        created_display = workflow.created_at.strftime('%Y-%m-%d %H:%M:%S') if workflow.created_at else "N/A"
+        created_display = (
+            workflow.created_at.strftime("%Y-%m-%d %H:%M:%S")
+            if workflow.created_at
+            else "N/A"
+        )
         run_id_display = _truncate_string(workflow.run_id or "N/A", 15)
-        
+
         table.add_row(
             _truncate_string(workflow.workflow_id, 20),
             _truncate_string(workflow.name, 20),
@@ -124,9 +143,9 @@ def _print_workflows_text(workflows, status_filter, server_id_or_url):
             created_display,
             _truncate_string(workflow.principal_id, 15),
         )
-    
+
     console.print(table)
-    
+
     if status_filter:
         console.print(f"\n[dim]Filtered by status: {status_filter}[/dim]")
 
@@ -134,13 +153,13 @@ def _print_workflows_text(workflows, status_filter, server_id_or_url):
 def _print_workflows_json(workflows):
     """Print workflows in JSON format."""
     workflows_data = [_workflow_to_dict(workflow) for workflow in workflows]
-    print(json.dumps({"workflows": workflows_data}, indent=2, default=str))
+    print(json.dumps({"workflow_runs": workflows_data}, indent=2, default=str))
 
 
 def _print_workflows_yaml(workflows):
     """Print workflows in YAML format."""
     workflows_data = [_workflow_to_dict(workflow) for workflow in workflows]
-    print(yaml.dump({"workflows": workflows_data}, default_flow_style=False))
+    print(yaml.dump({"workflow_runs": workflows_data}, default_flow_style=False))
 
 
 def _workflow_to_dict(workflow):
@@ -151,7 +170,9 @@ def _workflow_to_dict(workflow):
         "name": workflow.name,
         "created_at": workflow.created_at.isoformat() if workflow.created_at else None,
         "principal_id": workflow.principal_id,
-        "execution_status": workflow.execution_status.value if workflow.execution_status else None,
+        "execution_status": workflow.execution_status.value
+        if workflow.execution_status
+        else None,
     }
 
 
@@ -159,14 +180,14 @@ def _truncate_string(text: str, max_length: int) -> str:
     """Truncate string to max_length, adding ellipsis if truncated."""
     if len(text) <= max_length:
         return text
-    return text[:max_length-3] + "..."
+    return text[: max_length - 3] + "..."
 
 
 def _get_status_display(status):
     """Convert WorkflowExecutionStatus to display string with emoji."""
     if not status:
         return "❓ Unknown"
-    
+
     status_map = {
         WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_RUNNING: "[green]🟢 Running[/green]",
         WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_COMPLETED: "[blue]✅ Completed[/blue]",
@@ -176,5 +197,5 @@ def _get_status_display(status):
         WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_TIMED_OUT: "[orange]⏰ Timed Out[/orange]",
         WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW: "[purple]🔄 Continued[/purple]",
     }
-    
+
     return status_map.get(status, "❓ Unknown")

--- a/src/mcp_agent/cli/cloud/main.py
+++ b/src/mcp_agent/cli/cloud/main.py
@@ -32,12 +32,13 @@ from mcp_agent.cli.cloud.commands.workflows import (
     resume_workflow,
     suspend_workflow,
     cancel_workflow,
+    list_workflows,
+    list_workflow_runs,
 )
 from mcp_agent.cli.cloud.commands.servers import (
     list_servers,
     describe_server,
     delete_server,
-    list_workflows_for_server,
 )
 from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.utils.ux import print_error
@@ -150,10 +151,14 @@ app_cmd_workflows = typer.Typer(
     cls=HelpfulTyperGroup,
 )
 app_cmd_workflows.command(name="describe")(describe_workflow)
-app_cmd_workflows.command(name="status")(describe_workflow)  # alias for describe
+app_cmd_workflows.command(
+    name="status", help="Describe a workflow execution (alias for 'describe')"
+)(describe_workflow)
 app_cmd_workflows.command(name="resume")(resume_workflow)
 app_cmd_workflows.command(name="suspend")(suspend_workflow)
 app_cmd_workflows.command(name="cancel")(cancel_workflow)
+app_cmd_workflows.command(name="list")(list_workflows)
+app_cmd_workflows.command(name="runs")(list_workflow_runs)
 
 # Sub-typer for `mcp-agent servers` commands
 app_cmd_servers = typer.Typer(
@@ -164,7 +169,10 @@ app_cmd_servers = typer.Typer(
 app_cmd_servers.command(name="list")(list_servers)
 app_cmd_servers.command(name="describe")(describe_server)
 app_cmd_servers.command(name="delete")(delete_server)
-app_cmd_servers.command(name="workflows")(list_workflows_for_server)
+app_cmd_servers.command(
+    name="workflows",
+    help="List available workflows for a server (alias for 'workflows list')",
+)(list_workflows)
 app.add_typer(app_cmd_servers, name="servers", help="Manage MCP Servers")
 
 # Alias for servers - apps should behave identically

--- a/src/mcp_agent/cli/core/utils.py
+++ b/src/mcp_agent/cli/core/utils.py
@@ -28,36 +28,38 @@ def run_async(coro):
 
 def parse_app_identifier(identifier: str) -> Tuple[Optional[str], Optional[str]]:
     """Parse app identifier to extract app ID and config ID.
-    
+
     Args:
         identifier: App identifier (must be app_... or apcnf_...)
-        
+
     Returns:
         Tuple of (app_id, config_id)
-        
+
     Raises:
         ValueError: If identifier format is not recognized
     """
-    
-    if identifier.startswith('apcnf_'):
+
+    if identifier.startswith("apcnf_"):
         return None, identifier
-    
-    if identifier.startswith('app_'):
+
+    if identifier.startswith("app_"):
         return identifier, None
-    
-    raise ValueError(f"Invalid identifier format: '{identifier}'. Must be an app ID (app_...) or app configuration ID (apcnf_...)")
+
+    raise ValueError(
+        f"Invalid identifier format: '{identifier}'. Must be an app ID (app_...) or app configuration ID (apcnf_...)"
+    )
 
 
 async def resolve_server_url(
     app_id: Optional[str],
-    config_id: Optional[str], 
+    config_id: Optional[str],
     credentials: UserCredentials,
 ) -> str:
     """Resolve server URL from app ID or configuration ID."""
-    
+
     if not app_id and not config_id:
         raise CLIError("Either app_id or config_id must be provided")
-    
+
     if app_id:
         endpoint = "/mcp_app/get_app"
         payload = {"app_id": app_id}
@@ -76,38 +78,42 @@ async def resolve_server_url(
         no_url_msg = f"No server URL found for app configuration '{config_id}'"
         offline_msg = f"App configuration '{config_id}' server is offline"
         api_error_msg = "Failed to get app configuration"
-    
+
     api_base = DEFAULT_API_BASE_URL
     headers = {
         "Authorization": f"Bearer {credentials.api_key}",
         "Content-Type": "application/json",
     }
-    
+
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.post(f"{api_base}{endpoint}", json=payload, headers=headers)
-            
+            response = await client.post(
+                f"{api_base}{endpoint}", json=payload, headers=headers
+            )
+
             if response.status_code == 404:
                 raise CLIError(not_found_msg)
             elif response.status_code != 200:
-                raise CLIError(f"{api_error_msg}: {response.status_code} {response.text}")
-            
+                raise CLIError(
+                    f"{api_error_msg}: {response.status_code} {response.text}"
+                )
+
             data = response.json()
             resource_info = data.get(response_key, {})
             server_info = resource_info.get("appServerInfo")
-            
+
             if not server_info:
                 raise CLIError(not_deployed_msg)
-            
+
             server_url = server_info.get("serverUrl")
             if not server_url:
                 raise CLIError(no_url_msg)
-                
+
             status = server_info.get("status", "APP_SERVER_STATUS_UNSPECIFIED")
             if status == "APP_SERVER_STATUS_OFFLINE":
                 raise CLIError(offline_msg)
-            
+
             return server_url
-                
+
     except httpx.RequestError as e:
         raise CLIError(f"Failed to connect to API: {e}")

--- a/src/mcp_agent/cli/mcp_app/api_client.py
+++ b/src/mcp_agent/cli/mcp_app/api_client.py
@@ -66,6 +66,7 @@ class CanDoActionsResponse(BaseModel):
 
 class WorkflowExecutionStatus(Enum):
     """From temporal.api.enums.v1.WorkflowExecutionStatus"""
+
     WORKFLOW_EXECUTION_STATUS_UNSPECIFIED = "WORKFLOW_EXECUTION_STATUS_UNSPECIFIED"
     WORKFLOW_EXECUTION_STATUS_RUNNING = "WORKFLOW_EXECUTION_STATUS_RUNNING"
     WORKFLOW_EXECUTION_STATUS_FAILED = "WORKFLOW_EXECUTION_STATUS_FAILED"
@@ -73,11 +74,14 @@ class WorkflowExecutionStatus(Enum):
     WORKFLOW_EXECUTION_STATUS_CANCELED = "WORKFLOW_EXECUTION_STATUS_CANCELED"
     WORKFLOW_EXECUTION_STATUS_TERMINATED = "WORKFLOW_EXECUTION_STATUS_TERMINATED"
     WORKFLOW_EXECUTION_STATUS_COMPLETED = "WORKFLOW_EXECUTION_STATUS_COMPLETED"
-    WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW = "WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW"
+    WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW = (
+        "WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW"
+    )
 
 
 class WorkflowInfo(BaseModel):
     """Information about a workflow execution instance"""
+
     workflow_id: str
     run_id: Optional[str] = None
     name: str
@@ -88,6 +92,7 @@ class WorkflowInfo(BaseModel):
 
 class ListWorkflowsResponse(BaseModel):
     """Response for listing workflows"""
+
     workflows: Optional[List[WorkflowInfo]] = []
     next_page_token: Optional[str] = None
     total_count: Optional[int] = 0
@@ -136,19 +141,21 @@ def is_valid_server_url_format(server_url: str) -> bool:
 
 class LogEntry(BaseModel):
     """Represents a single log entry."""
+
     timestamp: Optional[str] = None
     level: Optional[str] = None
     message: Optional[str] = None
     # Allow additional fields that might be present
-    
+
     class Config:
         extra = "allow"
 
 
 class GetAppLogsResponse(BaseModel):
     """Response from get_app_logs API endpoint."""
+
     logEntries: Optional[List[LogEntry]] = []
-    
+
     @property
     def log_entries_list(self) -> List[LogEntry]:
         """Get log entries regardless of field name format."""
@@ -502,16 +509,16 @@ class MCPAppClient(APIClient):
         page_token: Optional[str] = None,
     ) -> ListWorkflowsResponse:
         """List workflows for a specific app or app configuration.
-        
+
         Args:
             app_id_or_config_id: The app ID (e.g. app_abc123) or app config ID (e.g. apcnf_xyz789)
             name_filter: Optional workflow name filter
             max_results: Maximum number of results to return
             page_token: Pagination token
-            
+
         Returns:
             ListWorkflowsResponse: The list of workflows
-            
+
         Raises:
             ValueError: If the app_id_or_config_id is invalid
             httpx.HTTPError: If the API request fails
@@ -519,19 +526,21 @@ class MCPAppClient(APIClient):
         payload: Dict[str, Any] = {
             "max_results": max_results,
         }
-        
+
         if is_valid_app_id_format(app_id_or_config_id):
             payload["app_specifier"] = {"app_id": app_id_or_config_id}
         elif is_valid_app_config_id_format(app_id_or_config_id):
             payload["app_specifier"] = {"app_config_id": app_id_or_config_id}
         else:
-            raise ValueError(f"Invalid app ID or app config ID format: {app_id_or_config_id}. Expected format: app_xxx or apcnf_xxx")
-        
+            raise ValueError(
+                f"Invalid app ID or app config ID format: {app_id_or_config_id}. Expected format: app_xxx or apcnf_xxx"
+            )
+
         if name_filter:
             payload["name"] = name_filter
         if page_token:
             payload["page_token"] = page_token
-        
+
         response = await self.post("/workflow/list", payload)
         return ListWorkflowsResponse(**response.json())
 
@@ -712,12 +721,18 @@ class MCPAppClient(APIClient):
         if not app_id and not app_configuration_id:
             raise ValueError("Either app_id or app_configuration_id must be provided")
         if app_id and app_configuration_id:
-            raise ValueError("Only one of app_id or app_configuration_id can be provided")
-        
+            raise ValueError(
+                "Only one of app_id or app_configuration_id can be provided"
+            )
+
         if app_id and not is_valid_app_id_format(app_id):
             raise ValueError(f"Invalid app ID format: {app_id}")
-        if app_configuration_id and not is_valid_app_config_id_format(app_configuration_id):
-            raise ValueError(f"Invalid app configuration ID format: {app_configuration_id}")
+        if app_configuration_id and not is_valid_app_config_id_format(
+            app_configuration_id
+        ):
+            raise ValueError(
+                f"Invalid app configuration ID format: {app_configuration_id}"
+            )
 
         # Prepare request payload
         payload = {}


### PR DESCRIPTION
### TL;DR

Reorganized workflow commands

`mcp-agent cloud workflows runs`
`mcp-agent cloud workflows list`
`mcp-agent cloud server workflows` (alias of workflows list)

### What changed?

- Moved `list_workflows_for_server` from the servers module to the workflows module as `list_workflow_runs`
- Added new workflow commands: `list_workflows` and `list_workflow_runs`
- Updated CLI command structure to make workflows commands more intuitive
- Applied consistent code formatting with black across all server and workflow related files

### How to test?

Test the new and reorganized workflow commands:

```bash
# List available workflow definitions
mcp-agent cloud workflows list app_abc123

# List workflow runs (previously under servers workflows)
mcp-agent cloud workflows runs app_abc123

# Test with different output formats
mcp-agent cloud workflows list app_abc123 --format json
mcp-agent cloud workflows runs app_abc123 --format yaml

# Verify existing commands still work
mcp-agent cloud servers list
mcp-agent cloud workflows describe app_abc123 run_xyz789
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added workflows list and workflows runs commands with text/JSON/YAML output.
  * Introduced apps alias for the servers command group.

* Refactor
  * Renamed server-scoped listing to list_workflow_runs; servers workflows now aliases the shared listing. JSON/YAML now use workflow_runs as the root key.

* Bug Fixes
  * More reliable server list filtering/sorting across deployed and configured apps.
  * Clearer errors when resolving servers; stricter format validation in workflow describe; better handling of empty workflow status.

* Documentation
  * Updated help text for workflows status and servers workflows (alias descriptions).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->