### PR TITLE
Add mcp-agent cloud compatibility to basic slack agent example

### DIFF
--- a/examples/usecases/mcp_basic_slack_agent/README.md
+++ b/examples/usecases/mcp_basic_slack_agent/README.md
@@ -96,3 +96,97 @@ Run your MCP Agent app:
 ```bash
 uv run main.py
 ```
+## `4` [Beta] Deploy to MCP Agent Cloud
+
+### Prerequisites
+Make sure your agent is cloud-compatible with the `@app.tool` decorator (already included in this example).
+
+### Step 1: Login to MCP Agent Cloud
+
+```bash
+uv run mcp-agent login
+```
+
+
+### Step 2: Deploy your agent
+
+```bash
+uv run mcp-agent deploy basic-slack-agent
+```
+
+During deployment, you'll be prompted to configure secrets. You'll see two options for each secret:
+
+#### For OpenAI API Key:
+```
+Select secret type for 'openai.api_key'
+1: Deployment Secret: The secret value will be stored securely and accessible to the deployed application runtime.
+2: User Secret: No secret value will be stored. The 'configure' command must be used to create a configured application with this secret.
+
+```
+Recommendation:
+- Choose Option 1 if you're deploying for personal use and want immediate functionality
+- Choose Option 2 if you're sharing this agent publicly and want users to provide their own OpenAI API keys
+
+#### For Slack Bot Token:
+```
+Select secret type for 'mcp.servers.slack.env.SLACK_BOT_TOKEN'
+1: Deployment Secret: The secret value will be stored securely and accessible to the deployed application runtime.
+2: User Secret: No secret value will be stored. The 'configure' command must be used to create a configured application with this secret.
+
+```
+Recommendation:
+- Choose Option 1 if you're deploying for your own Slack workspace and want the agent to work immediately
+- Choose Option 2 if you're sharing this agent publicly and want each user to connect their own Slack workspace
+
+### Step 3: Connect to your deployed agent
+
+Once deployed, you'll receive a deployment URL like: `https://[your-agent-server-id].deployments.mcp-agent.com`
+
+#### Claude Desktop Integration
+
+Configure Claude Desktop to access your agent by updating your `~/.claude-desktop/config.json`:
+
+```json
+{
+  "mcpServers": {
+    "basic-slack-agent": {
+      "command": "/path/to/npx",
+      "args": [
+        "mcp-remote",
+        "https://[your-agent-server-id].deployments.mcp-agent.com/sse",
+        "--header",
+        "Authorization: Bearer ${BEARER_TOKEN}"
+      ],
+      "env": {
+        "BEARER_TOKEN": "your-mcp-agent-cloud-api-token"
+      }
+    }
+  }
+}
+```
+
+#### MCP Inspector
+
+Test your deployed agent using MCP Inspector:
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+Configure the inspector with these settings:
+
+| Setting | Value |
+|---------|-------|
+| Transport Type | SSE |
+| SSE URL | `https://[your-agent-server-id].deployments.mcp-agent.com/sse` |
+| Header Name | Authorization |
+| Bearer Token | your-mcp-agent-cloud-api-token |
+
+**Tip:** Increase the request timeout in the Configuration since LLM calls take longer than simple API calls.
+
+### Available Tools
+
+Once deployed, your agent will expose the `fetch_latest_slack_message` tool, which:
+- Fetches the latest message from the bot-commits channel
+- Provides an AI-generated summary of the message content
+- Returns both the original message and summary

--- a/examples/usecases/mcp_basic_slack_agent/main.py
+++ b/examples/usecases/mcp_basic_slack_agent/main.py
@@ -8,7 +8,9 @@ from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
 app = MCPApp(name="mcp_basic_agent")
 
 
-async def example_usage():
+@app.tool
+async def fetch_latest_slack_message() -> str:
+    """Get the latest message from general channel and provide a summary."""
     async with app.run() as agent_app:
         logger = agent_app.logger
         context = agent_app.context
@@ -31,22 +33,25 @@ async def example_usage():
 
             llm = await slack_agent.attach_llm(OpenAIAugmentedLLM)
             result = await llm.generate_str(
-                message="What was the last message in the general channel?",
+                message="What was the latest message in the bot-commits channel?",
             )
             logger.info(f"Result: {result}")
 
             # Multi-turn conversations
-            result = await llm.generate_str(
-                message="Summarize it for me so I can understand it better.",
+            summary = await llm.generate_str(
+                message="Can you summarize what that commit was about?",
             )
-            logger.info(f"Result: {result}")
+            logger.info(f"Result: {summary}")
+
+            final_result = f"Latest message: {result}\n\nSummary: {summary}"
+            return final_result
 
 
 if __name__ == "__main__":
     import time
 
     start = time.time()
-    asyncio.run(example_usage())
+    asyncio.run(fetch_latest_slack_message())
     end = time.time()
     t = end - start
 


### PR DESCRIPTION
 1. Added @app.tool decorator (line 11) - Makes the function available as a cloud tool
  2. Renamed function from example_usage() to fetch_latest_slack_message() (line 12) - More descriptive name
  3. Added return type annotation -> str (line 12) - Required for cloud compatibility
  4. Added docstring (line 13) - Describes what the tool does
  6. Added return statement - Returns formatted result for cloud usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a user-accessible tool that fetches the latest message from the bot-commits Slack channel, generates a concise commit summary, and returns a single combined string.
  - Runtime now displays total execution time after completion.

- **Documentation**
  - Added a Beta cloud deployment guide with step-by-step deploy/login instructions, secret configuration recommendations, integration examples (desktop and inspector), and usage notes for the new tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->