### PR TITLE
Fix azure openai response format type

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_azure.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_azure.py
@@ -39,6 +39,10 @@ from openai import (
     UnprocessableEntityError as AzureOpenAIUnprocessableEntityError,
 )
 from openai.types.chat import ChatCompletion
+from openai.types.shared_params.response_format_json_schema import (
+    JSONSchema,
+    ResponseFormatJSONSchema,
+)
 
 from mcp.types import (
     CallToolRequestParams,
@@ -643,6 +647,14 @@ class AzureOpenAICompletionTasks:
             return model and model.startswith(("gpt-5", "gpt-o1", "gpt-o3", "gpt-o4"))
 
         payload = request.payload.copy()
+
+        # We must properly serialize response_format with type param for the OpenAI client
+        response_format = payload.get("response_format")
+        if response_format and isinstance(response_format, JsonSchemaFormat):
+            payload["response_format"] = ResponseFormatJSONSchema(
+                json_schema=JSONSchema(**response_format),
+                type="json_schema",
+            )
 
         # Handle reasoning models
         if _openai_reasoning(payload.get("model")):


### PR DESCRIPTION
## Summary
While looking into https://github.com/lastmile-ai/mcp-eval/issues/50 I was hitting this error:
```py
raise to_application_error(\nmcp_agent.executor.errors.WorkflowApplicationError: invalid_request_error: Error code: 400 - {'error': {'message': \"Missing required parameter: 'response_format.type'.\", 'type': 'invalid_request_error', 'param': 'response_format.type', 'code': 'missing_required_parameter'}}\n",
```

The reason is that the structured output generation is using the Azure AI client's `JsonSchemaFormat` which does not fully match the structured json schema request format expected by the OpenAI Azure client. To fix, just properly serialize to the OpenAI format (key addition is the `type` field).

## Testing
```bash
make lint
make format
make tests
```

In `examples/tracing/llm` configure the Azure secrets. In `main.py`, un-comment the azure example and then run `main.py` to see the tracing and successful logging of structured outputs:
```jsonl
{"level":"INFO","timestamp":"2025-11-18T19:35:50.968835","namespace":"mcp_agent.llm_tracing_example","message":"azure_llm structured result","data":{"data":{"countries":{"Spain":{"capital":"Madrid","population":47450795},"Portugal":{"capital":"Lisbon","population":10196709},"Italy":{"capital":"Rome","population":60244639}}}}}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure OpenAI integration to correctly handle and serialize JSON schema format responses, ensuring proper compatibility with the OpenAI client for structured output requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->