### PR TITLE
Fix upstream session binding in app server

### DIFF
--- a/examples/mcp_agent_server/asyncio/client.py
+++ b/examples/mcp_agent_server/asyncio/client.py
@@ -41,7 +41,7 @@ async def main():
         logger.info("Connecting to workflow server...")
 
         # Override the server configuration to point to our local script
-        run_server_args = ["run", "basic_agent_server.py"]
+        run_server_args = ["run", "main.py"]
         if use_custom_fastmcp_settings:
             logger.info("Using custom FastMCP settings for the server.")
             run_server_args += ["--custom-fastmcp-settings"]


### PR DESCRIPTION
After many fixes, we see in prod logs that /internal/session/by-run/{run_id}/notify requests are finally 200 OK all the way through (gateway → app: 200 “uvicorn”, content-length 11), but the client still shows no logs/notifications.
  - No more 401s or 503 “session_not_available”; authentication works and the app route accepts the request.

Hypothesis from logs: the app is writing to a stale upstream ServerSession (from an earlier client connection). Locally this doesn’t reproduce due to single-process/stable connection.

Changes

  - Rebind mapping on client calls:
      - On workflows-get_status, workflows-resume, workflows-cancel, re-register the current ctx.session to the workflow’s run_id/execution_id. Keeps the mapping fresh after reconnects.
  - Best-effort fallback on internal routes:
      - If a notify/request/log arrives without a mapped session, use app.context.upstream_session as a fallback and register it for this execution_id. Also tries fallback if primary send raises.
  - Additional logging temporarily so we can diagnose what's going on

  - If a worker notify arrives before any rebinding, the fallback uses the latest upstream session captured by the app and registers it.
  - Detailed logs make it clear which session_id handled a message, when the map was missing, and when messages were dropped.