### PR TITLE
Add AugmentedLLM for LM Studio

### DIFF
--- a/examples/lm_studio/README.md
+++ b/examples/lm_studio/README.md
@@ -1,0 +1,126 @@
+# LM Studio Basic Agent Example
+
+This example demonstrates using **LM Studio** with mcp-agent to run local LLMs with full tool calling and structured output support.
+
+## Architecture
+
+```plaintext
+┌──────────────┐      ┌──────────────┐
+│  LM Studio   │──────▶│  Filesystem  │
+│  Agent       │      │  MCP Server  │
+└──────────────┘      └──────────────┘
+       │
+       │ OpenAI-compatible API
+       ▼
+┌──────────────┐
+│  LM Studio   │
+│  Local       │
+│  http://     │
+│  localhost   │
+│  :1234       │
+└──────────────┘
+```
+
+The agent uses the filesystem MCP server to read and analyze local files, with all LLM inference happening locally through LM Studio.
+
+## Prerequisites
+
+### 1. Install LM Studio
+
+Download and install LM Studio from [https://lmstudio.ai](https://lmstudio.ai)
+
+### 2. Download and Load a Model
+
+1. Open LM Studio
+2. Go to the "Search" tab
+3. Search for and download: **`openai/gpt-oss-20b`**
+4. Once downloaded, go to the "Chat" tab
+5. Load the model by selecting it from the dropdown
+
+### 3. Start the LM Studio Server
+
+1. In LM Studio, go to the "Developer" tab (or "Local Server" section)
+2. Click "Start Server"
+3. The server should start at `http://localhost:1234`
+4. Verify it's running by visiting `http://localhost:1234/v1/models` in your browser
+
+## Setup
+
+### 1. Clone and Navigate
+
+```bash
+git clone https://github.com/lastmile-ai/mcp-agent.git
+cd mcp-agent/examples/lm_studio
+```
+
+### 2. Install Dependencies
+
+Install `uv` (if you don't have it):
+
+```bash
+pip install uv
+```
+
+Install dependencies:
+
+```bash
+uv pip install -r requirements.txt
+```
+
+### 3. Configuration
+
+The example uses `mcp_agent.config.yaml` which is already configured for LM Studio:
+
+```yaml
+lm_studio:
+  # base_url defaults to http://localhost:1234/v1
+  default_model: "openai/gpt-oss-20b"
+```
+
+**No API keys needed!** LM Studio runs locally and doesn't require authentication.
+
+## Running the Example
+
+With LM Studio running and the model loaded:
+
+```bash
+uv run main.py
+```
+
+## Expected Output
+
+You should see output like:
+
+```
+INFO - Starting LM Studio example...
+INFO - LM Studio config: {'api_key': 'lm-studio', 'base_url': 'http://localhost:1234/v1', 'default_model': 'openai/gpt-oss-20b'}
+INFO - Agent has 3 tools available: ['read_file', 'read_multiple_files', 'list_directory']
+
+--- Example 1: Reading config file ---
+INFO - Agent response: The mcp_agent.config.yaml file configures one MCP server: filesystem...
+
+--- Example 2: Listing files ---
+INFO - Agent response: Found 1 Python file in the current directory: main.py...
+
+--- Example 3: Multi-turn conversation ---
+INFO - Turn 1 response: The main Python file is main.py
+INFO - Turn 2 response: This file demonstrates using LM Studio with mcp-agent...
+
+--- Example completed successfully! ---
+INFO - Token usage summary: {...}
+```
+
+## Switching to Other Models
+
+You can use any model loaded in LM Studio. Just update `mcp_agent.config.yaml`:
+
+```yaml
+lm_studio:
+  default_model: "your-model-identifier"
+```
+
+## Additional Resources
+
+- [LM Studio Documentation](https://lmstudio.ai/docs)
+- [mcp-agent Documentation](https://docs.mcp-agent.com)
+- [MCP Protocol](https://modelcontextprotocol.io)

--- a/examples/lm_studio/main.py
+++ b/examples/lm_studio/main.py
@@ -1,0 +1,147 @@
+"""
+LM Studio Basic Agent Example
+
+This example demonstrates using LM Studio with mcp-agent to run local models.
+It shows:
+- Connecting to LM Studio's local server
+- Using the filesystem MCP server for tool calling
+- Running queries with the openai/gpt-oss-20b model
+- Multi-turn conversations with context
+
+Prerequisites:
+1. Install and run LM Studio (https://lmstudio.ai)
+2. Download and load the openai/gpt-oss-20b model in LM Studio
+3. Start the LM Studio server (default: http://localhost:1234)
+"""
+
+import asyncio
+import os
+
+from mcp_agent.app import MCPApp
+from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm_lm_studio import LMStudioAugmentedLLM
+
+# Create the app - configuration will be loaded from mcp_agent.config.yaml
+app = MCPApp(name="lmstudio_basic_agent")
+
+
+async def example_usage():
+    """
+    Example showing LM Studio agent using filesystem tools.
+    """
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+        context = agent_app.context
+
+        logger.info("Starting LM Studio example...")
+        logger.info("LM Studio config:", data=context.config.lm_studio.model_dump())
+
+        # Add the current directory to the filesystem server
+        context.config.mcp.servers["filesystem"].args.extend([os.getcwd()])
+
+        # Create an agent with filesystem access
+        file_agent = Agent(
+            name="file_explorer",
+            instruction="""You are a helpful assistant with access to the local filesystem.
+            You can read files, list directories, and answer questions about file contents.
+            Always be clear about what files you're accessing.""",
+            server_names=["filesystem"],
+        )
+
+        async with file_agent:
+            tools = await file_agent.list_tools()
+            logger.info(
+                f"Agent has {len(tools.tools)} tools available:",
+                data=[tool.name for tool in tools.tools],
+            )
+
+            llm = await file_agent.attach_llm(LMStudioAugmentedLLM)
+            logger.info(
+                f"Using LM Studio with model: {context.config.lm_studio.default_model}"
+            )
+
+            logger.info("\n--- Example 1: Reading config file ---")
+            result = await llm.generate_str(
+                "Read the mcp_agent.config.yaml file and tell me what MCP servers are configured."
+            )
+            logger.info("Agent response:", data=result)
+
+            logger.info("\n--- Example 2: Listing files ---")
+            result = await llm.generate_str(
+                "List all Python files (.py) in the current directory and tell me what they are."
+            )
+            logger.info("Agent response:", data=result)
+
+            logger.info("\n--- Example 3: Multi-turn conversation ---")
+            result = await llm.generate_str(
+                "What is the name of the main Python file in this directory?"
+            )
+            logger.info("Turn 1 response:", data=result)
+
+            result = await llm.generate_str(
+                "Can you read that file and summarize what it does in 2 sentences?"
+            )
+            logger.info("Turn 2 response:", data=result)
+
+            logger.info("\n--- Example completed successfully! ---")
+
+
+async def structured_output_example():
+    """
+    Example showing structured outputs with LM Studio.
+    """
+    from pydantic import BaseModel
+    from typing import List
+
+    class FileInfo(BaseModel):
+        """Information about files in a directory."""
+
+        file_names: List[str]
+        file_count: int
+        has_readme: bool
+
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+        context = agent_app.context
+
+        logger.info("\n--- Structured Output Example ---")
+
+        context.config.mcp.servers["filesystem"].args.extend([os.getcwd()])
+
+        agent = Agent(
+            name="structured_agent",
+            instruction="You analyze directories and return structured information.",
+            server_names=["filesystem"],
+        )
+
+        async with agent:
+            llm = await agent.attach_llm(LMStudioAugmentedLLM)
+
+            result = await llm.generate_structured(
+                message="List all files in the current directory and tell me if there's a README file.",
+                response_model=FileInfo,
+            )
+
+            logger.info("Structured response:", data=result.model_dump())
+            logger.info(f"Found {result.file_count} files")
+            logger.info(f"Has README: {result.has_readme}")
+
+
+async def main():
+    """
+    Main entry point - runs all examples.
+    """
+    try:
+        await example_usage()
+        await structured_output_example()
+
+    except Exception as e:
+        print(f"\nError: {e}")
+        print("\nMake sure:")
+        print("1. LM Studio is running (http://localhost:1234)")
+        print("2. You have loaded the openai/gpt-oss-20b model")
+        raise
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/lm_studio/main.py
+++ b/examples/lm_studio/main.py
@@ -89,6 +89,8 @@ async def example_usage():
 async def structured_output_example():
     """
     Example showing structured outputs with LM Studio.
+    Important: Not all models are capable of structured output, particularly LLMs below 7B parameters.
+    Check the model card README if you are unsure if the model supports structured output.
     """
     from pydantic import BaseModel
     from typing import List

--- a/examples/lm_studio/mcp_agent.config.yaml
+++ b/examples/lm_studio/mcp_agent.config.yaml
@@ -14,7 +14,7 @@ mcp:
   servers:
     filesystem:
       command: "npx"
-      args: ["-y", "@modelcontextprotocol/server-filesystem"]
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "."]
 
 lm_studio:
   # base_url defaults to http://localhost:1234/v1

--- a/examples/lm_studio/mcp_agent.config.yaml
+++ b/examples/lm_studio/mcp_agent.config.yaml
@@ -3,7 +3,7 @@ $schema: ../../schema/mcp-agent.config.schema.json
 execution_engine: asyncio
 logger:
   transports: [console, file]
-  level: debug
+  level: info
   progress_display: true
   path_settings:
     path_pattern: "logs/lmstudio-agent-{unique_id}.jsonl"

--- a/examples/lm_studio/mcp_agent.config.yaml
+++ b/examples/lm_studio/mcp_agent.config.yaml
@@ -1,0 +1,21 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  transports: [console, file]
+  level: debug
+  progress_display: true
+  path_settings:
+    path_pattern: "logs/lmstudio-agent-{unique_id}.jsonl"
+    unique_id: "timestamp"
+    timestamp_format: "%Y%m%d_%H%M%S"
+
+mcp:
+  servers:
+    filesystem:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-filesystem"]
+
+lm_studio:
+  # base_url defaults to http://localhost:1234/v1
+  default_model: "openai/gpt-oss-20b"

--- a/examples/lm_studio/requirements.txt
+++ b/examples/lm_studio/requirements.txt
@@ -1,0 +1,5 @@
+# Core framework dependency
+mcp-agent @ file://../../  # Link to the local mcp-agent project root
+
+# Additional dependencies specific to this example
+openai

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -458,6 +458,48 @@ class OpenAISettings(BaseSettings):
     )
 
 
+class LMStudioSettings(OpenAISettings):
+    """
+    Settings for using LM Studio local LLM server.
+
+    Extends OpenAISettings since LM Studio provides an OpenAI-compatible API.
+    Inherits all OpenAI fields (user, default_headers, reasoning_effort, etc.)
+    but overrides defaults for local usage.
+
+    Note: api_key is automatically set to "lm-studio" for compatibility.
+    """
+
+    api_key: str | None = Field(
+        default="lm-studio",
+        description="API key for OpenAI client compatibility (automatically set, no configuration needed)",
+        validation_alias=AliasChoices(
+            "api_key", "LM_STUDIO_API_KEY", "lm_studio__api_key"
+        ),
+    )
+
+    base_url: str | None = Field(
+        default="http://localhost:1234/v1",
+        validation_alias=AliasChoices(
+            "base_url", "LM_STUDIO_BASE_URL", "lm_studio__base_url"
+        ),
+    )
+
+    default_model: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "default_model", "LM_STUDIO_DEFAULT_MODEL", "lm_studio__default_model"
+        ),
+    )
+
+    model_config = SettingsConfigDict(
+        env_prefix="LM_STUDIO_",
+        extra="allow",
+        arbitrary_types_allowed=True,
+        env_file=".env",
+        env_file_encoding="utf-8",
+    )
+
+
 class AzureSettings(BaseSettings):
     """
     Settings for using Azure models in the MCP Agent application.
@@ -1130,6 +1172,9 @@ class Settings(BaseSettings):
 
     openai: OpenAISettings | None = Field(default_factory=OpenAISettings)
     """Settings for using OpenAI models in the MCP Agent application"""
+
+    lm_studio: LMStudioSettings | None = Field(default_factory=LMStudioSettings)
+    """Settings for using LM Studio models in the MCP Agent application"""
 
     workflow_task_modules: List[str] = Field(default_factory=list)
     """Optional list of modules to import at startup so workflow tasks register globally."""

--- a/src/mcp_agent/workflows/llm/augmented_llm_lm_studio.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_lm_studio.py
@@ -1,0 +1,29 @@
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+
+class LMStudioAugmentedLLM(OpenAIAugmentedLLM):
+    """
+    LM Studio implementation using OpenAI-compatible API.
+
+    LM Studio provides full OpenAI API compatibility at http://localhost:1234/v1
+    including chat completions, tool calling, and structured outputs.
+
+    This implementation extends OpenAIAugmentedLLM directly since LM Studio's API
+    is fully compatible with OpenAI's chat completions endpoint.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Override provider name for logging and telemetry
+        self.provider = "LM Studio"
+
+    @classmethod
+    def get_provider_config(cls, context):
+        """
+        Get LM Studio configuration from context.
+
+        Returns the lm_studio settings instead of openai settings,
+        allowing separate configuration for LM Studio.
+        """
+        return getattr(getattr(context, "config", None), "lm_studio", None)

--- a/src/mcp_agent/workflows/llm/augmented_llm_lm_studio.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_lm_studio.py
@@ -1,3 +1,6 @@
+from typing import Type
+
+from mcp_agent.workflows.llm.augmented_llm import ModelT, RequestParams
 from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
 
 
@@ -7,9 +10,6 @@ class LMStudioAugmentedLLM(OpenAIAugmentedLLM):
 
     LM Studio provides full OpenAI API compatibility at http://localhost:1234/v1
     including chat completions, tool calling, and structured outputs.
-
-    This implementation extends OpenAIAugmentedLLM directly since LM Studio's API
-    is fully compatible with OpenAI's chat completions endpoint.
     """
 
     def __init__(self, *args, **kwargs):
@@ -17,6 +17,39 @@ class LMStudioAugmentedLLM(OpenAIAugmentedLLM):
 
         # Override provider name for logging and telemetry
         self.provider = "LM Studio"
+
+    async def generate_structured(
+        self,
+        message,
+        response_model: Type[ModelT],
+        request_params: RequestParams | None = None,
+    ) -> ModelT:
+        """
+        Generate structured output. For structured outputs with tool calling (unsupported by API),
+        uses a two-step approach:
+        1. Generate response with tool calls (get real data)
+        2. Generate structured output response
+        """
+        text_response = await self.generate_str(
+            message=message,
+            request_params=request_params,
+        )
+
+        format_prompt = f"""Based on the following information, provide a response in JSON format.
+
+Information:
+{text_response}
+
+Return ONLY valid JSON matching this exact structure. Do not include any explanation or additional text."""
+
+        # Use openai's native structured output
+        result = await super().generate_structured(
+            message=format_prompt,
+            response_model=response_model,
+            request_params=request_params,
+        )
+
+        return result
 
     @classmethod
     def get_provider_config(cls, context):

--- a/src/mcp_agent/workflows/llm/augmented_llm_lm_studio.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_lm_studio.py
@@ -18,6 +18,24 @@ class LMStudioAugmentedLLM(OpenAIAugmentedLLM):
         # Override provider name for logging and telemetry
         self.provider = "LM Studio"
 
+    async def select_model(
+        self, request_params: RequestParams | None = None
+    ) -> str | None:
+        """
+        Select model for LM Studio, prioritizing config default_model over benchmarks.
+        """
+        # Check request_params first
+        if request_params and request_params.model:
+            return request_params.model
+
+        # Check LM Studio config default_model
+        lm_studio_config = self.get_provider_config(self.context)
+        if lm_studio_config and lm_studio_config.default_model:
+            return lm_studio_config.default_model
+
+        # Fall back to parent's model selection (benchmarks)
+        return await super().select_model(request_params)
+
     async def generate_structured(
         self,
         message,
@@ -42,7 +60,6 @@ Information:
 
 Return ONLY valid JSON matching this exact structure. Do not include any explanation or additional text."""
 
-        # Use openai's native structured output
         result = await super().generate_structured(
             message=format_prompt,
             response_model=response_model,

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -291,7 +291,7 @@ class OpenAIAugmentedLLM(
                 self._log_chat_progress(chat_turn=len(messages) // 2, model=model)
 
                 request = RequestCompletionRequest(
-                    config=self.context.config.openai,
+                    config=self.get_provider_config(self.context),
                     payload=arguments,
                 )
 
@@ -572,7 +572,7 @@ class OpenAIAugmentedLLM(
             completion: ChatCompletion = await self.executor.execute(
                 OpenAICompletionTasks.request_completion_task,
                 RequestCompletionRequest(
-                    config=self.context.config.openai, payload=payload
+                    config=self.get_provider_config(self.context), payload=payload
                 ),
             )
 

--- a/tests/workflows/llm/test_augmented_llm_lm_studio.py
+++ b/tests/workflows/llm/test_augmented_llm_lm_studio.py
@@ -1,0 +1,70 @@
+import pytest
+from unittest.mock import MagicMock
+
+from mcp_agent.config import LMStudioSettings
+from mcp_agent.workflows.llm.augmented_llm_lm_studio import LMStudioAugmentedLLM
+
+
+class TestLMStudioAugmentedLLM:
+    """
+    Tests for the LMStudioAugmentedLLM class.
+    """
+
+    @pytest.fixture
+    def mock_llm(self, mock_context):
+        """
+        Creates a mock LM Studio LLM instance with common mocks set up.
+        """
+        mock_context.config.lm_studio = LMStudioSettings(
+            default_model=None,
+            base_url="http://localhost:1234/v1",
+        )
+
+        llm = LMStudioAugmentedLLM(name="test", context=mock_context)
+        llm.history = MagicMock()
+        llm.history.get = MagicMock(return_value=[])
+        llm.history.set = MagicMock()
+
+        return llm
+
+    def test_initialization(self, mock_llm):
+        """
+        Test that LMStudioAugmentedLLM initializes correctly.
+        """
+        assert mock_llm.name == "test"
+        assert mock_llm.provider == "LM Studio"
+
+    def test_get_provider_config(self, mock_context):
+        """
+        Test that get_provider_config returns the lm_studio config.
+        """
+        mock_context.config.lm_studio = LMStudioSettings(
+            base_url="http://localhost:1234/v1",
+        )
+
+        config = LMStudioAugmentedLLM.get_provider_config(mock_context)
+
+        assert config is not None
+        assert config.base_url == "http://localhost:1234/v1"
+
+    def test_default_settings(self):
+        """
+        Test that LMStudioSettings has correct defaults.
+        """
+        settings = LMStudioSettings()
+
+        assert settings.base_url == "http://localhost:1234/v1"
+        assert settings.default_model is None
+
+    def test_api_key_injection(self, mock_context):
+        """
+        Test that api_key is injected automatically during initialization.
+        """
+        mock_context.config.lm_studio = LMStudioSettings(
+            base_url="http://localhost:1234/v1",
+        )
+
+        llm = LMStudioAugmentedLLM(name="test", context=mock_context)
+
+        assert hasattr(llm.context.config.lm_studio, "api_key")
+        assert llm.context.config.lm_studio.api_key == "lm-studio"


### PR DESCRIPTION
## Summary
As requested in #596, this PR adds basic support for LM Studio models by leveraging the [OpenAI Compatibility Endpoints](https://lmstudio.ai/docs/developer/openai-compat#openai-compatibility-endpoints) supported by LM Studio, extending the AugmentedLLMOpenAI to use the endpoints with overridden base url pointing to local LM Studio server.

A couple notes:
- The LM Studio api does not support tool calling combined with structured output so we handle `generate_structured` as 2 calls --> one to generate with tool calling, one to generate structured with the response model
- We override the model selection to prioritize the default model from the config instead of from the benchmarks since there are no LM Studio model benchmarks, and it makes more sense to use the provided config value anyway

## Testing
```
make format
make lint
make tests
```

Added example, which works for both default model `openai/gpt-oss-20b` and `deepseek/deepseek-r1-distill-qwen-14b`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LM Studio integration to run local models and produce structured outputs via the agent framework.
  * Added a sample interactive agent demo and structured-output example for local model usage.

* **Documentation**
  * Added comprehensive example README, configuration guide, and requirements for LM Studio usage.

* **Refactor**
  * Improved provider config handling for OpenAI-backed flows.

* **Tests**
  * Added tests covering LM Studio integration, config injection, and model selection logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->