### PR TITLE
Update deployment URLs from lastmileai.dev to mcp-agent.com domain

### DIFF
--- a/docs/cloud/agent-server.mdx
+++ b/docs/cloud/agent-server.mdx
@@ -182,7 +182,7 @@ For **mcp-agent cloud**, add to `claude_desktop_config.json`:
   "command": "/path/to/npx",
   "args": [
     "mcp-remote",
-    "https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse",
+    "https://[your-agent-server-id].deployments.mcp-agent.com/sse",
     "--header",
     "Authorization: Bearer ${BEARER_TOKEN}"
   ],

--- a/docs/cloud/overview.mdx
+++ b/docs/cloud/overview.mdx
@@ -71,7 +71,7 @@ Configure Claude Desktop to access your agent server
   "command": "/path/to/npx",
   "args": [
     "mcp-remote",
-    "https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse",
+    "https://[your-agent-server-id].deployments.mcp-agent.com/sse",
     "--header",
     "Authorization: Bearer ${BEARER_TOKEN}"
   ],
@@ -92,7 +92,7 @@ Connect with the following settings
 | Setting | Value | 
 |---|---|
 | *Transport Type* | *SSE* |
-| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse* |
+| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent.com/sse* |
 | *Header Name* | *Authorization* | 
 | *Bearer Token* | *your-mcp-agent-cloud-api-token* |
 

--- a/examples/basic/mcp_basic_agent/README.md
+++ b/examples/basic/mcp_basic_agent/README.md
@@ -122,7 +122,7 @@ Configure Claude Desktop to access your agent servers by updating your `~/.claud
   "command": "/path/to/npx",
   "args": [
     "mcp-remote",
-    "https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse",
+    "https://[your-agent-server-id].deployments.mcp-agent.com/sse",
     "--header",
     "Authorization: Bearer ${BEARER_TOKEN}"
   ],
@@ -145,7 +145,7 @@ Make sure to fill out the following settings:
 | Setting | Value | 
 |---|---|
 | *Transport Type* | *SSE* |
-| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse* |
+| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent.com/sse* |
 | *Header Name* | *Authorization* | 
 | *Bearer Token* | *your-mcp-agent-cloud-api-token* |
 

--- a/examples/basic/mcp_model_selector/README.md
+++ b/examples/basic/mcp_model_selector/README.md
@@ -98,7 +98,7 @@ Configure Claude Desktop to access your agent servers by updating your `~/.claud
   "command": "/path/to/npx",
   "args": [
     "mcp-remote",
-    "https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse",
+    "https://[your-agent-server-id].deployments.mcp-agent.com/sse",
     "--header",
     "Authorization: Bearer ${BEARER_TOKEN}"
   ],
@@ -121,7 +121,7 @@ Make sure to fill out the following settings:
 | Setting | Value | 
 |---|---|
 | *Transport Type* | *SSE* |
-| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse* |
+| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent.com/sse* |
 | *Header Name* | *Authorization* | 
 | *Bearer Token* | *your-mcp-agent-cloud-api-token* |
 

--- a/examples/basic/mcp_server_aggregator/README.md
+++ b/examples/basic/mcp_server_aggregator/README.md
@@ -82,7 +82,7 @@ Configure Claude Desktop to access your agent servers by updating your `~/.claud
   "command": "/path/to/npx",
   "args": [
     "mcp-remote",
-    "https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse",
+    "https://[your-agent-server-id].deployments.mcp-agent.com/sse",
     "--header",
     "Authorization: Bearer ${BEARER_TOKEN}"
   ],
@@ -105,7 +105,7 @@ Make sure to fill out the following settings:
 | Setting | Value | 
 |---|---|
 | *Transport Type* | *SSE* |
-| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse* |
+| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent.com/sse* |
 | *Header Name* | *Authorization* | 
 | *Bearer Token* | *your-mcp-agent-cloud-api-token* |
 

--- a/examples/mcp_agent_server/asyncio/README.md
+++ b/examples/mcp_agent_server/asyncio/README.md
@@ -222,7 +222,7 @@ INFO: Transformed secrets file written to /Users/andrew_lm/Documents/GitHub/mcp-
 WARNING: Found a __main__ entrypoint in main.py. This will be ignored in the deployment.
 ▰▰▰▰▰▰▱ ✅ Bundled successfully
 ▹▹▹▹▹ Deploying MCP App bundle...INFO: App ID: app_ddde033d-21as-fe3s-b82c-aaae4243c52f
-INFO: App URL: https://770xdsp22y321prwv9rasdfasd9l5zj5.deployments.mcp-agent-cloud.lastmileai.dev
+INFO: App URL: https://770xdsp22y321prwv9rasdfasd9l5zj5.deployments.mcp-agent.com
 INFO: App Status: OFFLINE
 ▹▹▹▹▹ ✅ MCP App deployed successfully!
 ```

--- a/examples/usecases/mcp_github_to_slack_agent/README.md
+++ b/examples/usecases/mcp_github_to_slack_agent/README.md
@@ -111,7 +111,7 @@ Configure Claude Desktop to access your agent servers by updating your `~/.claud
   "command": "/path/to/npx",
   "args": [
     "mcp-remote",
-    "https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse",
+    "https://[your-agent-server-id].deployments.mcp-agent.com/sse",
     "--header",
     "Authorization: Bearer ${BEARER_TOKEN}"
   ],
@@ -134,7 +134,7 @@ Make sure to fill out the following settings:
 | Setting | Value | 
 |---|---|
 | *Transport Type* | *SSE* |
-| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse* |
+| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent.com/sse* |
 | *Header Name* | *Authorization* | 
 | *Bearer Token* | *your-mcp-agent-cloud-api-token* |
 

--- a/examples/workflows/workflow_evaluator_optimizer/README.md
+++ b/examples/workflows/workflow_evaluator_optimizer/README.md
@@ -132,7 +132,7 @@ Configure Claude Desktop to access your agent by updating `~/.claude-desktop/con
     "command": "/path/to/npx",
     "args": [
       "mcp-remote",
-      "https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse",
+      "https://[your-agent-server-id].deployments.mcp-agent.com/sse",
       "--header",
       "Authorization: Bearer ${BEARER_TOKEN}"
     ],
@@ -156,7 +156,7 @@ Configure the following settings in MCP Inspector:
 | Setting | Value |
 |---|---|
 | **Transport Type** | SSE |
-| **SSE URL** | `https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse` |
+| **SSE URL** | `https://[your-agent-server-id].deployments.mcp-agent.com/sse` |
 | **Header Name** | Authorization |
 | **Bearer Token** | your-mcp-agent-cloud-api-token |
 

--- a/examples/workflows/workflow_intent_classifier/README.md
+++ b/examples/workflows/workflow_intent_classifier/README.md
@@ -84,7 +84,7 @@ Configure Claude Desktop to access your agent servers by updating your `~/.claud
   "command": "/path/to/npx",
   "args": [
     "mcp-remote",
-    "https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse",
+    "https://[your-agent-server-id].deployments.mcp-agent.com/sse",
     "--header",
     "Authorization: Bearer ${BEARER_TOKEN}"
   ],
@@ -107,7 +107,7 @@ Make sure to fill out the following settings:
 | Setting | Value | 
 |---|---|
 | *Transport Type* | *SSE* |
-| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse* |
+| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent.com/sse* |
 | *Header Name* | *Authorization* | 
 | *Bearer Token* | *your-mcp-agent-cloud-api-token* |
 

--- a/examples/workflows/workflow_orchestrator_worker/README.md
+++ b/examples/workflows/workflow_orchestrator_worker/README.md
@@ -102,7 +102,7 @@ Configure Claude Desktop to access your agent servers by updating your `~/.claud
   "command": "/path/to/npx",
   "args": [
     "mcp-remote",
-    "https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse",
+    "https://[your-agent-server-id].deployments.mcp-agent.com/sse",
     "--header",
     "Authorization: Bearer ${BEARER_TOKEN}"
   ],
@@ -125,7 +125,7 @@ Make sure to fill out the following settings:
 | Setting | Value | 
 |---|---|
 | *Transport Type* | *SSE* |
-| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse* |
+| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent.com/sse* |
 | *Header Name* | *Authorization* | 
 | *Bearer Token* | *your-mcp-agent-cloud-api-token* |
 


### PR DESCRIPTION
# Update deployment URLs to new domain

### TL;DR

Updated all deployment URLs from `deployments.mcp-agent-cloud.lastmileai.dev` to `deployments.mcp-agent.com`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example documentation to use the new mcp-agent.com domain for SSE endpoints and deployment app URLs.
  * Applied across guides for Basic MCP Agent, Model Selector, Asyncio Agent Server, GitHub-to-Slack agent, and Workflow examples (Evaluator/Optimizer, Intent Classifier, Orchestrator Worker).
  * No behavioral changes; existing configurations and headers remain the same.
  * Ensures consistency and removes outdated cloud.lastmileai.dev references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->