### PR TITLE
Fix breaking type change in mcp 1.20.0 URL elicitation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-agent"
-version = "0.2.5"
+version = "0.2.6"
 description = "Build effective agents with Model Context Protocol (MCP) using simple, composable patterns."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -18,7 +18,7 @@ dependencies = [
     "fastapi>=0.115.6",
     "httpx>=0.28.1",
     "jsonref>=1.1.0",
-    "mcp>=1.19.0",
+    "mcp>=1.20.0",
     "numpy>=2.1.3",
     "opentelemetry-distro>=0.50b0",
     "opentelemetry-exporter-otlp-proto-http>=1.29.0",

--- a/src/mcp_agent/elicitation/handler.py
+++ b/src/mcp_agent/elicitation/handler.py
@@ -88,7 +88,8 @@ def _create_panel(request: ElicitRequestParams) -> Panel:
 
 async def _handle_elicitation_requested_schema(request: ElicitRequestParams) -> str:
     """Prompt for structured input based on requested schema."""
-    schema = request.requestedSchema
+    # requestedSchema is only available on form mode elicitation requests
+    schema = getattr(request, "requestedSchema", None)
     if not schema or "properties" not in schema:
         raise ValueError("Invalid schema: must contain 'properties'")
 

--- a/src/mcp_agent/elicitation/types.py
+++ b/src/mcp_agent/elicitation/types.py
@@ -1,14 +1,28 @@
-from typing import Protocol
+from typing import Protocol, Union
 from mcp.types import (
-    ElicitRequestParams as MCPElicitRequestParams,
+    ElicitRequestFormParams as MCPElicitRequestFormParams,
+    ElicitRequestURLParams as MCPElicitRequestURLParams,
     ElicitResult,
     ErrorData,
 )
 
 
-class ElicitRequestParams(MCPElicitRequestParams):
+class ElicitRequestFormParams(MCPElicitRequestFormParams):
+    """Form mode elicitation request with additional metadata."""
+
     server_name: str | None = None
-    """Name of the MCP server making the elicitation request"""
+    """Name of the MCP server making the elicitation request."""
+
+
+class ElicitRequestURLParams(MCPElicitRequestURLParams):
+    """URL mode elicitation request with additional metadata."""
+
+    server_name: str | None = None
+    """Name of the MCP server making the elicitation request."""
+
+
+ElicitRequestParams = Union[ElicitRequestFormParams, ElicitRequestURLParams]
+"""Elicitation request parameters - either form or URL mode, with server_name."""
 
 
 class ElicitationCallback(Protocol):

--- a/src/mcp_agent/server/app_server.py
+++ b/src/mcp_agent/server/app_server.py
@@ -1023,7 +1023,8 @@ def create_mcp_server_for_app(app: MCPApp, **kwargs: Any) -> FastMCP:
                 CreateMessageRequestParams,
                 CreateMessageResult,
                 ElicitRequest,
-                ElicitRequestParams,
+                ElicitRequestFormParams,
+                ElicitRequestURLParams,
                 ElicitResult,
                 ListRootsRequest,
                 ListRootsResult,
@@ -1046,10 +1047,16 @@ def create_mcp_server_for_app(app: MCPApp, **kwargs: Any) -> FastMCP:
                     by_alias=True, mode="json", exclude_none=True
                 )
             elif method == "elicitation/create":
+                # Determine which elicitation mode to use based on params
+                mode = params.get("mode", "form")
+                if mode == "url":
+                    elicit_params = ElicitRequestURLParams(**params)
+                else:
+                    elicit_params = ElicitRequestFormParams(**params)
                 req = ServerRequest(
                     ElicitRequest(
                         method="elicitation/create",
-                        params=ElicitRequestParams(**params),
+                        params=elicit_params,
                     )
                 )
                 callback_data = await session.send_request(
@@ -1139,7 +1146,7 @@ def create_mcp_server_for_app(app: MCPApp, **kwargs: Any) -> FastMCP:
         async def _perform_auth_flow(context, params, scopes, session):
             from mcp.types import (
                 ElicitRequest,
-                ElicitRequestParams,
+                ElicitRequestFormParams,
                 ElicitResult,
             )
 
@@ -1164,7 +1171,7 @@ def create_mcp_server_for_app(app: MCPApp, **kwargs: Any) -> FastMCP:
             callback_future = await callback_registry.create_handle(flow_id)
             req = ElicitRequest(
                 method="elicitation/create",
-                params=ElicitRequestParams(
+                params=ElicitRequestFormParams(
                     message=params["message"] + "\n\n" + params["url"],
                     requestedSchema=AuthToken.model_json_schema(),
                 ),

--- a/src/mcp_agent/workflows/llm/augmented_llm.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm.py
@@ -31,6 +31,7 @@ from mcp.types import (
     SamplingMessage,
     TextContent,
     PromptMessage,
+    Tool,  # noqa: F401 - Required to resolve forward reference in CreateMessageRequestParams
 )
 
 from mcp_agent.core.context_dependent import ContextDependent

--- a/uv.lock
+++ b/uv.lock
@@ -2081,7 +2081,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.19.0"
+version = "1.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2090,20 +2090,23 @@ dependencies = [
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
     { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/2b/916852a5668f45d8787378461eaa1244876d77575ffef024483c94c0649c/mcp-1.19.0.tar.gz", hash = "sha256:213de0d3cd63f71bc08ffe9cc8d4409cc87acffd383f6195d2ce0457c021b5c1", size = 444163, upload-time = "2025-10-24T01:11:15.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/42/10c0c09ca27aceacd8c428956cfabdd67e3d328fe55c4abc16589285d294/mcp-1.23.1.tar.gz", hash = "sha256:7403e053e8e2283b1e6ae631423cb54736933fea70b32422152e6064556cd298", size = 596519, upload-time = "2025-12-02T18:41:12.807Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/a3/3e71a875a08b6a830b88c40bc413bff01f1650f1efe8a054b5e90a9d4f56/mcp-1.19.0-py3-none-any.whl", hash = "sha256:f5907fe1c0167255f916718f376d05f09a830a215327a3ccdd5ec8a519f2e572", size = 170105, upload-time = "2025-10-24T01:11:14.151Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/9e/26e1d2d2c6afe15dfba5ca6799eeeea7656dce625c22766e4c57305e9cc2/mcp-1.23.1-py3-none-any.whl", hash = "sha256:3ce897fcc20a41bd50b4c58d3aa88085f11f505dcc0eaed48930012d34c731d8", size = 231433, upload-time = "2025-12-02T18:41:11.195Z" },
 ]
 
 [[package]]
 name = "mcp-agent"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2202,7 +2205,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jsonref", specifier = ">=1.1.0" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=0.3.64" },
-    { name = "mcp", specifier = ">=1.19.0" },
+    { name = "mcp", specifier = ">=1.20.0" },
     { name = "numpy", specifier = ">=2.1.3" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.58.1" },
     { name = "opentelemetry-distro", specifier = ">=0.50b0" },
@@ -2240,11 +2243,6 @@ dev = [
     { name = "tomli", specifier = ">=2.2.1" },
     { name = "trio", specifier = ">=0.30.0" },
 ]
-
-[[package]]
-name = "mcptest"
-version = "0.1.0"
-source = { virtual = "mcptest" }
 
 [[package]]
 name = "mdurl"


### PR DESCRIPTION
Support MCP `ElicitRequestParams` as a union type by subclassing its two member types instead of the union itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped project version to 0.2.6.
  * Updated MCP dependency requirement from >=1.19.0 to >=1.20.0.
  * Internal improvements to elicitation parameter handling and type safety for enhanced robustness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->