### PR TITLE
feat(openai): add per-request reasoning_effort override for GPT-5.1

### DIFF
--- a/examples/basic/functions/main.py
+++ b/examples/basic/functions/main.py
@@ -6,6 +6,7 @@ from mcp_agent.core.context import Context
 from mcp_agent.app import MCPApp
 from mcp_agent.agents.agent import Agent
 from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+from mcp_agent.workflows.llm.augmented_llm import RequestParams
 
 
 def add_numbers(a: int, b: int) -> int:
@@ -44,6 +45,7 @@ async def calculate(expr: str, app_ctx: Optional[Context] = None) -> str:
         llm = await math_agent.attach_llm(OpenAIAugmentedLLM)
         result = await llm.generate_str(
             message=expr,
+            request_params=RequestParams(model="gpt-5.1", reasoning_effort="none"),
         )
 
         logger.info(f"Expert math result: {result}")

--- a/schema/mcp-agent.config.schema.json
+++ b/schema/mcp-agent.config.schema.json
@@ -1331,6 +1331,7 @@
         "reasoning_effort": {
           "default": "medium",
           "enum": [
+            "none",
             "low",
             "medium",
             "high"

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -418,7 +418,7 @@ class OpenAISettings(BaseSettings):
         validation_alias=AliasChoices("api_key", "OPENAI_API_KEY", "openai__api_key"),
     )
 
-    reasoning_effort: Literal["low", "medium", "high"] = Field(
+    reasoning_effort: Literal["none", "low", "medium", "high"] = Field(
         default="medium",
         validation_alias=AliasChoices(
             "reasoning_effort", "OPENAI_REASONING_EFFORT", "openai__reasoning_effort"

--- a/src/mcp_agent/workflows/llm/augmented_llm.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm.py
@@ -12,6 +12,7 @@ from typing import (
     TypeVar,
     Union,
     TYPE_CHECKING,
+    Literal,
 )
 
 from opentelemetry import trace
@@ -193,6 +194,13 @@ class RequestParams(CreateMessageRequestParams):
         - None - No filtering applied (default behavior)
 
     Tool names should match exactly as they appear in the server's tool list.
+    """
+
+    reasoning_effort: Optional[Literal["none", "low", "medium", "high"]] = None
+    """
+    (OpenAI only) Controls the reasoning effort for o1/o3/o4/gpt-5/gpt-5.1 models.
+    Valid values: 'none', 'low', 'medium', 'high'
+    Ignored by other providers.
     """
 
 

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -277,7 +277,8 @@ class OpenAIAugmentedLLM(
                         # DEPRECATED: https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens
                         # "max_tokens": params.maxTokens,
                         "max_completion_tokens": params.maxTokens,
-                        "reasoning_effort": self._reasoning_effort,
+                        "reasoning_effort": params.reasoning_effort
+                        or self._reasoning_effort,
                     }
                 else:
                     arguments = {**arguments, "max_tokens": params.maxTokens}
@@ -558,7 +559,9 @@ class OpenAIAugmentedLLM(
                 # DEPRECATED: https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens
                 # "max_tokens": params.maxTokens,
                 payload["max_completion_tokens"] = params.maxTokens
-                payload["reasoning_effort"] = self._reasoning_effort
+                payload["reasoning_effort"] = (
+                    params.reasoning_effort or self._reasoning_effort
+                )
             else:
                 payload["max_tokens"] = params.maxTokens
             user = params.user or getattr(self.context.config.openai, "user", None)


### PR DESCRIPTION
## Summary

Add per-request `reasoning_effort` parameter override to support mixing reasoning and non-reasoning modes in multi-agent applications with GPT-5.1.

## Problem

With GPT-5.1's release, OpenAI added `reasoning_effort='none'` for non-reasoning mode. However, mcp-agent only supported one global `reasoning_effort` setting per application.

**Real-world issue:**
- My multi-agent project uses GPT-5 with reasoning for analysis agents
- Simple utility agents used GPT-4.1 for fast responses
- When upgrading utility agents to GPT-5.1, the global `reasoning_effort` setting created conflicts
- Couldn't use GPT-5.1 with `reasoning_effort='none'` for some agents and `reasoning_effort='high'` for others

## Solution

Allow `reasoning_effort` to be set per-request via `RequestParams`, with fallback to config default.

**Usage:**
```python
# Complex reasoning
await llm.generate_str(
    message="Analyze...",
    request_params=RequestParams(
        model="gpt-5.1",
        reasoning_effort="high"
    )
)

# Fast, no reasoning
await llm.generate_str(
    message="Format...",
    request_params=RequestParams(
        model="gpt-5.1",
        reasoning_effort="none"
    )
)
```

## Changes

- Add `reasoning_effort` field to `RequestParams` with `Literal["none", "low", "medium", "high"]`
- Support `'none'` value in `OpenAISettings` config
- Implement fallback: request param → config → default (`'medium'`)
- Add 5 unit tests (145+ lines)
- Update example demonstrating GPT-5.1 with `reasoning_effort='none'`
- Update JSON schema

## Testing

- [x] `make format` - passed
- [x] `make lint` - passed
- [x] `make schema` - updated
- [x] Added 5 comprehensive test cases
- [x] All existing tests pass

## Backward Compatibility

✅ Fully backward compatible - existing applications work without changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "none" as a new reasoning effort option (in addition to "low", "medium", "high").
  * Enabled per-request override of reasoning effort settings, allowing individual requests to specify their own reasoning effort independent of the default configuration.

* **Tests**
  * Added comprehensive test coverage for reasoning effort behavior across different model types and configuration scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->