### PR TITLE
Update README.md - fixed urls

### DIFF
--- a/examples/workflows/workflow_evaluator_optimizer/README.md
+++ b/examples/workflows/workflow_evaluator_optimizer/README.md
@@ -132,7 +132,7 @@ Configure Claude Desktop to access your agent by updating `~/.claude-desktop/con
     "command": "/path/to/npx",
     "args": [
       "mcp-remote",
-      "https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse",
+      "https://[your-agent-server-id].deployments.mcp-agent.com/sse",
       "--header",
       "Authorization: Bearer ${BEARER_TOKEN}"
     ],
@@ -156,7 +156,7 @@ Configure the following settings in MCP Inspector:
 | Setting | Value |
 |---|---|
 | **Transport Type** | SSE |
-| **SSE URL** | `https://[your-agent-server-id].deployments.mcp-agent-cloud.lastmileai.dev/sse` |
+| **SSE URL** | `https://[your-agent-server-id].deployments.mcp-agent.com/sse` |
 | **Header Name** | Authorization |
 | **Bearer Token** | your-mcp-agent-cloud-api-token |
 


### PR DESCRIPTION
Updated deployment URLs from deployments.mcp-agent-cloud.lastmileai.dev to deployments.mcp-agent.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated SSE endpoint URLs in setup instructions to use the agent.com domain.
  - Clarified integration steps for Claude Desktop and configuration for MCP Inspector with the new endpoints.
  - Ensures users connect to the correct, current services.
  - No functional changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->