### PR TITLE
Add better identity management in app server

### DIFF
--- a/src/mcp_agent/oauth/context_state.py
+++ b/src/mcp_agent/oauth/context_state.py
@@ -1,0 +1,54 @@
+"""Utilities for propagating authenticated user identity across async tasks."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from typing import Iterator
+
+from mcp_agent.oauth.identity import OAuthUserIdentity
+
+_identity_var: ContextVar[OAuthUserIdentity | None] = ContextVar(
+    "mcp_agent_current_identity", default=None
+)
+_session_var: ContextVar[str | None] = ContextVar(
+    "mcp_agent_current_session_id", default=None
+)
+
+
+def get_current_identity() -> OAuthUserIdentity | None:
+    """Return the identity bound to the current task, if any."""
+    return _identity_var.get()
+
+
+def get_current_session_id() -> str | None:
+    """Return the session id bound to the current task, if any."""
+    return _session_var.get()
+
+
+def push_identity(
+    identity: OAuthUserIdentity | None, session_id: str | None = None
+) -> tuple[Token, Token]:
+    """Bind identity/session to the current task and return reset tokens."""
+    identity_token = _identity_var.set(identity)
+    session_token = _session_var.set(session_id)
+    return identity_token, session_token
+
+
+def reset_identity(tokens: tuple[Token, Token]) -> None:
+    """Reset identity/session using previously returned tokens."""
+    identity_token, session_token = tokens
+    _identity_var.reset(identity_token)
+    _session_var.reset(session_token)
+
+
+@contextmanager
+def identity_scope(
+    identity: OAuthUserIdentity | None, session_id: str | None = None
+) -> Iterator[None]:
+    """Context manager that temporarily binds identity/session."""
+    tokens = push_identity(identity, session_id)
+    try:
+        yield
+    finally:
+        reset_identity(tokens)

--- a/tests/server/test_app_server_memo.py
+++ b/tests/server/test_app_server_memo.py
@@ -28,7 +28,7 @@ async def test_memo_from_forwarded_headers(monkeypatch):
         lambda ctx: ({"TestWorkflow": FakeWorkflow}, SimpleNamespace()),
     )
     # Avoid registry side effects
-    monkeypatch.setattr(app_server, "_register_session", lambda *a, **k: None)
+    monkeypatch.setattr(app_server, "_register_execution_binding", lambda *a, **k: None)
 
     # Construct a request-like object with only X-Forwarded-* headers
     headers = {
@@ -83,7 +83,6 @@ async def test_memo_falls_back_to_env(monkeypatch):
         "_resolve_workflows_and_context",
         lambda ctx: ({"TestWorkflow": FakeWorkflow}, SimpleNamespace()),
     )
-    monkeypatch.setattr(app_server, "_register_session", lambda *a, **k: None)
 
     # No headers at all; env should be used
     req = SimpleNamespace(headers={}, base_url=None)


### PR DESCRIPTION
## Problems

- Identity Leakage: The server used to stash the authenticated user in app.context.current_user, a shared, long-lived object. Concurrent requests (or workflows coming back later) would overwrite that field, so TokenManager might refresh or invalidate tokens for the wrong human.

- Temporal Callbacks Missing Identity: Activities and workflows emit `internal/session/...` calls from separate processes; those relays ran without any authenticated context, causing delegated OAuth flows (auth/request) to fail because the TokenManager saw no user identity.

- TokenManager Context Dependence: Downstream OAuth clients relied exclusively on context.current_user and context.session_id. If either was missing (e.g., because we intentionally avoided touching shared context), they couldn’t fetch or refresh tokens.

## Changes

We introduce per-request/per-execution identity scoping (via contextvars) and memo propagation so each outbound OAuth interaction — and every Temporal callback—runs under the correct user without mutating global state.
