### PR TITLE
Fix/prompt to reprocess matching secrets values

### DIFF
--- a/examples/basic/functions/main.py
+++ b/examples/basic/functions/main.py
@@ -56,7 +56,9 @@ async def example_usage():
         logger = agent_app.logger
         context = agent_app.context
 
-        outcome = await calculate("Add 2 and 3, then multiply the result by 4.", context)
+        outcome = await calculate(
+            "Add 2 and 3, then multiply the result by 4.", context
+        )
         logger.info(f"(2+3) * 4 equals {outcome}")
 
 

--- a/src/mcp_agent/cli/secrets/processor.py
+++ b/src/mcp_agent/cli/secrets/processor.py
@@ -278,7 +278,14 @@ async def get_validated_config_secrets(
 
                 if key in input_config:
                     if input_config[key] == secret_value:
-                        validated_config[key] = existing_value
+                        reprocess = not non_interactive and typer.confirm(
+                            f"Secret at '{current_path}' value in transformed secrets file matches raw secrets file. Do you want to reprocess it anyway?",
+                            default=False,
+                        )
+                        if reprocess:
+                            continue
+                        else:
+                            validated_config[key] = existing_value
                     else:
                         if non_interactive:
                             print_warning(

--- a/tests/test_config_exporters.py
+++ b/tests/test_config_exporters.py
@@ -95,9 +95,7 @@ def test_literal_exporters_become_typed_configs():
     settings = OpenTelemetrySettings(exporters=["console", "file", "otlp"])
 
     assert len(settings.exporters) == 3
-    assert [
-        type(exporter) for exporter in settings.exporters
-    ] == [
+    assert [type(exporter) for exporter in settings.exporters] == [
         ConsoleExporterSettings,
         FileExporterSettings,
         OTLPExporterSettings,

--- a/uv.lock
+++ b/uv.lock
@@ -2041,7 +2041,7 @@ wheels = [
 
 [[package]]
 name = "mcp-agent"
-version = "0.1.29"
+version = "0.1.30"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -2041,7 +2041,7 @@ wheels = [
 
 [[package]]
 name = "mcp-agent"
-version = "0.1.28"
+version = "0.1.29"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
When deploying an app with existing `mcp_agent.deployed.secrets.yaml` file, allow reprocessing all secrets in the `mcp_agent.secrets.yaml` file, even those that already match the processed handle's values. This will allow re-deploying an app and specifying a secret as a user secret after it had already been processed as a deployment secret previously.

## Testing
```bash
make sync
make lint
make format
make tests
```

```bash
uv run mcp-agent deploy MCPAgentServerTemporal -c examples/mcp_agent_server/temporal 
INFO: Using API at https://mcp-agent.com/api
INFO: Checking for existing app ID for 'MCPAgentServerTemporal'...
SUCCESS: Found existing app with ID: app_3c033939-dfc6-4b39-ad1f-363bd5bb7185 for 
name 'MCPAgentServerTemporal'
Do you want deploy an update to the existing app ID: app_3c033939-dfc6-4b39-ad1f-363bd5bb7185? [Y/n]: 
INFO: Will deploy an update to app ID: app_3c033939-dfc6-4b39-ad1f-363bd5bb7185
INFO: Both 'mcp_agent.secrets.yaml' and 'mcp_agent.deployed.secrets.yaml' found in 
/Users/ryanholinshead/Projects/mcp-agent/examples/mcp_agent_server/temporal.
Do you want to reuse the previously deployed secrets in 'mcp_agent.deployed.secrets.yaml'? [Y/n]: n
INFO: Will update existing 'mcp_agent.deployed.secrets.yaml' by re-processing 
'mcp_agent.secrets.yaml'.
╭────────────────────────────── MCP Agent Deployment ──────────────────────────────╮
│ App: MCPAgentServerTemporal (ID: app_3c033939-dfc6-4b39-ad1f-363bd5bb7185)       │
│ Configuration:                                                                   │
│ /Users/ryanholinshead/Projects/mcp-agent/examples/mcp_agent_server/temporal/mcp_ │
│ agent.config.yaml                                                                │
│ Secrets file:                                                                    │
│ /Users/ryanholinshead/Projects/mcp-agent/examples/mcp_agent_server/temporal/mcp_ │
│ agent.secrets.yaml                                                               │
│ Deployed secrets file: Pending creation                                          │
│                                                                                  │
╰────────────────────────────────── LastMile AI ───────────────────────────────────╯
INFO: Processing secrets file...
INFO: Found existing transformed secrets to use where applicable: 
/Users/ryanholinshead/Projects/mcp-agent/examples/mcp_agent_server/temporal/mcp_agen
t.deployed.secrets.yaml
INFO: Loaded existing secrets configuration for reuse
Secret at 'anthropic.api_key' value in transformed secrets file matches raw secrets file. Do you want to reprocess it anyway? [y/N]: y
Secret at 'openai.api_key' value in transformed secrets file matches raw secrets file. Do you want to reprocess it anyway? [y/N]: n
INFO: 
Reusing existing deployment secret handle at 'openai.api_key': 
mcpac_sc_2cd2e737-215a-40d2-bec2-4b87e95fabf6

Select secret type for 'anthropic.api_key'
1: Deployment Secret: The secret value will be stored securely and accessible to the
deployed application runtime.
2: User Secret: No secret value will be stored. The 'configure' command must be used
to create a configured application with this secret.

Select secret type: (1): 2
INFO: Tagging 'anthropic.api_key' as a user secret (!user_secret)
INFO: Transformed config written to 
/Users/ryanholinshead/Projects/mcp-agent/examples/mcp_agent_server/temporal/mcp_agen
t.deployed.secrets.yaml

                      Secrets Processing Summary                      
┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃    Type    ┃ Path              ┃ Handle/Status         ┃  Source   ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ Deployment │ openai.api_key    │ mcpac_sc...e95fabf6   │ ♻️  Reused │
│    User    │ anthropic.api_key │ ▶️  Runtime Collection │ End User  │
└────────────┴───────────────────┴───────────────────────┴───────────┘

Summary: 0 new secrets created, 1 existing secrets reused, 1 user secrets 
identified, 0 secrets skipped due to errors.
SUCCESS: Secrets file processed successfully
INFO: Transformed secrets file written to 
/Users/ryanholinshead/Projects/mcp-agent/examples/mcp_agent_server/temporal/mcp_agen
t.deployed.secrets.yaml
```