### PR TITLE
Fix: Bump timeout on configure deployment API call

### DIFF
--- a/src/mcp_agent/cli/mcp_app/api_client.py
+++ b/src/mcp_agent/cli/mcp_app/api_client.py
@@ -372,7 +372,11 @@ class MCPAppClient(APIClient):
             "params": config_params,
         }
 
-        response = await self.put("/mcp_app/configure_app", payload)
+        # Use a longer timeout for configuring deployments
+        configure_timeout = 300.0
+        response = await self.put(
+            "/mcp_app/configure_app", payload, timeout=configure_timeout
+        )
 
         res = response.json()
         if not res or "appConfiguration" not in res:


### PR DESCRIPTION
## Summary
Based on error message, Bill noticed that the configure deployment calls are timing out. At the API call level, we have a 300s timeout for deployment calls but are defaulting to 30s for the configure deployment calls so bump it to match.

## Testing
```
uv run mcp-agent cloud configure --id=https://zlb2e67xnscyz6lxc6tbe2p0m07reui.deployments.mcp-agent.com
INFO: App https://zlb2e67xnscyz6lxc6tbe2p0m07reui.deployments.mcp-agent.com does not
require any parameters.
▹▹▸▹▹ Configuring MCP App...╭───────────────────────────── Configuration Complete ─────────────────────────────╮
│ Configured App ID: apcnf_0d7ad2e4-8ab3-47ed-9869-83ca0f265130                    │
│ Configured App Server URL:                                                       │
│ https://17re94ramf24z966qnsumyuav7iy4og1.deployments.mcp-agent.com               │
╰──────────────────────────────────────────────────────────────────────────────────╯
▹▹▹▸▹ ✅ MCP App configured successfully!
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a timeout to the app configuration request to prevent indefinite hangs and improve reliability during setup.
  * Provides clearer failure behavior if the configuration service is slow or unresponsive, reducing stalled sessions.

* **Chores**
  * Standardized network request behavior by applying a consistent timeout for configuration operations, aligning with overall stability expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->