### PR TITLE
Refactor CLI: dev umbrella, default main.py, smart server defaults, clearer init

### DIFF
--- a/src/mcp_agent/cli/__main__.py
+++ b/src/mcp_agent/cli/__main__.py
@@ -25,35 +25,35 @@ GO_OPTIONS = {
 }
 
 KNOWN = {
-    "go",
-    "check",
-    "chat",
-    "dev",
-    "invoke",
-    "serve",
+    # Curated top-level commands
     "init",
     "quickstart",
     "config",
-    "keys",
-    "models",
-    "server",
-    "build",
-    "logs",
     "doctor",
-    "configure",
+    "deploy",
+    "login",
+    "whoami",
+    "logout",
     "cloud",
+    # Umbrella group
+    "dev",
 }
 
 
 def main():
     if len(sys.argv) > 1:
         first = sys.argv[1]
-        if first not in KNOWN:
+        # Back-compat: allow `mcp-agent go ...`
+        if first == "go":
+            sys.argv.insert(1, "dev")
+        elif first not in KNOWN:
             for i, arg in enumerate(sys.argv[1:], 1):
                 if arg in GO_OPTIONS or any(
                     arg.startswith(opt + "=") for opt in GO_OPTIONS
                 ):
-                    sys.argv.insert(i, "go")
+                    # Route bare chat-like invocations to dev go (legacy behavior)
+                    sys.argv.insert(i, "dev")
+                    sys.argv.insert(i + 1, "go")
                     break
     app()
 

--- a/src/mcp_agent/cli/commands/chat.py
+++ b/src/mcp_agent/cli/commands/chat.py
@@ -22,6 +22,7 @@ from mcp_agent.cli.core.utils import (
 from mcp_agent.cli.utils.url_parser import generate_server_configs, parse_server_urls
 from mcp_agent.workflows.factory import create_llm
 from mcp_agent.agents.agent import Agent
+from mcp_agent.config import get_settings
 
 
 app = typer.Typer(help="Ephemeral REPL for quick iteration")
@@ -155,7 +156,11 @@ def chat(
         try:
 
             async def _list():
-                app_obj = load_user_app(script)
+                # Disable progress display for cleaner listing output
+                settings = get_settings()
+                if settings.logger:
+                    settings.logger.progress_display = False
+                app_obj = load_user_app(script, settings_override=settings)
                 await app_obj.initialize()
                 attach_url_servers(app_obj, url_servers)
                 attach_stdio_servers(app_obj, stdio_servers)
@@ -213,7 +218,11 @@ def chat(
         ):
 
             async def _parallel_repl():
-                app_obj = load_user_app(script)
+                # Disable progress display for cleaner multi-model REPL
+                settings = get_settings()
+                if settings.logger:
+                    settings.logger.progress_display = False
+                app_obj = load_user_app(script, settings_override=settings)
                 await app_obj.initialize()
                 attach_url_servers(app_obj, url_servers)
                 attach_stdio_servers(app_obj, stdio_servers)
@@ -406,9 +415,12 @@ def chat(
             and not models
             and not (list_servers or list_tools or list_resources)
         ):
-            # Interactive loop
+            # Interactive loop - disable progress display for cleaner REPL experience
             async def _repl():
-                app_obj = load_user_app(script)
+                settings = get_settings()
+                if settings.logger:
+                    settings.logger.progress_display = False
+                app_obj = load_user_app(script, settings_override=settings)
                 await app_obj.initialize()
                 attach_url_servers(app_obj, url_servers)
                 attach_stdio_servers(app_obj, stdio_servers)

--- a/src/mcp_agent/cli/commands/chat.py
+++ b/src/mcp_agent/cli/commands/chat.py
@@ -588,7 +588,7 @@ def chat(
                                 prompt_msgs = await ag.create_prompt(
                                     prompt_name=prompt_name,
                                     arguments=arguments,
-                                    server_names=server_list or [],
+                                    server_names=resolved_server_list or [],
                                 )
                                 # Generate with prompt messages
                                 out = await llm.generate_str(prompt_msgs)

--- a/src/mcp_agent/cli/commands/dev.py
+++ b/src/mcp_agent/cli/commands/dev.py
@@ -15,6 +15,7 @@ import typer
 from rich.console import Console
 
 from mcp_agent.config import get_settings
+from mcp_agent.cli.core.utils import detect_default_script
 
 
 app = typer.Typer(help="Run app locally with diagnostics")
@@ -22,7 +23,7 @@ console = Console()
 
 
 @app.callback(invoke_without_command=True)
-def dev(script: Path = typer.Option(Path("agent.py"), "--script")) -> None:
+def dev(script: Path = typer.Option(None, "--script")) -> None:
     """Run the user's app script with optional live reload and preflight checks."""
 
     def _preflight_ok() -> bool:
@@ -48,6 +49,9 @@ def dev(script: Path = typer.Option(Path("agent.py"), "--script")) -> None:
             stderr=None,  # Inherit stderr
             stdin=None,  # Inherit stdin
         )
+
+    # Resolve script path with auto-detection (main.py preferred)
+    script = detect_default_script(script)
 
     # Simple preflight
     _ = _preflight_ok()

--- a/src/mcp_agent/cli/commands/doctor.py
+++ b/src/mcp_agent/cli/commands/doctor.py
@@ -412,7 +412,7 @@ def doctor() -> None:
             "• Add API key: [cyan]mcp-agent keys set <provider> <key>[/cyan]\n"
             "• Add server: [cyan]mcp-agent server add recipe filesystem[/cyan]\n"
             "• Start chat: [cyan]mcp-agent chat --model anthropic.haiku[/cyan]\n"
-            "• Run agent: [cyan]mcp-agent dev --script agent.py[/cyan]",
+            "• Run agent: [cyan]mcp-agent dev start --script main.py[/cyan]",
             title="Getting Started",
             border_style="dim",
         )

--- a/src/mcp_agent/cli/commands/init.py
+++ b/src/mcp_agent/cli/commands/init.py
@@ -221,7 +221,7 @@ def init(
         elif template == "server":
             console.print("3. Run the server: [cyan]uv run server.py[/cyan]")
             console.print(
-                "   Or serve: [cyan]mcp-agent serve --script server.py[/cyan]"
+                "   Or serve: [cyan]mcp-agent dev serve --script server.py[/cyan]"
             )
         elif template == "token":
             console.print("3. Run the example: [cyan]uv run token_example.py[/cyan]")

--- a/src/mcp_agent/cli/commands/init.py
+++ b/src/mcp_agent/cli/commands/init.py
@@ -100,6 +100,7 @@ def init(
     console.print(f"Template: [cyan]{template}[/cyan] - {templates[template]}\n")
 
     files_created = []
+    entry_script_name: str | None = None
 
     # Always create config files
     config_path = dir / "mcp_agent.config.yaml"
@@ -122,15 +123,35 @@ def init(
 
     # Create template-specific files
     if template == "basic":
-        agent_path = dir / "agent.py"
+        # Determine entry script name and handle existing files
+        script_name = "main.py"
+        script_path = dir / script_name
         agent_content = _load_template("basic_agent.py")
-        if agent_content and _write(agent_path, agent_content, force):
-            files_created.append("agent.py")
-            # Make executable
-            try:
-                agent_path.chmod(agent_path.stat().st_mode | 0o111)
-            except Exception:
-                pass
+
+        if agent_content:
+            write_force_flag = force
+            if script_path.exists() and not force:
+                if Confirm.ask(f"{script_path} exists. Overwrite?", default=False):
+                    write_force_flag = True
+                else:
+                    # Ask for an alternate filename and ensure it ends with .py
+                    alt_name = Prompt.ask(
+                        "Enter a filename to save the agent", default="agent.py"
+                    )
+                    if not alt_name.endswith(".py"):
+                        alt_name += ".py"
+                    script_name = alt_name
+                    script_path = dir / script_name
+                    # keep write_force_flag as-is to allow overwrite prompt if needed
+
+            if _write(script_path, agent_content, write_force_flag):
+                files_created.append(script_name)
+                entry_script_name = script_name
+                # Make executable
+                try:
+                    script_path.chmod(script_path.stat().st_mode | 0o111)
+                except Exception:
+                    pass
 
     elif template == "server":
         server_path = dir / "server.py"
@@ -185,20 +206,29 @@ def init(
         console.print("2. Review and customize [cyan]mcp_agent.config.yaml[/cyan]")
 
         if template == "basic":
-            console.print("3. Run your agent: [cyan]python agent.py[/cyan]")
-            console.print("   Or use: [cyan]mcp-agent dev --script agent.py[/cyan]")
-            console.print("   Or chat: [cyan]mcp-agent chat[/cyan]")
+            run_file = entry_script_name or "main.py"
+            console.print(f"3. Run your agent: [cyan]uv run {run_file}[/cyan]")
+            console.print(
+                f"   Or use: [cyan]mcp-agent dev start --script {run_file}[/cyan]"
+            )
+            console.print(
+                f"   Or serve: [cyan]mcp-agent dev serve --script {run_file}[/cyan]"
+            )
+            console.print("   Or chat: [cyan]mcp-agent dev chat[/cyan]")
+            console.print(
+                "4. Edit config: [cyan]mcp-agent config edit[/cyan] (then rerun)"
+            )
         elif template == "server":
-            console.print("3. Run the server: [cyan]python server.py[/cyan]")
+            console.print("3. Run the server: [cyan]uv run server.py[/cyan]")
             console.print(
                 "   Or serve: [cyan]mcp-agent serve --script server.py[/cyan]"
             )
         elif template == "token":
-            console.print("3. Run the example: [cyan]python token_example.py[/cyan]")
+            console.print("3. Run the example: [cyan]uv run token_example.py[/cyan]")
             console.print("   Watch token usage in real-time!")
         elif template == "factory":
             console.print("3. Customize agents in [cyan]agents.yaml[/cyan]")
-            console.print("4. Run the factory: [cyan]python factory.py[/cyan]")
+            console.print("4. Run the factory: [cyan]uv run factory.py[/cyan]")
         elif template == "minimal":
             console.print("3. Create your agent script")
             console.print("   See examples: [cyan]mcp-agent quickstart[/cyan]")

--- a/src/mcp_agent/cli/commands/keys.py
+++ b/src/mcp_agent/cli/commands/keys.py
@@ -44,7 +44,7 @@ PROVIDERS = {
             "claude-3-opus-20240229",
             "claude-3-haiku-20240307",
         ],
-        "test_endpoint": "https://api.anthropic.com/v1/messages",
+        "test_endpoint": "https://api.anthropic.com/v1/models",
         "docs": "https://console.anthropic.com/settings/keys",
     },
     "google": {

--- a/src/mcp_agent/cli/commands/serve.py
+++ b/src/mcp_agent/cli/commands/serve.py
@@ -118,9 +118,9 @@ def serve(
     Start an MCP server for your app.
 
     Examples:
-        mcp-agent serve --script agent.py
-        mcp-agent serve --transport http --port 8000
-        mcp-agent serve --reload --debug
+        mcp-agent dev serve --script agent.py
+        mcp-agent dev serve --transport http --port 8000
+        mcp-agent dev serve --reload --debug
     """
 
     if ctx.invoked_subcommand:
@@ -468,7 +468,7 @@ def test(
             )
 
             console.print("\n[dim]Server is ready to run with:[/dim]")
-            console.print(f"  [cyan]mcp-agent serve --script {script_path}[/cyan]")
+            console.print(f"  [cyan]mcp-agent dev serve --script {script_path}[/cyan]")
 
         except Exception:
             console.print("\n[red bold]❌ Server test failed[/red bold]")
@@ -531,9 +531,11 @@ def generate(
     console.print("\n[bold]Next steps:[/bold]")
     console.print(f"1. Edit the server: [cyan]{output}[/cyan]")
     console.print(
-        f"2. Test the server: [cyan]mcp-agent serve test --script {output}[/cyan]"
+        f"2. Test the server: [cyan]mcp-agent dev serve test --script {output}[/cyan]"
     )
-    console.print(f"3. Run the server: [cyan]mcp-agent serve --script {output}[/cyan]")
     console.print(
-        f"4. Or serve via HTTP: [cyan]mcp-agent serve --script {output} --transport http --port 8000[/cyan]"
+        f"3. Run the server: [cyan]mcp-agent dev serve --script {output}[/cyan]"
+    )
+    console.print(
+        f"4. Or serve via HTTP: [cyan]mcp-agent dev serve --script {output} --transport http --port 8000[/cyan]"
     )

--- a/src/mcp_agent/cli/commands/serve.py
+++ b/src/mcp_agent/cli/commands/serve.py
@@ -19,7 +19,7 @@ from rich.live import Live
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from mcp_agent.server.app_server import create_mcp_server_for_app
-from mcp_agent.cli.core.utils import load_user_app
+from mcp_agent.cli.core.utils import load_user_app, detect_default_script
 from mcp_agent.config import get_settings
 
 
@@ -138,12 +138,14 @@ def serve(
     # Load configuration path is handled after loading app by overriding app settings
 
     async def _run():
-        # Load the app
-        script_path = Path(script) if script else Path("agent.py")
+        # Load the app (auto-detect main.py preferred)
+        script_path = detect_default_script(Path(script) if script else None)
 
         if not script_path.exists():
             console.print(f"[red]Script not found: {script_path}[/red]")
-            console.print("\n[dim]Create an agent.py file or specify --script[/dim]")
+            console.print(
+                "\n[dim]Create a main.py (preferred) or agent.py file, or specify --script[/dim]"
+            )
             raise typer.Exit(1)
 
         console.print("\n[bold cyan]🚀 MCP-Agent Server[/bold cyan]")
@@ -379,10 +381,13 @@ def test(
     timeout: float = typer.Option(5.0, "--timeout", "-t", help="Test timeout"),
 ) -> None:
     """Test if the server can be loaded and initialized."""
-    script_path = Path(script) if script else Path("agent.py")
+    script_path = detect_default_script(Path(script) if script else None)
 
     if not script_path.exists():
         console.print(f"[red]Script not found: {script_path}[/red]")
+        console.print(
+            "\n[dim]Create a main.py (preferred) or agent.py file, or specify --script[/dim]"
+        )
         raise typer.Exit(1)
 
     console.print(f"\n[bold]Testing server: {script_path}[/bold]\n")

--- a/src/mcp_agent/cli/main.py
+++ b/src/mcp_agent/cli/main.py
@@ -69,7 +69,7 @@ app = typer.Typer(
 # Local development umbrella group
 dev_group = typer.Typer(
     help="Local development: start app, chat, invoke, serve, servers, build, logs",
-    no_args_is_help=True,
+    no_args_is_help=False,
     cls=HelpfulTyperGroup,
 )
 

--- a/src/mcp_agent/cli/main.py
+++ b/src/mcp_agent/cli/main.py
@@ -10,6 +10,7 @@ progressively.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import typer
 from rich.console import Console
@@ -24,7 +25,7 @@ except Exception:  # pragma: no cover - cloud is optional for non-cloud developm
 
 
 # Local command groups (scaffolded)
-from mcp_agent.cli.cloud.commands import deploy_config, login, logout, whoami
+from mcp_agent.cli.cloud.commands import deploy_config, login
 from mcp_agent.cli.commands import (
     check as check_cmd,
     chat as chat_cmd,
@@ -64,6 +65,25 @@ app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
     cls=HelpfulTyperGroup,
 )
+
+# Local development umbrella group
+dev_group = typer.Typer(
+    help="Local development: start app, chat, invoke, serve, servers, build, logs",
+    no_args_is_help=True,
+    cls=HelpfulTyperGroup,
+)
+
+
+@dev_group.callback(invoke_without_command=True)
+def _dev_group_entry(
+    ctx: typer.Context,
+    script: Path = typer.Option(None, "--script", help="Entry script"),
+):
+    """If no subcommand is provided, behave like 'dev start'."""
+    if ctx.invoked_subcommand:
+        return
+    # Delegate to the existing dev implementation
+    dev_cmd.dev(script=script)
 
 
 console = Console(stderr=False)
@@ -123,43 +143,47 @@ def main(
         console.print("Run 'mcp-agent --help' to see all commands.")
 
 
-# Mount non-cloud command groups
+# Mount non-cloud command groups (top-level, curated)
 app.add_typer(init_cmd.app, name="init", help="Scaffold a new mcp-agent project")
 app.add_typer(quickstart_cmd.app, name="quickstart", help="Copy curated examples")
-app.add_typer(go_cmd.app, name="go", help="Quick interactive agent")
-app.add_typer(check_cmd.app, name="check", help="Check configuration and environment")
 app.add_typer(config_cmd.app, name="config", help="Manage and inspect configuration")
-app.add_typer(keys_cmd.app, name="keys", help="Manage provider API keys")
-app.add_typer(models_cmd.app, name="models", help="List and manage models")
+app.add_typer(doctor_cmd.app, name="doctor", help="Comprehensive diagnostics")
 
-app.add_typer(chat_cmd.app, name="chat", help="Ephemeral REPL for quick iteration")
-app.add_typer(dev_cmd.app, name="dev", help="Run app locally with live reload")
-app.add_typer(
+# Group local dev/runtime commands under `dev`
+dev_group.add_typer(dev_cmd.app, name="start", help="Run app locally with live reload")
+dev_group.add_typer(
+    chat_cmd.app, name="chat", help="Ephemeral REPL for quick iteration"
+)
+dev_group.add_typer(
     invoke_cmd.app, name="invoke", help="Invoke agent/workflow programmatically"
 )
-app.add_typer(serve_cmd.app, name="serve", help="Serve app as an MCP server")
-app.add_typer(server_cmd.app, name="server", help="Local server helpers")
-app.add_typer(
+dev_group.add_typer(serve_cmd.app, name="serve", help="Serve app as an MCP server")
+dev_group.add_typer(server_cmd.app, name="server", help="Local server helpers")
+dev_group.add_typer(
     build_cmd.app, name="build", help="Preflight and bundle prep for deployment"
 )
-app.add_typer(logs_cmd.app, name="logs", help="Tail local logs")
-app.add_typer(doctor_cmd.app, name="doctor", help="Comprehensive diagnostics")
-app.add_typer(configure_cmd.app, name="configure", help="Client integration helpers")
+dev_group.add_typer(logs_cmd.app, name="logs", help="Tail local logs")
+dev_group.add_typer(
+    check_cmd.app, name="check", help="Check configuration and environment"
+)
+dev_group.add_typer(go_cmd.app, name="go", help="Quick interactive agent")
+dev_group.add_typer(keys_cmd.app, name="keys", help="Manage provider API keys")
+dev_group.add_typer(models_cmd.app, name="models", help="List and manage models")
+dev_group.add_typer(configure_cmd.app, name="client", help="Client integration helpers")
+
+# Mount the dev umbrella group
+app.add_typer(dev_group, name="dev", help="Local development and runtime")
 
 # Mount cloud commands
 app.add_typer(cloud_app, name="cloud", help="MCP Agent Cloud commands")
 
-# Register some key cloud commands directly as top-level commands
+# Register key cloud commands directly as top-level aliases
 app.command("deploy", help="Deploy an MCP agent (alias for 'cloud deploy')")(
     deploy_config
 )
 app.command(
     "login", help="Authenticate to MCP Agent Cloud API (alias for 'cloud login')"
 )(login)
-app.command(
-    "whoami", help="Print current identity and org(s) (alias for 'cloud whoami')"
-)(whoami)
-app.command("logout", help="Clear credentials (alias for 'cloud logout')")(logout)
 
 
 def run() -> None:


### PR DESCRIPTION
- Consolidates runtime commands under `dev`
- Smarter defaults for servers based on `mcp_agent.config.yaml`
- Keeps cloud commands curated at top-level

### Motivation
- Reduce cognitive load at top-level -- there are a lot of commands in the CLI
- Make first-run smoother: scripts and servers are auto-detected wherever possible.
- Align init output and docs with the expected layout.

### What changed

- CLI layout (`src/mcp_agent/cli/main.py`, `src/mcp_agent/cli/__main__.py`)
  - Curated top-level: `init`, `config`, `quickstart`, `doctor`, `cloud`, plus aliases `deploy`, `login`
  - New umbrella: `mcp-agent dev`
    - `dev start` (replaces old `dev`)
    - `dev chat`, `dev invoke`, `dev serve`, `dev go`, `dev server`, `dev build`, `dev logs`, `dev check`, `dev keys`, `dev models`, `dev client`
  - Calling `mcp-agent dev` with no subcommand behaves like `dev start`
  - Convenience routing: bare chat-like invocations and `mcp-agent go …` route to `dev go …`

- Smart server defaults
  - New helper resolves active servers:
    - If `--servers` provided ⇒ use it
    - Else, include dynamically attached URL/stdio servers
    - Else, use all servers from `mcp_agent.config.yaml`
  - Applied in `chat`, `go`, `invoke` so flags are optional for common cases

- Init UX (`src/mcp_agent/cli/commands/init.py`)
  - Basic template writes to `main.py` (asks to overwrite or choose another name)
  - “Next steps” now print exact commands with the chosen script:
    - `uv run <file>`
    - `mcp-agent dev start --script <file>`
    - `mcp-agent dev serve --script <file>`
    - `mcp-agent config edit`

- Client helpers
  - Mounted as `mcp-agent dev client …` (same functionality as `configure` module, clearer noun)

- Small docs/help alignments
  - `doctor` example updated to `mcp-agent dev start --script main.py`
  - Serve/test messages reference `main.py` first

### New helpers
- `detect_default_script(explicit)` in `src/mcp_agent/cli/core/utils.py`
- `select_servers_from_config(servers_csv, url_servers, stdio_servers)` in the same module

### Breaking/behavior notes
- Runtime commands moved under `dev`; use `dev start`, `dev serve`, etc.
- `go` remains available via `dev go`; top-level `go` is routed for convenience.
- Script defaults changed to prefer `main.py`; existing `agent.py` projects continue to work.

### How to test

- Scaffold and run
  ```bash
  mcp-agent init
  mcp-agent dev start              # auto-detects main.py
  mcp-agent dev serve --transport http --port 8080
  ```

- Smart server defaults
  ```bash
  # With configured servers in mcp_agent.config.yaml
  mcp-agent dev chat -m "hello"    # should auto-enable configured servers
  mcp-agent dev go --uvx "mcp-server-fetch" -m "fetch https://example.com"
  ```

- Invoke agent/workflow
  ```bash
  mcp-agent dev invoke --agent demo -m "Hi"
  mcp-agent dev invoke --workflow orchestrator --vars '{"task":"grade"}'
  ```

- Serve test
  ```bash
  mcp-agent dev serve test         # prefers main.py, clear hint if missing
  ```

### Files touched (high level)
- `src/mcp_agent/cli/main.py` (layout, groups, aliases)
- `src/mcp_agent/cli/__main__.py` (routing convenience)
- `src/mcp_agent/cli/core/utils.py` (new helpers)
- `src/mcp_agent/cli/commands/dev.py` (auto-detect script)
- `src/mcp_agent/cli/commands/serve.py` (auto-detect script; improved messages; test)
- `src/mcp_agent/cli/commands/chat.py`, `go.py`, `invoke.py` (auto-detect script; smart server defaults)
- `src/mcp_agent/cli/commands/init.py` (write to `main.py`; improved next steps)
- `src/mcp_agent/cli/commands/doctor.py` (example alignment)

### Follow-ups (optional)
- Add top-level `client` alias (in addition to `dev client`) if you want higher discoverability
- Standardize `-s` short flag for `--script` across chat/go/invoke for parity with serve
- Update full CLI docs to reflect the new `dev` umbrella and examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unified "dev" umbrella command grouping local run, chat, invoke, serve, and tools.
  - Added "doctor" diagnostics command.
  - Automatic entry-script detection (prefers main.py); --script optional.
  - Smart server selection from config/flags and backward-compatible routing for legacy "go" invocations.

- **Refactor**
  - Curated top-level commands; many moved under "dev"; top-level aliases added for deploy and login.

- **Bug Fixes**
  - Updated Anthropic key-test endpoint used when validating keys.

- **Documentation**
  - Init/quick-start updated to dynamic entry script and uv run examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->