### PR TITLE
Add validation for a project deps file

### DIFF
--- a/src/mcp_agent/cli/cloud/commands/deploy/validation.py
+++ b/src/mcp_agent/cli/cloud/commands/deploy/validation.py
@@ -44,6 +44,11 @@ def validate_project(project_dir: Path):
             "Invalid poetry project: poetry.lock found without corresponding pyproject.toml"
         )
 
+    if sum([has_pyproject, has_requirements, has_poetry_lock, has_uv_lock]) == 0:
+        raise ValueError(
+            "No Python project dependency management files found. Expected one of: pyproject.toml, requirements.txt, poetry.lock, uv.lock in the project directory."
+        )
+
 
 def validate_entrypoint(entrypoint_path: Path):
     """

--- a/tests/cli/commands/test_wrangler_wrapper.py
+++ b/tests/cli/commands/test_wrangler_wrapper.py
@@ -42,6 +42,9 @@ app = MCPApp(
         main_py_path = project_path / "main.py"
         main_py_path.write_text(main_py_content)
 
+        # Create a requirements.txt to satisfy dependency file requirement
+        (project_path / "requirements.txt").write_text("mcp-agent")
+
         yield project_path
 
 
@@ -280,6 +283,25 @@ app = MCPApp(name="test-app")
         with pytest.raises(
             ValueError,
             match="Invalid poetry project: poetry.lock found without corresponding pyproject.toml",
+        ):
+            validate_project(project_path)
+
+
+def test_validate_project_no_dependency_files():
+    """Test validate_project when no dependency management files exist."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        project_path = Path(temp_dir)
+
+        # Create main.py only, no dependency files
+        main_py_content = """from mcp_agent_cloud import MCPApp
+
+app = MCPApp(name="test-app")
+"""
+        (project_path / "main.py").write_text(main_py_content)
+
+        with pytest.raises(
+            ValueError,
+            match="No Python project dependency management files found. Expected one of: pyproject.toml, requirements.txt, poetry.lock, uv.lock in the project directory.",
         ):
             validate_project(project_path)
 
@@ -634,6 +656,8 @@ def test_wrangler_deploy_complex_file_extensions():
 from mcp_agent_cloud import MCPApp
 app = MCPApp(name="test-app")
 """)
+        # Create requirements.txt to satisfy dependency file requirement
+        (project_path / "requirements.txt").write_text("mcp-agent")
 
         # Create files with complex extensions
         complex_files = {
@@ -906,10 +930,16 @@ def test_wrangler_deploy_no_requirements_txt():
     with tempfile.TemporaryDirectory() as temp_dir:
         project_path = Path(temp_dir)
 
-        # Create main.py only
+        # Create main.py
         (project_path / "main.py").write_text("""
 from mcp_agent_cloud import MCPApp
 app = MCPApp(name="test-app")
+""")
+        # Create pyproject.toml to satisfy dependency file requirement
+        (project_path / "pyproject.toml").write_text("""[project]
+name = "test-app"
+version = "0.1.0"
+dependencies = ["mcp-agent"]
 """)
 
         with patch("subprocess.run") as mock_subprocess:
@@ -932,6 +962,8 @@ def test_wrangler_deploy_secrets_file_exclusion():
 from mcp_agent_cloud import MCPApp
 app = MCPApp(name="test-app")
 """)
+        # Create requirements.txt to satisfy dependency file requirement
+        (project_path / "requirements.txt").write_text("mcp-agent")
 
         # Create secrets file
         secrets_content = """
@@ -1160,6 +1192,8 @@ def test_wrangler_deploy_with_ignore_file():
 from mcp_agent_cloud import MCPApp
 app = MCPApp(name="test-app")
 """)
+        # Create requirements.txt to satisfy dependency file requirement
+        (project_path / "requirements.txt").write_text("mcp-agent")
 
         # Create .mcpacignore
         ignore_content = """*.log
@@ -1223,6 +1257,8 @@ from mcp_agent_cloud import MCPApp
 app = MCPApp(name="test-app")
 """
         )
+        # Create requirements.txt to satisfy dependency file requirement
+        (project_path / "requirements.txt").write_text("mcp-agent")
         (project_path / "config.yaml").write_text("name: test-app\n")
         (project_path / "artifact.txt").write_text("artifact\n")
 

--- a/tests/cli/test_deploy_validation.py
+++ b/tests/cli/test_deploy_validation.py
@@ -24,6 +24,8 @@ from mcp_agent.cloud import MCPApp
 
 app = MCPApp(name="test-app")
 """)
+            # Create requirements.txt to satisfy dependency file requirement
+            (project_dir / "requirements.txt").write_text("mcp-agent")
 
             # Should not raise any exception
             validate_project(project_dir)
@@ -53,6 +55,8 @@ app = MCPApp(name="test-app")
             project_dir = Path(temp_dir)
             main_py = project_dir / "main.py"
             main_py.write_text("app = MCPApp()")
+            # Create requirements.txt to satisfy dependency file requirement
+            (project_dir / "requirements.txt").write_text("mcp-agent")
 
             with patch(
                 "mcp_agent.cli.cloud.commands.deploy.validation.validate_entrypoint"


### PR DESCRIPTION
## Summary
Server-side, we're depending on the existence of a python project dependency file (`pyproject.toml`, `poetry.lock`, `uv.lock`, or `requirements.txt`) so that the app can install its dependencies. This PR adds client-side validation that one of those files exists to prevent hitting the COPY error during deployment.

## Testing
```bash
make lint
make format
make tests
```

Deployed mcp_agent_server/temporal example successfully.

Then removed the requirements.txt file from that example and retried, see the error:

```bash
╭────────────────────────────── MCP Agent Deployment ──────────────────────────────╮
│ App: MCPAgentServerTemporal (ID: app_3c033939-dfc6-4b39-ad1f-363bd5bb7185)       │
│ Configuration:                                                                   │
│ /Users/ryanholinshead/Projects/mcp-agent/examples/mcp_agent_server/temporal/mcp_ │
│ agent.config.yaml                                                                │
│ Secrets file:                                                                    │
│ /Users/ryanholinshead/Projects/mcp-agent/examples/mcp_agent_server/temporal/mcp_ │
│ agent.secrets.yaml                                                               │
│ Deployed secrets file:                                                           │
│ /Users/ryanholinshead/Projects/mcp-agent/examples/mcp_agent_server/temporal/mcp_ │
│ agent.deployed.secrets.yaml                                                      │
│                                                                                  │
╰────────────────────────────────── LastMile AI ───────────────────────────────────╯
INFO: Skipping secrets processing...
╭──────────────────────────────── Deployment Ready ────────────────────────────────╮
│ Ready to deploy MCP Agent with processed configuration                           │
╰──────────────────────────────────────────────────────────────────────────────────╯
WARNING: Found a __main__ entrypoint in main.py. This will be ignored in the 
deployment.
ERROR: Deployment failed: Bundling failed: No Python project dependency management 
files found. Expected one of: pyproject.toml, requirements.txt, poetry.lock, uv.lock
in the project directory.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Deployment validation now requires at least one dependency file (pyproject.toml, requirements.txt, poetry.lock, or uv.lock). If none are found, deployment stops with a clear error message.
  - Reinforces rules to use a single dependency manager and ensures pyproject.toml is present when using uv or poetry lock files, reducing misconfiguration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->