### PR TITLE
Update OrchestratorWorkflow tool docstring

### DIFF
--- a/examples/temporal/orchestrator.py
+++ b/examples/temporal/orchestrator.py
@@ -25,13 +25,12 @@ and will have a workflow created behind the scenes.
 
 
 @app.async_tool(name="OrchestratorWorkflow")
-async def run_orchestrator(input: str, app_ctx: Optional[AppContext]) -> str:
+async def run_orchestrator(input: str, app_ctx: Optional[AppContext] = None) -> str:
     """
     Run the workflow, processing the input data.
 
     Args:
         input: Task description or instruction text.
-        app_ctx: Optional application context for the workflow.
 
     Returns:
         A WorkflowResult containing the processed data


### PR DESCRIPTION
## Description
Remove reference to internal app_ctx argument

<img width="578" height="479" alt="Screenshot 2025-09-11 at 6 30 54 PM" src="https://github.com/user-attachments/assets/57796d07-c7d8-47a3-9211-4b590c6051a2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * You can now run the orchestrator without explicitly passing an app context; it automatically uses the app’s context when omitted, preserving existing behavior.

* **Documentation**
  * Updated parameter description and usage guidance to reflect the optional app context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->