### PR TITLE
Example of elicitation for MCP cloud

### DIFF
--- a/examples/mcp/mcp_elicitation/cloud/README.md
+++ b/examples/mcp/mcp_elicitation/cloud/README.md
@@ -1,0 +1,19 @@
+# Deploying the elicitation example to the cloud
+
+In `mcp_agent.secrets.yaml`, set your OpenAI `api_key`.
+
+Then, in the current directory (`cloud`), run:
+
+```bash
+uv run mcp-agent deploy elicitation --config-dir .
+```
+
+Once deployed, you should see an app ID, and a URL in the output. 
+You can use the URL to access the MCP via e.g. the [MCP Inspector](https://github.com/modelcontextprotocol/inspector).
+Add `/sse` to the end of the url, as the MCP is exposed as a server-sent events endpoint.
+Do not forget to add an authorization header with your MCP-agent API key as the bearer token.
+
+The app ID can be used to delete the example again:
+
+```bash
+uv run mcp-agent cloud app delete --id=<app-id>

--- a/examples/mcp/mcp_elicitation/cloud/README.md
+++ b/examples/mcp/mcp_elicitation/cloud/README.md
@@ -13,7 +13,8 @@ You can use the URL to access the MCP via e.g. the [MCP Inspector](https://githu
 Add `/sse` to the end of the url, as the MCP is exposed as a server-sent events endpoint.
 Do not forget to add an authorization header with your MCP-agent API key as the bearer token.
 
-The app ID can be used to delete the example again:
+The app ID can be used to delete the example again afterward:
 
 ```bash
 uv run mcp-agent cloud app delete --id=<app-id>
+```

--- a/examples/mcp/mcp_elicitation/cloud/main.py
+++ b/examples/mcp/mcp_elicitation/cloud/main.py
@@ -1,18 +1,8 @@
-import asyncio
 import logging
-import sys
 
-from mcp.server.fastmcp import FastMCP, Context
-from mcp.server.elicitation import (
-    AcceptedElicitation,
-    DeclinedElicitation,
-    CancelledElicitation,
-)
+from mcp.server.fastmcp import Context
 from pydantic import BaseModel, Field
 from mcp_agent.app import MCPApp
-from mcp_agent.server.app_server import create_mcp_server_for_app
-from mcp_agent.executor.workflow import Workflow, WorkflowResult
-from temporalio import workflow
 
 # Initialize logging
 logging.basicConfig(level=logging.INFO)

--- a/examples/mcp/mcp_elicitation/cloud/main.py
+++ b/examples/mcp/mcp_elicitation/cloud/main.py
@@ -1,0 +1,55 @@
+import asyncio
+import logging
+import sys
+
+from mcp.server.fastmcp import FastMCP, Context
+from mcp.server.elicitation import (
+    AcceptedElicitation,
+    DeclinedElicitation,
+    CancelledElicitation,
+)
+from pydantic import BaseModel, Field
+from mcp_agent.app import MCPApp
+from mcp_agent.server.app_server import create_mcp_server_for_app
+from mcp_agent.executor.workflow import Workflow, WorkflowResult
+from temporalio import workflow
+
+# Initialize logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = MCPApp(
+    name="elicitation_demo",
+    description="Demo of workflow with elicitation"
+)
+
+
+# mcp_context for fastmcp context
+@app.tool()
+async def book_table(date: str, party_size: int, app_ctx: Context) -> str:
+    """Book a table with confirmation"""
+
+    # Schema must only contain primitive types (str, int, float, bool)
+    class ConfirmBooking(BaseModel):
+        confirm: bool = Field(description="Confirm booking?")
+        notes: str = Field(default="", description="Special requests")
+
+    app.logger.info(f"Confirming the use wants to book a table for {party_size} on {date} via elicitation")
+
+    result = await app.context.upstream_session.elicit(
+        message=f"Confirm booking for {party_size} on {date}?",
+        requestedSchema=ConfirmBooking.model_json_schema(),
+    )
+
+    app.logger.info(f"Result from confirmation: {result}")
+
+    if result.action == "accept":
+        data = ConfirmBooking.model_validate(result.content)
+        if data.confirm:
+            return f"Booked! Notes: {data.notes or 'None'}"
+        return "Booking cancelled"
+    elif result.action == "decline":
+        return "Booking declined"
+    elif result.action == "cancel":
+        return "Booking cancelled"
+

--- a/examples/mcp/mcp_elicitation/cloud/mcp_agent.config.yaml
+++ b/examples/mcp/mcp_elicitation/cloud/mcp_agent.config.yaml
@@ -1,0 +1,15 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  transports: [file]
+  level: debug
+  path_settings:
+    path_pattern: "logs/mcp-agent-{unique_id}.jsonl"
+    unique_id: "timestamp" # Options: "timestamp" or "session_id"
+    timestamp_format: "%Y%m%d_%H%M%S"
+
+openai:
+  # Secrets (API keys, etc.) are stored in an mcp_agent.secrets.yaml file which can be gitignored
+  #  default_model: "o3-mini"
+  default_model: "gpt-4o-mini"

--- a/examples/mcp/mcp_elicitation/cloud/mcp_agent.secrets.yaml.example
+++ b/examples/mcp/mcp_elicitation/cloud/mcp_agent.secrets.yaml.example
@@ -1,0 +1,7 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+openai:
+  api_key: openai_api_key
+
+anthropic:
+  api_key: anthropic_api_key

--- a/examples/mcp/mcp_elicitation/cloud/requirements.txt
+++ b/examples/mcp/mcp_elicitation/cloud/requirements.txt
@@ -1,0 +1,6 @@
+# Core framework dependency
+mcp-agent
+
+# Additional dependencies specific to this example
+anthropic
+openai


### PR DESCRIPTION
Minimal example that can be run on the cloud with instructions how to use it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an elicitation-based booking example app for cloud deployment with confirm/decline/cancel flow.

* **Documentation**
  * Added cloud deployment guide: API key setup, deploy command, app ID/URL output, MCP Inspector access, SSE endpoint usage, Authorization header, and app deletion steps.

* **Chores**
  * Added configuration with asyncio engine, logging settings, and default model.
  * Added example secrets template for OpenAI/Anthropic keys.
  * Added requirements file including mcp-agent, openai, and anthropic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->