### PR TITLE
ensure auto workflows are initialised

### DIFF
--- a/src/mcp_agent/app.py
+++ b/src/mcp_agent/app.py
@@ -649,6 +649,8 @@ class MCPApp:
             return res
 
         async def _run(self, *args, **kwargs):  # type: ignore[no-redef]
+            # ensure initialization
+            await self.initialize()
             return await _invoke_target(self, *args, **kwargs)
 
         # Decorate run with engine-specific decorator


### PR DESCRIPTION
Autoworkflows are wrapped directly in a temporal `workflow_run` decorator, which means they don't call `initialize`, which is (among other things) sets up the context properly. Without calling this function, the `upstream_session` ends up being unset, which breaks e.g. log forwarding and elicitation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured workflows initialize before execution, improving startup reliability and preventing intermittent runtime errors during task invocation.
  * Initialization is idempotent, avoiding duplicate setup and ensuring safe repeated runs.
  * Enhances consistency and predictability when invoking workflows across sessions.
  * No changes to the public API; existing integrations and usage remain unchanged, with no action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->