### PR TITLE
Fix: Deployed App Status Enum Check

### DIFF
--- a/src/mcp_agent/cli/cloud/commands/deploy/main.py
+++ b/src/mcp_agent/cli/cloud/commands/deploy/main.py
@@ -271,7 +271,11 @@ def deploy_config(
                 print_info(f"App ID: {app_id}")
 
                 if app.appServerInfo:
-                    status = "ONLINE" if app.appServerInfo.status == 1 else "OFFLINE"
+                    status = (
+                        "ONLINE"
+                        if app.appServerInfo.status == "APP_SERVER_STATUS_ONLINE"
+                        else "OFFLINE"
+                    )
                     print_info(f"App URL: {app.appServerInfo.serverUrl}")
                     print_info(f"App Status: {status}")
                 return app_id


### PR DESCRIPTION
## Description
The enum check was using legacy logic to map to the number representing the value. The status enum is serialized to string now so fix the check:

```bash
INFO: App Status: ONLINE
▹▸▹▹▹ ✅ MCP App deployed successfully!
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected app server status detection in the cloud deploy command to prevent false ONLINE/OFFLINE readings.
  * Status is now reliably recognized and reported as ONLINE or OFFLINE across environments.
  * Output (URL and status) remains unchanged, preserving existing workflows and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->