### PR TITLE
'update' CLI command, and also a --noauth flag

### DIFF
--- a/src/mcp_agent/cli/cloud/commands/apps/__init__.py
+++ b/src/mcp_agent/cli/cloud/commands/apps/__init__.py
@@ -1,5 +1,6 @@
 """MCP Agent Cloud apps command."""
 
 from .list import list_apps
+from .update import update_app
 
-__all__ = ["list_apps"]
+__all__ = ["list_apps", "update_app"]

--- a/src/mcp_agent/cli/cloud/commands/apps/update/__init__.py
+++ b/src/mcp_agent/cli/cloud/commands/apps/update/__init__.py
@@ -1,0 +1,5 @@
+"""Update MCP apps command module exports."""
+
+from .main import update_app
+
+__all__ = ["update_app"]

--- a/src/mcp_agent/cli/cloud/commands/apps/update/main.py
+++ b/src/mcp_agent/cli/cloud/commands/apps/update/main.py
@@ -1,0 +1,126 @@
+from typing import Optional
+
+import typer
+
+from mcp_agent.cli.auth import load_api_key_credentials
+from mcp_agent.cli.config import settings
+from mcp_agent.cli.core.api_client import UnauthenticatedError
+from mcp_agent.cli.core.constants import (
+    DEFAULT_API_BASE_URL,
+    ENV_API_BASE_URL,
+    ENV_API_KEY,
+)
+from mcp_agent.cli.core.utils import run_async
+from mcp_agent.cli.exceptions import CLIError
+from mcp_agent.cli.mcp_app.api_client import MCPApp, MCPAppClient, MCPAppConfiguration
+from mcp_agent.cli.utils.ux import print_info, print_success
+from ...utils import resolve_server
+
+
+def update_app(
+    app_id_or_name: str = typer.Argument(
+        ...,
+        help="ID, server URL, configuration ID, or name of the app to update.",
+        show_default=False,
+    ),
+    name: Optional[str] = typer.Option(
+        None,
+        "--name",
+        "-n",
+        help="Set a new name for the app.",
+    ),
+    description: Optional[str] = typer.Option(
+        None,
+        "--description",
+        "-d",
+        help="Set a new description for the app. Use an empty string to clear it.",
+    ),
+    unauthenticated_access: Optional[bool] = typer.Option(
+        None,
+        "--no-auth/--auth",
+        help=(
+            "Allow unauthenticated access to the app server (--no-auth) or require authentication (--auth). "
+            "If omitted, the current setting is preserved."
+        ),
+    ),
+    api_url: Optional[str] = typer.Option(
+        settings.API_BASE_URL,
+        "--api-url",
+        help="API base URL. Defaults to MCP_API_BASE_URL environment variable.",
+        envvar=ENV_API_BASE_URL,
+    ),
+    api_key: Optional[str] = typer.Option(
+        settings.API_KEY,
+        "--api-key",
+        help="API key for authentication. Defaults to MCP_API_KEY environment variable.",
+        envvar=ENV_API_KEY,
+    ),
+) -> None:
+    """Update metadata or authentication settings for a deployed MCP App."""
+    if name is None and description is None and unauthenticated_access is None:
+        raise CLIError(
+            "Specify at least one of --name, --description, or --no-auth/--auth to update.",
+            retriable=False,
+        )
+
+    effective_api_key = api_key or settings.API_KEY or load_api_key_credentials()
+
+    if not effective_api_key:
+        raise CLIError(
+            "Must be logged in to update an app. Run 'mcp-agent login', set MCP_API_KEY environment variable or specify --api-key option.",
+            retriable=False,
+        )
+
+    client = MCPAppClient(
+        api_url=api_url or DEFAULT_API_BASE_URL, api_key=effective_api_key
+    )
+
+    try:
+        resolved = resolve_server(client, app_id_or_name)
+
+        if isinstance(resolved, MCPAppConfiguration):
+            if not resolved.app:
+                raise CLIError(
+                    "Could not resolve the underlying app for the configuration provided."
+                )
+            target_app: MCPApp = resolved.app
+        else:
+            target_app = resolved
+
+        updated_app = run_async(
+            client.update_app(
+                app_id=target_app.appId,
+                name=name,
+                description=description,
+                unauthenticated_access=unauthenticated_access,
+            )
+        )
+
+        short_id = f"{updated_app.appId[:8]}…"
+        print_success(
+            f"Updated app '{updated_app.name or target_app.name}' (ID: `{short_id}`)"
+        )
+
+        if updated_app.description is not None:
+            desc_text = updated_app.description or "(cleared)"
+            print_info(f"Description: {desc_text}")
+
+        app_server_info = updated_app.appServerInfo
+        if app_server_info and app_server_info.serverUrl:
+            print_info(f"Server URL: {app_server_info.serverUrl}")
+            if app_server_info.unauthenticatedAccess is not None:
+                auth_msg = (
+                    "Unauthenticated access allowed"
+                    if app_server_info.unauthenticatedAccess
+                    else "Authentication required"
+                )
+                print_info(f"Authentication: {auth_msg}")
+
+    except UnauthenticatedError as e:
+        raise CLIError(
+            "Invalid API key. Run 'mcp-agent login' or set MCP_API_KEY environment variable with new API key."
+        ) from e
+    except CLIError:
+        raise
+    except Exception as e:
+        raise CLIError(f"Error updating app: {str(e)}") from e

--- a/src/mcp_agent/cli/cloud/commands/deploy/wrangler_wrapper.py
+++ b/src/mcp_agent/cli/cloud/commands/deploy/wrangler_wrapper.py
@@ -296,7 +296,9 @@ def wrangler_deploy(
             )
             meta_vars.update({"MCP_DEPLOY_WORKSPACE_HASH": bundle_hash})
             if settings.VERBOSE:
-                print_info(f"Deploying from non-git workspace (hash {bundle_hash[:12]}…)")
+                print_info(
+                    f"Deploying from non-git workspace (hash {bundle_hash[:12]}…)"
+                )
 
         # Write a breadcrumb file into the project so it ships with the bundle.
         # Use a Python file for guaranteed inclusion without renaming.

--- a/src/mcp_agent/cli/cloud/main.py
+++ b/src/mcp_agent/cli/cloud/main.py
@@ -16,6 +16,7 @@ from mcp_agent.cli.cloud.commands import (
     logout,
     whoami,
 )
+from mcp_agent.cli.cloud.commands.apps import update_app as update_app_command
 from mcp_agent.cli.cloud.commands.app import (
     delete_app,
     get_app_status,
@@ -88,6 +89,7 @@ app_cmd_app.command(name="list")(list_servers)
 app_cmd_app.command(name="delete")(delete_app)
 app_cmd_app.command(name="status")(get_app_status)
 app_cmd_app.command(name="workflows")(list_app_workflows)
+app_cmd_app.command(name="update")(update_app_command)
 app.add_typer(app_cmd_app, name="apps", help="Manage an MCP App")
 
 # Sub-typer for `mcp-agent workflows` commands

--- a/tests/cli/commands/test_apps_update.py
+++ b/tests/cli/commands/test_apps_update.py
@@ -1,0 +1,128 @@
+"""Tests for the `mcp-agent apps update` command."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from mcp_agent.cli.cloud.main import app
+from mcp_agent.cli.mcp_app.api_client import AppServerInfo, MCPApp, MCPAppConfiguration
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _make_app(unauthenticated: bool = False) -> MCPApp:
+    now = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    return MCPApp(
+        appId="app_12345678-1234-1234-1234-1234567890ab",
+        name="Sample App",
+        creatorId="u_12345678-1234-1234-1234-1234567890ab",
+        description="Initial",
+        createdAt=now,
+        updatedAt=now,
+        appServerInfo=AppServerInfo(
+            serverUrl="https://example.com",
+            status="APP_SERVER_STATUS_ONLINE",
+            unauthenticatedAccess=unauthenticated,
+        ),
+    )
+
+
+def test_apps_update_requires_fields(runner: CliRunner):
+    result = runner.invoke(
+        app,
+        [
+            "apps",
+            "update",
+            "app_12345678-1234-1234-1234-1234567890ab",
+            "--api-key",
+            "token",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Specify at least one" in result.stdout
+
+
+def test_apps_update_sets_auth_flag(runner: CliRunner):
+    existing_app = _make_app()
+    updated_app = _make_app(unauthenticated=True)
+
+    mock_client = AsyncMock()
+    mock_client.update_app.return_value = updated_app
+
+    with (
+        patch(
+            "mcp_agent.cli.cloud.commands.apps.update.main.MCPAppClient",
+            return_value=mock_client,
+        ),
+        patch(
+            "mcp_agent.cli.cloud.commands.apps.update.main.resolve_server",
+            return_value=existing_app,
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "apps",
+                "update",
+                existing_app.appId,
+                "--no-auth",
+                "--api-key",
+                "token",
+                "--api-url",
+                "http://api",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    update_kwargs = mock_client.update_app.await_args.kwargs
+    assert update_kwargs["unauthenticated_access"] is True
+    assert "Unauthenticated access allowed" in result.stdout
+
+
+def test_apps_update_accepts_configuration_identifier(runner: CliRunner):
+    base_app = _make_app()
+    config = MCPAppConfiguration(
+        appConfigurationId="apcnf_12345678-1234-1234-1234-1234567890ab",
+        app=base_app,
+        creatorId="u_12345678-1234-1234-1234-1234567890ab",
+    )
+    updated_app = _make_app()
+    updated_app.description = "Updated description"
+
+    mock_client = AsyncMock()
+    mock_client.update_app.return_value = updated_app
+
+    with (
+        patch(
+            "mcp_agent.cli.cloud.commands.apps.update.main.MCPAppClient",
+            return_value=mock_client,
+        ),
+        patch(
+            "mcp_agent.cli.cloud.commands.apps.update.main.resolve_server",
+            return_value=config,
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "apps",
+                "update",
+                config.appConfigurationId,
+                "--description",
+                "Updated description",
+                "--api-key",
+                "token",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    update_kwargs = mock_client.update_app.await_args.kwargs
+    assert update_kwargs["description"] == "Updated description"
+    assert update_kwargs["app_id"] == base_app.appId
+    assert "Description: Updated description" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -2029,7 +2029,7 @@ wheels = [
 
 [[package]]
 name = "mcp-agent"
-version = "0.1.32"
+version = "0.1.33"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
* Add a --no-auth flag to the deploy command to enable an unauthenticated app deployment
* Add an `update` command (`mcp-agent cloud apps update`) to toggle auth, name, description, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New “apps update” CLI command to modify app name, description, and authentication requirement.
  * Deploy command now supports --no-auth/--auth to control unauthenticated access and can update existing apps accordingly.
  * Post-deploy output now clearly shows the app’s authentication status.

* **Style**
  * Minor formatting improvement to a verbose deploy log message.

* **Tests**
  * Added coverage for the new apps update command and deploy authentication flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->