### PR TITLE
Add deployed config to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,10 @@ cython_debug/
 # but make sure example files are
 !examples/**/*.secrets.yaml.example
 
+# For our repo, ignore deployed configs (e.g. from examples)
+# For your own projects, you likely won't want to ignore these
+**/mcp_agent.deployed.config.yaml
+
 # Test data files
 examples/mcp/mcp_roots/test_data/*.png
 


### PR DESCRIPTION
## Summary
When running any of the examples, the deployed config file will be tracked by git. For end users using mcp-agent, they likely _will_ want to track their deployed config files in their repos, but for the mcp-agent repo we should ignore them to prevent unintentionally committing them.

## Testing
`cd examples/cloud/mcp` `uv run mcp-agent deploy cloud_mcp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude deployed configuration files from version control tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->