### PR TITLE
Fix/swap relative mcp agent dependency on deploy

### DIFF
--- a/src/mcp_agent/cli/cloud/commands/deploy/wrangler_wrapper.py
+++ b/src/mcp_agent/cli/cloud/commands/deploy/wrangler_wrapper.py
@@ -180,7 +180,7 @@ def wrangler_deploy(app_id: str, api_key: str, project_dir: Path) -> None:
         # Backup and modify requirements.txt if needed
         if requirements_needs_modification:
             # Create .bak file same as other files for consistent cleanup
-            requirements_backup = requirements_path.with_suffix(".txt.bak")
+            requirements_backup = Path(str(requirements_path) + ".bak")
             shutil.copy(requirements_path, requirements_backup)
             copied_py_files.append(requirements_backup)  # Track for cleanup
 
@@ -225,14 +225,14 @@ def wrangler_deploy(app_id: str, api_key: str, project_dir: Path) -> None:
                 temp_original = Path(str(file_path) + ".bak")
 
                 # Hide the original file by renaming it temporarily
-                # Skip renaming requirements.txt if already backed up but still track
-                # it for cleanup
-                if not (
-                    filename == "requirements.txt" and requirements_needs_modification
-                ):
+                # Skip requirements.txt if already backed up (and tracked)
+                if filename == "requirements.txt" and requirements_needs_modification:
+                    # Original .bak and updated .mcpac.py already tracked
+                    # Just remove raw requirements.txt to exclude it from the bundle
+                    file_path.unlink()
+                else:
                     file_path.rename(temp_original)
-
-                copied_py_files.append(temp_original)  # Track for cleanup
+                    copied_py_files.append(temp_original)  # Track for cleanup
 
         wrangler_toml_path.write_text(wrangler_toml_content)
 

--- a/tests/cli/commands/test_wrangler_wrapper.py
+++ b/tests/cli/commands/test_wrangler_wrapper.py
@@ -870,10 +870,14 @@ def test_wrangler_deploy_requirements_txt_backup_and_restore(
     original_content = requirements_path.read_text()
 
     def check_requirements_during_subprocess(*args, **kwargs):
-        # During subprocess execution, requirements.txt should be modified
-        current_content = requirements_path.read_text()
+        deployed_path = requirements_path.with_suffix(".txt.mcpac.py")
+        current_content = deployed_path.read_text()
         assert "mcp-agent @ file://" not in current_content
         assert "mcp-agent\n" in current_content
+
+        assert not requirements_path.exists(), (
+            "Original requirements.txt should be hidden"
+        )
 
         return MagicMock(returncode=0)
 


### PR DESCRIPTION
## Description
When testing examples, we're always hitting the issue with the requirements.txt file referencing the local mcp-agent package. We can special-case this file handling in the wrangler wrapper to replace the `mcp-agent @ file://...` with `mcp-agent` to prevent these issues. We swap out the original requirements.txt to a `.bak` backup, similar to the other modified files, so that the updated version is`requirements.txt.mcpac.py` in the bundle.

## Testing
Can now deploy temporal example without changes to requirements.txt (set `capture_output` to False in the wrangler_wrapper to see bundled files):

```
┌──────────────────────────────────────────┬────────┬───────────┐
│ Name                                     │ Type   │ Size      │
├──────────────────────────────────────────┼────────┼───────────┤
│ README.md.mcpac.py                       │ python │ 6.11 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ basic.py                                 │ python │ 1.98 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ evaluator_optimizer.py                   │ python │ 4.50 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ graded_report.md.mcpac.py                │ python │ 2.94 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ interactive.py                           │ python │ 2.30 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ mcp_agent.config.yaml.mcpac.py           │ python │ 1.30 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ mcp_agent.deployed.secrets.yaml.mcpac.py │ python │ 0.18 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ mcp_agent.secrets.yaml.example.mcpac.py  │ python │ 0.08 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ orchestrator.py                          │ python │ 4.36 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ parallel.py                              │ python │ 8.07 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ requirements.txt.mcpac.py                │ python │ 0.12 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ router.py                                │ python │ 5.73 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ run_worker.py                            │ python │ 0.80 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ short_story.md.mcpac.py                  │ python │ 1.21 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ workflows.py                             │ python │ 0.33 KiB  │
├──────────────────────────────────────────┼────────┼───────────┤
│ Total (15 modules)                       │        │ 40.01 KiB │
└──────────────────────────────────────────┴────────┴───────────┘
```


```bash
make lint
make format
make tests
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically detects and temporarily converts local mcp-agent references in requirements.txt for smoother Wrangler deployments.
  * Safely backs up and restores requirements.txt around deployment, ensuring original content is preserved.

* **Bug Fixes**
  * Prevents deployment failures caused by relative/local package references in requirements.txt.
  * Ensures proper cleanup and restoration even if deployment fails.

* **Tests**
  * Expanded coverage for requirements.txt handling across multiple scenarios (presence/absence, formatting variations, failure paths), improving deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->