### PR TITLE
Fix coroutine 'MCPAppClient.get_app_by_name' was never awaited

### DIFF
--- a/src/mcp_agent/cli/mcp_app/api_client.py
+++ b/src/mcp_agent/cli/mcp_app/api_client.py
@@ -386,7 +386,7 @@ class MCPAppClient(APIClient):
             httpx.HTTPStatusError: If the API returns an error
             httpx.HTTPError: If the request fails
         """
-        app = self.get_app_by_name(name)
+        app = await self.get_app_by_name(name)
         return app.appId if app else None
 
     async def deploy_app(


### PR DESCRIPTION
`uvx mcp-agent cloud servers describe my-agent` fails as coroutine 'MCPAppClient.get_app_by_name' was never awaited

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an async operation issue in the app ID retrieval function to ensure proper coroutine handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->