### PR TITLE
fix: example update secret tagging

### DIFF
--- a/examples/usecases/mcp_github_to_slack_agent/mcp_agent.secrets.yaml.example
+++ b/examples/usecases/mcp_github_to_slack_agent/mcp_agent.secrets.yaml.example
@@ -8,7 +8,6 @@ mcp:
     slack:
       env:
         SLACK_MCP_XOXP_TOKEN: "xoxp-oauth-token"
-#        SLACK_MCP_XOXP_TOKEN: !developer_secret SLACK_MCP_XOXP_TOKEN
 
     # GitHub configuration
     # Create a GitHub Personal Access Token with repo scope
@@ -16,8 +15,6 @@ mcp:
     github:
       headers:
         Authorization: "Bearer ghp_xxxxxxxxxxx"
-#        Authorization: !developer_secret GITHUB_PERSONAL_ACCESS_TOKEN_WITH_BEARER_PREFIX
 
 anthropic:
   api_key: your-anthropic-api-key
-#  api_key: !developer_secret ANTHROPIC_API_KEY

--- a/examples/workflows/workflow_evaluator_optimizer/main.py
+++ b/examples/workflows/workflow_evaluator_optimizer/main.py
@@ -78,7 +78,7 @@ async def example_usage(
 
         result = await evaluator_optimizer.generate_str(
             message=f"Write a cover letter for the following job posting: {job_posting}\n\nCandidate Details: {candidate_details}\n\nCompany information: {company_information}",
-            request_params=RequestParams(model="gpt-4.1"),
+            request_params=RequestParams(model="gpt-5"),
         )
 
         logger.info(f"Generated cover letter: {result}")

--- a/examples/workflows/workflow_evaluator_optimizer/mcp_agent.config.yaml
+++ b/examples/workflows/workflow_evaluator_optimizer/mcp_agent.config.yaml
@@ -3,6 +3,12 @@ $schema: ../../../schema/mcp-agent.config.schema.json
 # Execution engine configuration
 execution_engine: asyncio
 
+# [cloud deployment] if you want to change default 60s timeout for each agent task run, uncomment temporal section below
+#temporal:
+#  timeout_seconds: 600      # timeout in seconds
+#  host: placeholder         # placeholder for schema validation
+#  task_queue: placeholder   # placeholder for schema validation
+
 # Logging configuration
 logger:
   type: console          # Log output type (console, file, or http)
@@ -30,7 +36,7 @@ mcp:
 # OpenAI configuration
 openai:
   # API keys are stored in mcp_agent.secrets.yaml (gitignored for security)
-  default_model: gpt-4.1  # Default model for OpenAI API calls
+  default_model: gpt-5  # Default model for OpenAI API calls
 
 # OpenTelemetry (OTEL) configuration for distributed tracing
 otel:

--- a/examples/workflows/workflow_evaluator_optimizer/mcp_agent.secrets.yaml.example
+++ b/examples/workflows/workflow_evaluator_optimizer/mcp_agent.secrets.yaml.example
@@ -7,12 +7,8 @@ $schema: ../../../schema/mcp-agent.config.schema.json
 # Create an API key at: https://platform.openai.com/api-keys
 openai:
   api_key: your-openai-api-key
-  # For cloud deployment, use developer secrets:
-  # api_key: !developer_secret OPENAI_API_KEY
 
 # Anthropic Configuration (if using Claude models)
 # Create an API key at: https://console.anthropic.com/settings/keys
 anthropic:
   api_key: your-anthropic-api-key
-  # For cloud deployment, use developer secrets:
-  # api_key: !developer_secret ANTHROPIC_API_KEY


### PR DESCRIPTION
### TL;DR

Updated model references from `gpt-4.1` to `gpt-5` and removed commented-out developer secret references.

### What changed?

- Changed the default OpenAI model from `gpt-4.1` to `gpt-5` in both the config file and the main.py script
- Removed commented-out developer secret references in the example secret files
- Added commented-out temporal configuration section for cloud deployment with timeout settings
- Cleaned up the example secret files by removing redundant commented lines

### How to test?

1. Verify that the model references in `mcp_agent.config.yaml` and `main.py` are correctly updated to `gpt-5`
2. Ensure the example secret files still contain the necessary configuration structure
3. Check that the added temporal configuration section is properly formatted and commented out

### Why make this change?

This change updates the model references to use the latest GPT model and simplifies the example configuration files by removing unnecessary commented-out developer secret references. The added temporal configuration section provides guidance for users who need to adjust timeout settings for cloud deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional (commented) cloud deployment configuration block to support timeout, host, and task queue settings.

- Chores
  - Upgraded the default model in the workflow evaluator/optimizer example to gpt-5.

- Documentation
  - Cleaned up example secrets by removing outdated commented placeholders and guidance lines.
  - Clarified example configuration for Anthropic by using a plain api_key placeholder.
  - Improved comments describing optional cloud deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->