### PR TITLE
Fix CLI logging issues

### DIFF
--- a/src/mcp_agent/cli/cloud/commands/logger/tail/main.py
+++ b/src/mcp_agent/cli/cloud/commands/logger/tail/main.py
@@ -313,6 +313,7 @@ async def _stream_logs(
                 async for chunk in response.aiter_text():
                     buffer += chunk
                     lines = buffer.split("\n")
+                    buffer = lines[-1]
 
                     for line in lines[:-1]:
                         if line.startswith("data:"):


### PR DESCRIPTION
### TL;DR

Fixed a bug in the log tail command where the buffer wasn't being properly updated.

### What changed?

Added a line to update the buffer with the last incomplete line after processing complete lines. This ensures that partial log entries are properly handled and concatenated with subsequent chunks.

### How to test?

1. Run the logger tail command to stream logs
2. Verify that log entries that span multiple chunks are properly displayed
3. Check that no duplicate lines appear in the output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming log tail now correctly preserves partial lines between chunks, preventing truncated or merged lines and delivering accurate, orderly live output.
  * Improves reliability for long-running tails and high-throughput streams, aligning displayed logs more closely with their source.
  * No changes to commands or flags; behavior and performance remain otherwise unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->