### PR TITLE
Fix router constructor and generally how params are set

### DIFF
--- a/examples/basic/agent_factory/mcp_agent.config.yaml
+++ b/examples/basic/agent_factory/mcp_agent.config.yaml
@@ -4,7 +4,7 @@ execution_engine: asyncio
 
 logger:
   type: console
-  level: info
+  level: debug
 
 mcp:
   servers:
@@ -18,6 +18,9 @@ mcp:
 openai:
   # API keys and secrets go in mcp_agent.secrets.yaml; this file is safe to check in.
   default_model: gpt-4o-mini
+
+google:
+  default_model: gemini-2_5-pro
 
 agents:
   enabled: true

--- a/examples/basic/agent_factory/requirements.txt
+++ b/examples/basic/agent_factory/requirements.txt
@@ -1,0 +1,6 @@
+# Core framework dependency
+mcp-agent @ file://../../../  # Link to the local mcp-agent project root
+
+# Additional dependencies specific to this example
+anthropic
+openai

--- a/examples/model_providers/mcp_basic_google_agent/README.md
+++ b/examples/model_providers/mcp_basic_google_agent/README.md
@@ -42,7 +42,7 @@ Before running the agent, ensure you have your Gemini Developer API or Vertex AI
 - `vertexai`: Boolean flag to enable VertexAI integration (default: false)
 - `project`: Google Cloud project ID (required if using VertexAI)
 - `location`: Google Cloud location (required if using VertexAI)
-- `default_model`: Defaults to "gemini-2.0-flash" but can be customized in your config
+- `default_model`: Defaults to "gemini-2.5-flash" but can be customized in your config
 
 You can provide these in one of the following ways:
 

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -341,6 +341,13 @@ class GoogleSettings(BaseSettings, VertexAIMixin):
         ),
     )
 
+    default_model: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "default_model", "GOOGLE_DEFAULT_MODEL", "google__default_model"
+        ),
+    )
+
     model_config = SettingsConfigDict(
         env_prefix="GOOGLE_",
         extra="allow",

--- a/src/mcp_agent/data/artificial_analysis_llm_benchmarks.json
+++ b/src/mcp_agent/data/artificial_analysis_llm_benchmarks.json
@@ -8350,7 +8350,7 @@
     }
   },
   {
-    "name": "gemini-2-5-pro",
+    "name": "gemini-2.5-pro",
     "description": "Gemini 2.5 Pro (AI_Studio)",
     "provider": "Google (AI_Studio)",
     "context_window": 1000000,
@@ -8375,7 +8375,7 @@
     }
   },
   {
-    "name": "gemini-2-5-pro",
+    "name": "gemini-2.5-pro",
     "description": "Gemini 2.5 Pro Vertex",
     "provider": "Google Vertex",
     "context_window": 1000000,
@@ -9025,7 +9025,7 @@
     }
   },
   {
-    "name": "gemini-2-5-flash-reasoning",
+    "name": "gemini-2.5-flash-reasoning",
     "description": "Gemini 2.5 Flash (Reasoning) (AI_Studio)",
     "provider": "Google (AI_Studio)",
     "context_window": 1000000,
@@ -9050,7 +9050,7 @@
     }
   },
   {
-    "name": "gemini-2-5-flash-reasoning",
+    "name": "gemini-2.5-flash-reasoning",
     "description": "Gemini 2.5 Flash (Reasoning) (Vertex)",
     "provider": "Google (Vertex)",
     "context_window": 1000000,
@@ -9675,7 +9675,7 @@
     }
   },
   {
-    "name": "gemini-2-5-flash",
+    "name": "gemini-2.5-flash",
     "description": "Gemini 2.5 Flash (AI_Studio)",
     "provider": "Google (AI_Studio)",
     "context_window": 1000000,
@@ -9700,7 +9700,7 @@
     }
   },
   {
-    "name": "gemini-2-5-flash",
+    "name": "gemini-2.5-flash",
     "description": "Gemini 2.5 Flash (Vertex)",
     "provider": "Google (Vertex)",
     "context_window": 1000000,
@@ -12375,7 +12375,7 @@
     }
   },
   {
-    "name": "gemini-2-5-flash-lite",
+    "name": "gemini-2.5-flash-lite",
     "description": "Gemini 2.5 Flash-Lite (AI Studio)",
     "provider": "Google (AI Studio)",
     "context_window": 1000000,
@@ -12400,7 +12400,7 @@
     }
   },
   {
-    "name": "gemini-2-5-flash-lite-reasoning",
+    "name": "gemini-2.5-flash-lite-reasoning",
     "description": "Gemini 2.5 Flash-Lite (Reasoning) (AI\n                              Studio)",
     "provider": "Google (AI Studio)",
     "context_window": 1000000,

--- a/src/mcp_agent/workflows/llm/augmented_llm.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm.py
@@ -356,9 +356,9 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol[MessageParamT, Message
 
     # Provider configuration access
     @classmethod
-    @abstractmethod
     def get_provider_config(cls, context: Optional["Context"]):
         """Return the provider-specific settings object from the app context, or None."""
+        return None
 
     async def select_model(
         self, request_params: RequestParams | None = None

--- a/src/mcp_agent/workflows/llm/augmented_llm.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm.py
@@ -354,6 +354,12 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol[MessageParamT, Message
     ) -> ModelT:
         """Request a structured LLM generation and return the result as a Pydantic model."""
 
+    # Provider configuration access
+    @classmethod
+    @abstractmethod
+    def get_provider_config(cls, context: Optional["Context"]):
+        """Return the provider-specific settings object from the app context, or None."""
+
     async def select_model(
         self, request_params: RequestParams | None = None
     ) -> str | None:

--- a/src/mcp_agent/workflows/llm/augmented_llm_anthropic.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_anthropic.py
@@ -149,6 +149,10 @@ class AnthropicAugmentedLLM(AugmentedLLM[MessageParam, Message]):
             use_history=True,
         )
 
+    @classmethod
+    def get_provider_config(cls, context):
+        return getattr(getattr(context, "config", None), "anthropic", None)
+
     @track_tokens()
     async def generate(
         self,

--- a/src/mcp_agent/workflows/llm/augmented_llm_azure.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_azure.py
@@ -128,6 +128,10 @@ class AzureAugmentedLLM(AugmentedLLM[MessageParam, ResponseMessage]):
             use_history=True,
         )
 
+    @classmethod
+    def get_provider_config(cls, context):
+        return getattr(getattr(context, "config", None), "azure", None)
+
     @track_tokens()
     async def generate(self, message, request_params: RequestParams | None = None):
         """

--- a/src/mcp_agent/workflows/llm/augmented_llm_bedrock.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_bedrock.py
@@ -91,6 +91,10 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
             use_history=True,
         )
 
+    @classmethod
+    def get_provider_config(cls, context):
+        return getattr(getattr(context, "config", None), "bedrock", None)
+
     @track_tokens()
     async def generate(self, message, request_params: RequestParams | None = None):
         """

--- a/src/mcp_agent/workflows/llm/augmented_llm_google.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_google.py
@@ -57,7 +57,7 @@ class GoogleAugmentedLLM(
             intelligencePriority=0.3,
         )
         # Get default model from config if available
-        default_model = "gemini-2.0-flash"  # Fallback default
+        default_model = "gemini-2.5-flash"  # Fallback default
 
         if self.context.config.google:
             if hasattr(self.context.config.google, "default_model"):
@@ -238,6 +238,10 @@ class GoogleAugmentedLLM(
 
         return response.text or ""
 
+    @classmethod
+    def get_provider_config(cls, context):
+        return getattr(getattr(context, "config", None), "google", None)
+
     async def generate_structured(
         self,
         message,
@@ -250,7 +254,7 @@ class GoogleAugmentedLLM(
         import json
 
         params = self.get_request_params(request_params)
-        model = await self.select_model(params) or (params.model or "gemini-2.0-flash")
+        model = await self.select_model(params) or (params.model or "gemini-2.5-flash")
 
         # Convert input messages and build config
         messages = GoogleConverter.convert_mixed_messages_to_google(message)

--- a/src/mcp_agent/workflows/llm/augmented_llm_ollama.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_ollama.py
@@ -33,6 +33,11 @@ class OllamaAugmentedLLM(OpenAIAugmentedLLM):
 
         self.provider = "Ollama"
 
+    @classmethod
+    def get_provider_config(cls, context):
+        # Uses the OpenAI-compatible config (base_url, api_key) for Ollama
+        return getattr(getattr(context, "config", None), "openai", None)
+
     async def generate_structured(
         self,
         message,

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -135,6 +135,10 @@ class OpenAIAugmentedLLM(
         )
 
     @classmethod
+    def get_provider_config(cls, context):
+        return getattr(getattr(context, "config", None), "openai", None)
+
+    @classmethod
     def convert_message_to_message_param(
         cls, message: ChatCompletionMessage, **kwargs
     ) -> ChatCompletionMessageParam:


### PR DESCRIPTION
Fixes #516 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Router now supports additional LLM providers (Azure, Google, Bedrock, Ollama) alongside OpenAI and Anthropic.
  - Added provider-config access hooks for multiple LLM implementations.
  - Automatic fallback to provider default models when none is specified; Google’s default updated to gemini-2.5-flash.

- Documentation
  - Updated Google provider README to reflect the new default model.

- Data
  - Standardized benchmark model names to the Gemini 2.5 naming convention.

- Chores
  - Added a requirements file for the basic agent factory example and example config now includes Google defaults and increased logging verbosity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->