### PR TITLE
add cloud logger configure

### DIFF
--- a/src/mcp_agent/cli/cloud/main.py
+++ b/src/mcp_agent/cli/cloud/main.py
@@ -21,6 +21,7 @@ from mcp_agent.cli.cloud.commands import (
     whoami,
 )
 from mcp_agent.cli.cloud.commands.logger import tail_logs
+from mcp_agent.cli.cloud.commands.logger.configure import configure_logger
 from mcp_agent.cli.cloud.commands.app import (
     delete_app,
     get_app_status,
@@ -190,6 +191,10 @@ app_cmd_cloud_logger = typer.Typer(
     cls=HelpfulTyperGroup,
 )
 # Register logger commands under cloud logger
+app_cmd_cloud_logger.command(
+    name="configure",
+    help="Set OTEL endpoint and headers; test and apply configuration",
+)(configure_logger)
 app_cmd_cloud_logger.command(
     name="tail",
     help="Retrieve and stream logs from deployed MCP apps",


### PR DESCRIPTION
### TL;DR

Updated the OTEL logger configuration structure and added the `configure` command to the cloud logger command group.

### What changed?

- Updated the OTEL configuration structure to use a nested `otlp_settings` object that contains endpoint and headers
- Added backward compatibility to support the old configuration format
- Enhanced the health check endpoint detection to handle both `/v1/traces` and `/v1/logs` paths
- Added additional OTEL configuration parameters: `enabled` flag and `exporters` list
- Fixed the example in the help text to use `/v1/traces` instead of `/v1/logs`
- Registered the `configure_logger` command under the cloud logger command group

### How to test?

1. Test the new configuration format:
2. Test with custom headers:
3. Test the current configuration: