### PR TITLE
Exclude the meta field from SamplingMessage when converting to Azure message types

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_azure.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_azure.py
@@ -736,13 +736,13 @@ class MCPAzureTypeConverter(ProviderToMCPConverter[MessageParam, ResponseMessage
     @classmethod
     def from_mcp_message_param(cls, param: MCPMessageParam) -> MessageParam:
         if param.role == "assistant":
-            extras = param.model_dump(exclude={"role", "content"})
+            extras = param.model_dump(exclude={"role", "content", "meta"})
             return AssistantMessage(
                 content=mcp_content_to_azure_content([param.content]),
                 **extras,
             )
         elif param.role == "user":
-            extras = param.model_dump(exclude={"role", "content"})
+            extras = param.model_dump(exclude={"role", "content", "meta"})
             return UserMessage(
                 content=mcp_content_to_azure_content([param.content], str_only=False),
                 **extras,


### PR DESCRIPTION
Exclude the meta field from SamplingMessage when converting to Azure message types, since MCP 1.23.1 added this field but Azure's UserMessage/AssistantMessage don't accept it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure integration message parameter handling to correctly exclude additional fields during conversion, ensuring cleaner data processing between system components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->