### PR TITLE
Refactor server resolution into a shared utility function

### DIFF
--- a/src/mcp_agent/cli/cloud/commands/app/delete/main.py
+++ b/src/mcp_agent/cli/cloud/commands/app/delete/main.py
@@ -11,6 +11,7 @@ from mcp_agent.cli.core.constants import (
     ENV_API_KEY,
 )
 from mcp_agent.cli.core.utils import run_async
+from ...utils import resolve_server
 from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.mcp_app.api_client import (
     MCPAppClient,
@@ -71,7 +72,7 @@ def delete_app(
     id_type = "app"
     id_to_delete = None
     try:
-        app_or_config = run_async(client.get_app_or_config(app_id_or_url))
+        app_or_config = resolve_server(client, app_id_or_url)
 
         if isinstance(app_or_config, MCPAppConfiguration):
             id_to_delete = app_or_config.appConfigurationId

--- a/src/mcp_agent/cli/cloud/commands/app/status/main.py
+++ b/src/mcp_agent/cli/cloud/commands/app/status/main.py
@@ -19,6 +19,7 @@ from mcp_agent.cli.core.constants import (
     ENV_API_KEY,
 )
 from mcp_agent.cli.core.utils import run_async
+from ...utils import resolve_server
 from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.mcp_app.api_client import AppServerInfo, MCPAppClient
 from mcp_agent.cli.mcp_app.mcp_client import (
@@ -67,7 +68,7 @@ def get_app_status(
         raise CLIError("You must provide an app ID or server URL to get its status.")
 
     try:
-        app_or_config = run_async(client.get_app_or_config(app_id_or_url))
+        app_or_config = resolve_server(client, app_id_or_url)
 
         if not app_or_config:
             raise CLIError(f"App or config with ID or URL '{app_id_or_url}' not found.")

--- a/src/mcp_agent/cli/cloud/commands/app/workflows/main.py
+++ b/src/mcp_agent/cli/cloud/commands/app/workflows/main.py
@@ -21,6 +21,7 @@ from mcp_agent.cli.core.constants import (
     ENV_API_KEY,
 )
 from mcp_agent.cli.core.utils import run_async
+from ...utils import resolve_server
 from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.mcp_app.api_client import MCPAppClient
 from mcp_agent.cli.mcp_app.mcp_client import (
@@ -72,7 +73,7 @@ def list_app_workflows(
         )
 
     try:
-        app_or_config = run_async(client.get_app_or_config(app_id_or_url))
+        app_or_config = resolve_server(client, app_id_or_url)
 
         if not app_or_config:
             raise CLIError(f"App or config with ID or URL '{app_id_or_url}' not found.")

--- a/src/mcp_agent/cli/cloud/commands/logger/tail/main.py
+++ b/src/mcp_agent/cli/cloud/commands/logger/tail/main.py
@@ -17,9 +17,8 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.auth import load_credentials, UserCredentials
-from mcp_agent.cli.cloud.commands.utils import setup_authenticated_client
+from mcp_agent.cli.cloud.commands.utils import setup_authenticated_client, resolve_server
 from mcp_agent.cli.core.api_client import UnauthenticatedError
-from mcp_agent.cli.core.utils import run_async
 from mcp_agent.cli.utils.ux import print_error
 from mcp_agent.cli.mcp_app.api_client import MCPApp, MCPAppConfiguration
 
@@ -135,7 +134,7 @@ def tail_logs(
         raise typer.Exit(6)
 
     client = setup_authenticated_client()
-    server = run_async(client.get_app_or_config(app_identifier))
+    server = resolve_server(client, app_identifier)
     
     try:
         if follow:

--- a/src/mcp_agent/cli/cloud/commands/servers/delete/main.py
+++ b/src/mcp_agent/cli/cloud/commands/servers/delete/main.py
@@ -6,6 +6,7 @@ from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.mcp_app.api_client import MCPApp
 from ...utils import (
     setup_authenticated_client,
+    resolve_server,
     handle_server_api_errors,
     get_server_name,
     get_server_id,
@@ -24,7 +25,7 @@ def delete_server(
 ) -> None:
     """Delete a specific MCP Server."""
     client = setup_authenticated_client()
-    server = run_async(client.get_app_or_config(id_or_url))
+    server = resolve_server(client, id_or_url)
 
     # Determine server type and delete function
     if isinstance(server, MCPApp):

--- a/src/mcp_agent/cli/cloud/commands/servers/describe/main.py
+++ b/src/mcp_agent/cli/cloud/commands/servers/describe/main.py
@@ -10,10 +10,10 @@ from mcp_agent.cli.mcp_app.api_client import MCPApp, MCPAppConfiguration
 from ...utils import (
     setup_authenticated_client,
     validate_output_format,
+    resolve_server,
     handle_server_api_errors,
     clean_server_status,
 )
-from mcp_agent.cli.core.utils import run_async
 from mcp_agent.cli.utils.ux import console
 
 
@@ -29,7 +29,7 @@ def describe_server(
     """Describe a specific MCP Server."""
     validate_output_format(format)
     client = setup_authenticated_client()
-    server = run_async(client.get_app_or_config(id_or_url))
+    server = resolve_server(client, id_or_url)
     print_server_description(server, format)
 
 

--- a/src/mcp_agent/cli/cloud/commands/utils.py
+++ b/src/mcp_agent/cli/cloud/commands/utils.py
@@ -6,6 +6,7 @@ from typing import Union
 from mcp_agent.cli.auth import load_api_key_credentials
 from mcp_agent.cli.core.api_client import UnauthenticatedError
 from mcp_agent.cli.core.constants import DEFAULT_API_BASE_URL
+from mcp_agent.cli.core.utils import run_async
 from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.mcp_app.api_client import (
     MCPApp,
@@ -45,6 +46,28 @@ def validate_output_format(format: str) -> None:
         raise CLIError(
             f"Invalid format '{format}'. Valid options are: {', '.join(valid_formats)}"
         )
+
+
+def resolve_server(
+    client: MCPAppClient, id_or_url: str
+) -> Union[MCPApp, MCPAppConfiguration]:
+    """Resolve server from ID or URL.
+
+    Args:
+        client: Authenticated MCP App client
+        id_or_url: Server identifier (app ID, app config ID, or server URL)
+
+    Returns:
+        Server object (MCPApp or MCPAppConfiguration)
+
+    Raises:
+        CLIError: If server resolution fails
+    """
+    try:
+        return run_async(client.get_app_or_config(id_or_url))
+
+    except Exception as e:
+        raise CLIError(f"Failed to resolve server '{id_or_url}': {str(e)}") from e
 
 
 def handle_server_api_errors(func):

--- a/src/mcp_agent/cli/cloud/commands/workflows/cancel/main.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/cancel/main.py
@@ -13,6 +13,7 @@ from mcp_agent.mcp.gen_client import gen_client
 from ...utils import (
     setup_authenticated_client,
     handle_server_api_errors,
+    resolve_server,
 )
 
 
@@ -24,7 +25,7 @@ async def _cancel_workflow_async(
         server_url = server_id_or_url
     else:
         client = setup_authenticated_client()
-        server = run_async(client.get_app_or_config(server_id_or_url))
+        server = resolve_server(client, server_id_or_url)
 
         if hasattr(server, "appServerInfo") and server.appServerInfo:
             server_url = server.appServerInfo.serverUrl

--- a/src/mcp_agent/cli/cloud/commands/workflows/describe/main.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/describe/main.py
@@ -15,6 +15,7 @@ from mcp_agent.mcp.gen_client import gen_client
 from ...utils import (
     setup_authenticated_client,
     handle_server_api_errors,
+    resolve_server,
 )
 
 
@@ -26,7 +27,7 @@ async def _describe_workflow_async(
         server_url = server_id_or_url
     else:
         client = setup_authenticated_client()
-        server = run_async(client.get_app_or_config(server_id_or_url))
+        server = resolve_server(client, server_id_or_url)
 
         if hasattr(server, "appServerInfo") and server.appServerInfo:
             server_url = server.appServerInfo.serverUrl

--- a/src/mcp_agent/cli/cloud/commands/workflows/list/main.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/list/main.py
@@ -15,6 +15,7 @@ from mcp_agent.config import MCPServerSettings, Settings, LoggerSettings
 from mcp_agent.mcp.gen_client import gen_client
 from ...utils import (
     setup_authenticated_client,
+    resolve_server,
     handle_server_api_errors,
     validate_output_format,
 )
@@ -26,7 +27,7 @@ async def _list_workflows_async(server_id_or_url: str, format: str = "text") -> 
         server_url = server_id_or_url
     else:
         client = setup_authenticated_client()
-        server = run_async(client.get_app_or_config(server_id_or_url))
+        server = resolve_server(client, server_id_or_url)
 
         if hasattr(server, "appServerInfo") and server.appServerInfo:
             server_url = server.appServerInfo.serverUrl

--- a/src/mcp_agent/cli/cloud/commands/workflows/resume/main.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/resume/main.py
@@ -14,6 +14,7 @@ from mcp_agent.mcp.gen_client import gen_client
 from ...utils import (
     setup_authenticated_client,
     handle_server_api_errors,
+    resolve_server,
 )
 
 
@@ -28,7 +29,7 @@ async def _signal_workflow_async(
         server_url = server_id_or_url
     else:
         client = setup_authenticated_client()
-        server = run_async(client.get_app_or_config(server_id_or_url))
+        server = resolve_server(client, server_id_or_url)
 
         if hasattr(server, "appServerInfo") and server.appServerInfo:
             server_url = server.appServerInfo.serverUrl

--- a/src/mcp_agent/cli/cloud/commands/workflows/runs/main.py
+++ b/src/mcp_agent/cli/cloud/commands/workflows/runs/main.py
@@ -14,6 +14,7 @@ from mcp_agent.mcp.gen_client import gen_client
 from ...utils import (
     setup_authenticated_client,
     validate_output_format,
+    resolve_server,
 )
 from mcp_agent.cli.utils.ux import console, print_info
 
@@ -26,7 +27,7 @@ async def _list_workflow_runs_async(
         server_url = server_id_or_url
     else:
         client = setup_authenticated_client()
-        server = run_async(client.get_app_or_config(server_id_or_url))
+        server = resolve_server(client, server_id_or_url)
 
         if hasattr(server, "appServerInfo") and server.appServerInfo:
             server_url = server.appServerInfo.serverUrl


### PR DESCRIPTION
### TL;DR

Refactored server resolution logic into a centralized utility function to improve error handling and code maintainability.

### What changed?

- Created a new `resolve_server()` utility function in `commands/utils.py` that encapsulates the logic for resolving a server from an ID or URL
- Replaced direct calls to `run_async(client.get_app_or_config())` with the new `resolve_server()` function across multiple command modules:
  - App commands (delete, status, workflows)
  - Logger tail command
  - Server commands (delete, describe)
  - Workflow commands (cancel, describe, list, resume, runs)
- Added proper error handling in the utility function to provide clearer error messages when server resolution fails

### How to test?

Test various CLI commands that interact with servers using different identifiers:
1. Use app IDs: `mcp app status <app-id>`
2. Use server URLs: `mcp workflows list <server-url>`
3. Use invalid identifiers to verify error handling: `mcp app delete invalid-id`

### Why make this change?

This refactoring:
- Centralizes server resolution logic to avoid code duplication
- Improves error handling with more descriptive error messages
- Makes the codebase more maintainable by isolating the server resolution logic
- Creates a consistent pattern for resolving servers across different command modules