### PR TITLE
Fix bundle path for .mcpac.py files on Windows

### DIFF
--- a/src/mcp_agent/cli/cloud/commands/deploy/wrangler_wrapper.py
+++ b/src/mcp_agent/cli/cloud/commands/deploy/wrangler_wrapper.py
@@ -195,8 +195,7 @@ def wrangler_deploy(app_id: str, api_key: str, project_dir: Path) -> None:
                     continue
 
                 # For non-Python files, rename with .mcpac.py extension to be included as py files
-                relative_path = file_path.relative_to(temp_project_dir)
-                py_path = temp_project_dir / f"{relative_path}.mcpac.py"
+                py_path = file_path.with_suffix(file_path.suffix + ".mcpac.py")
 
                 # Rename in place
                 file_path.rename(py_path)


### PR DESCRIPTION
## Description
The following error is seen when trying to deploy on Windows:

<img width="853" height="88" alt="Screenshot 2025-09-29 at 1 54 20 PM" src="https://github.com/user-attachments/assets/8d759a00-87a6-4461-aae0-a6eb1f4d3da2" />

I believe the issues is due to our f-string use in constructing the path, so fix to use Path methods only

## Testing
```bash
make lint
make format
make tests
```

```bash
uv run mcp-agent deploy MCPAgentServerTemporal -c examples/mcp_agent_server/temporal 
```
Deployed successfully