### PR TITLE
Missing tool workflows-BasicAgentWorkflow-get_status

### DIFF
--- a/examples/mcp_agent_server/temporal/client.py
+++ b/examples/mcp_agent_server/temporal/client.py
@@ -199,7 +199,7 @@ async def main():
                 if "workflows" in selected:
                     while True:
                         get_status_result = await server.call_tool(
-                            "workflows-BasicAgentWorkflow-get_status",
+                            "workflows-get_status",
                             arguments={"run_id": run_id},
                         )
 


### PR DESCRIPTION
Temporal example fails due to missing tool. Renaming to `workflows-get_status`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized the tool used to poll workflow status to a generalized identifier, aligning status retrieval across environments and simplifying status checks.
- Chores
  - Minor internal cleanup to the workflow status polling path with no changes to user-facing behavior or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->