### PR TITLE
Support `cwd` configuration for stdio mcp servers

### DIFF
--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -745,6 +745,19 @@
           "type": "array",
           "description": "The arguments for the server command in stdio mode."
         },
+        "cwd": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cwd",
+          "description": "The working directory to use when spawning the server process in stdio mode."
+        },
         "url": {
           "anyOf": [
             {

--- a/src/mcp_agent/cli/commands/server.py
+++ b/src/mcp_agent/cli/commands/server.py
@@ -304,6 +304,8 @@ def _persist_server_entry(name: str, settings: MCPServerSettings) -> None:
             entry["args"] = settings.args
         if settings.env:
             entry["env"] = settings.env
+        if settings.cwd:
+            entry["cwd"] = settings.cwd
     else:
         if settings.url:
             entry["url"] = settings.url
@@ -431,6 +433,9 @@ def add(
     env: Optional[str] = typer.Option(
         None, "--env", "-e", help="Environment variables (KEY=value,...)"
     ),
+    cwd: Optional[str] = typer.Option(
+        None, "--cwd", help="Working directory for stdio server process"
+    ),
     write: bool = typer.Option(
         True, "--write/--no-write", help="Persist to config file"
     ),
@@ -505,6 +510,7 @@ def add(
         entry.command = recipe.get("command")
         entry.args = recipe.get("args", [])
         entry.env = {**recipe.get("env", {}), **env_dict}
+        entry.cwd = recipe.get("cwd")
 
         srv_name = name or value
 
@@ -619,6 +625,7 @@ def add(
         entry.command = parts[0]
         entry.args = parts[1:] if len(parts) > 1 else []
         entry.env = env_dict
+        entry.cwd = cwd
         srv_name = name or parts[0].split("/")[-1]
 
     # Check if server already exists
@@ -853,6 +860,7 @@ def import_claude(
                             entry.command = server_config.get("command", "")
                             entry.args = server_config.get("args", [])
                             entry.env = server_config.get("env", {})
+                            entry.cwd = server_config.get("cwd")
                             _persist_server_entry(name, entry)
                         console.print(
                             f"\n[green]✅ Imported {len(servers)} servers[/green]"

--- a/src/mcp_agent/cli/core/utils.py
+++ b/src/mcp_agent/cli/core/utils.py
@@ -170,5 +170,6 @@ def attach_stdio_servers(
             transport="stdio",
             command=desc.get("command"),
             args=desc.get("args", []),
+            cwd=desc.get("cwd"),
         )
         app.context.config.mcp.servers[name] = settings

--- a/src/mcp_agent/cli/utils/importers.py
+++ b/src/mcp_agent/cli/utils/importers.py
@@ -28,6 +28,7 @@ def _to_settings(obj: dict) -> MCPServerSettings:
             command=obj.get("command"),
             args=obj.get("args") or [],
             env=obj.get("env") or None,
+            cwd=obj.get("cwd") or None,
         )
     else:
         return MCPServerSettings(

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -78,6 +78,9 @@ class MCPServerSettings(BaseModel):
     args: List[str] = Field(default_factory=list)
     """The arguments for the server command in stdio mode."""
 
+    cwd: str | None = None
+    """The working directory to use when spawning the server process in stdio mode."""
+
     url: str | None = None
     """The URL for the server for SSE, Streamble HTTP or websocket transport."""
 

--- a/src/mcp_agent/mcp/mcp_connection_manager.py
+++ b/src/mcp_agent/mcp/mcp_connection_manager.py
@@ -442,6 +442,7 @@ class MCPConnectionManager(ContextDependent):
                     command=config.command,
                     args=config.args or [],
                     env={**get_default_environment(), **(config.env or {})},
+                    cwd=config.cwd or None,
                 )
                 # Create stdio client config with redirected stderr
                 return stdio_client(server=server_params)

--- a/src/mcp_agent/mcp/mcp_server_registry.py
+++ b/src/mcp_agent/mcp/mcp_server_registry.py
@@ -153,6 +153,7 @@ class ServerRegistry:
                 command=config.command,
                 args=config.args or [],
                 env={**get_default_environment(), **(config.env or {})},
+                cwd=config.cwd or None,
             )
 
             async with stdio_client(server_params) as (read_stream, write_stream):


### PR DESCRIPTION
Recently I've been trying to use mcp-agent with [ck](https://github.com/BeaconBay/ck) which requires to set cwd for serving as mcp server.

However, I noticed that the framework do provide such parameter in `StdioServerParameters` but the upper layers of the framework does not pass down this arg.

Therefore I made some small modifications so that, now we can support this `cwd` arg by either using `yaml` configurations or using dynamic code style with `MCPServerSettings`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--cwd` command-line option to specify a working directory when adding new servers
  * Server working directory configuration is now persisted in settings
  * Added support for working directory configuration in server recipe imports and configuration files
  * Server processes launched in stdio mode now support explicit working directory specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->