### PR TITLE
Add mcp-agent init to cloud getting-started.mdx

### DIFF
--- a/docs/cloud/getting-started.mdx
+++ b/docs/cloud/getting-started.mdx
@@ -30,6 +30,16 @@ Before you begin, make sure you have:
 ## Quick Start
 
 <Steps>
+  <Step title="Initialize Project">
+    Create a new mcp-agent project:
+
+    ```bash
+    mcp-agent init
+    ```
+
+    This will initialize a mcp-agent project for you and create all the necessary files.
+  </Step>
+
   <Step title="Authenticate">
     Log in to **mcp-agent cloud**:
     


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the cloud Getting Started guide with a new Quick Start step: “Initialize Project.”
  * Instructs users to run `mcp-agent init` (with a code example) to scaffold a new project and generate required files.
  * Placed the new step before “Authenticate” to streamline the onboarding flow.
  * Improves clarity for first-time setup without changing existing steps or other content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->