### PR TITLE
Update README.md  - fixed urls 

### DIFF
--- a/examples/basic/mcp_basic_agent/README.md
+++ b/examples/basic/mcp_basic_agent/README.md
@@ -122,7 +122,7 @@ Configure Claude Desktop to access your agent servers by updating your `~/.claud
   "command": "/path/to/npx",
   "args": [
     "mcp-remote",
-    "https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse",
+    "https://[your-agent-server-id].deployments.mcp-agent.com/sse",
     "--header",
     "Authorization: Bearer ${BEARER_TOKEN}"
   ],
@@ -145,7 +145,7 @@ Make sure to fill out the following settings:
 | Setting | Value | 
 |---|---|
 | *Transport Type* | *SSE* |
-| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse* |
+| *SSE* | *https://[your-agent-server-id].deployments.mcp-agent.com/sse* |
 | *Header Name* | *Authorization* | 
 | *Bearer Token* | *your-mcp-agent-cloud-api-token* |
 


### PR DESCRIPTION
Updated all deployment URLs from deployments.mcp-agent-cloud.lastmileai.dev to deployments.mcp-agent.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated SSE endpoint domain in setup instructions from deployments.mcp-agent-cloud.lastmileai.dev to deployments.mcp-agent.com.
  - Refreshed Claude Desktop integration steps to use the new mcp-remote URL format.
  - Revised MCP Inspector configuration table with the new SSE URL.
  - Clarifies connection steps and ensures consistency across docs; no functional changes to the example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->