### PR TITLE
Fix error when serving app as MCP server in stdio mode

### DIFF
--- a/src/mcp_agent/cli/commands/serve.py
+++ b/src/mcp_agent/cli/commands/serve.py
@@ -24,7 +24,7 @@ from mcp_agent.config import get_settings
 
 
 app = typer.Typer(help="Serve app as an MCP server")
-console = Console()
+console = Console(stderr=True)
 
 
 class ServerMonitor:

--- a/src/mcp_agent/data/templates/mcp_agent.config.yaml
+++ b/src/mcp_agent/data/templates/mcp_agent.config.yaml
@@ -7,7 +7,7 @@ execution_engine: asyncio
 
 # Logger configuration
 logger:
-  transports: [console]  # Options: console, file
+  transports: [file]  # Options: console, file
   level: info  # Options: debug, info, warning, error
   progress_display: true  # Show progress bars for token usage
   path_settings:


### PR DESCRIPTION
- Redirect serve output to stderr using `Console(stderr=True)` and update the `mcp-agent.config.yaml` template to default logging to a file. This fixes the `Error from MCP server: SyntaxError: Unexpected token 'xxx', " xxx" is not valid JSON` issue when running app as MCP server in stdio mode

- Fix the `--config` option so that the serve command correctly loads configuration into MCPApp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to load a configuration file at server startup, with early validation, clear error messages, and optional debug trace on failure.
- Refactor
  - Console messages now print to stderr by default, improving shell piping and log separation.
- Chores
  - Default config template switches logging to a file instead of the console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->