### PR TITLE
use the API base URL from settings

### DIFF
--- a/src/mcp_agent/cli/cloud/commands/utils.py
+++ b/src/mcp_agent/cli/cloud/commands/utils.py
@@ -6,7 +6,6 @@ from typing import Union
 from mcp_agent.cli.auth import load_api_key_credentials
 from mcp_agent.cli.config import settings
 from mcp_agent.cli.core.api_client import UnauthenticatedError
-from mcp_agent.cli.core.constants import DEFAULT_API_BASE_URL
 from mcp_agent.cli.core.utils import run_async
 from mcp_agent.cli.exceptions import CLIError
 from mcp_agent.cli.mcp_app.api_client import (
@@ -34,7 +33,7 @@ def setup_authenticated_client() -> MCPAppClient:
             retriable=False,
         )
 
-    return MCPAppClient(api_url=DEFAULT_API_BASE_URL, api_key=effective_api_key)
+    return MCPAppClient(api_url=settings.API_BASE_URL, api_key=effective_api_key)
 
 
 def validate_output_format(format: str) -> None:


### PR DESCRIPTION
### TL;DR

Updated the `setup_authenticated_client` function to use the API base URL from settings instead of the default constant. This ensures that ENV var substitution works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - Updated API URL configuration to use dynamic settings instead of a hard-coded constant, improving system flexibility and configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->