### PR TITLE
Update cloud example requirements to specify 'mcp-agent[cli]'

### DIFF
--- a/examples/cloud/chatgpt_app/requirements.txt
+++ b/examples/cloud/chatgpt_app/requirements.txt
@@ -1,2 +1,2 @@
 # Core framework dependency
-mcp-agent @ file://../../../  # Link to the local mcp-agent project root
+mcp-agent[cli] @ file://../../../  # Link to the local mcp-agent project root

--- a/examples/cloud/hello_world/requirements.txt
+++ b/examples/cloud/hello_world/requirements.txt
@@ -1,2 +1,2 @@
 # Core framework dependency
-mcp-agent @ file://../../..  # Link to the local mcp-agent project root
+mcp-agent[cli] @ file://../../..  # Link to the local mcp-agent project root

--- a/examples/cloud/mcp/requirements.txt
+++ b/examples/cloud/mcp/requirements.txt
@@ -1,4 +1,4 @@
 # Core framework dependency
-mcp-agent @ file://../../../  # Link to the local mcp-agent project root
+mcp-agent[cli] @ file://../../../  # Link to the local mcp-agent project root
 
 openai>=1.0.0

--- a/examples/cloud/temporal/requirements.txt
+++ b/examples/cloud/temporal/requirements.txt
@@ -1,5 +1,5 @@
 # Core framework dependency
-mcp-agent @ file://../../../  # Link to the local mcp-agent project root
+mcp-agent[cli] @ file://../../../  # Link to the local mcp-agent project root
 
 # Additional dependencies specific to this example
 openai


### PR DESCRIPTION
`uv run mcp-agent login` fails if user runs example without installing mcp-agent optional dependencies prior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mcp-agent package dependencies to include CLI extras across example projects. This configuration update has been applied consistently to chatgpt_app, hello_world, mcp, and temporal examples. The changes ensure unified dependency specifications and enhanced CLI functionality support across all example implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->