### PR TITLE
Add default number of retries in config for temporal workflows

### DIFF
--- a/docs/mcp-agent-sdk/advanced/durable-agents.mdx
+++ b/docs/mcp-agent-sdk/advanced/durable-agents.mdx
@@ -150,9 +150,28 @@ The same helper works on the asyncio executor via `app.context.executor.signal_b
 
 The Temporal server example also shows how durable workflows call nested MCP servers and trigger [MCP elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation) when a human response is required. Activities such as `call_nested_elicitation` log progress via `app.app.logger` so the request trace and Temporal history stay aligned.
 
-## Configure workflow-task modules and retry policies
+## Configure retry policies
 
-Add optional top-level overrides to preload custom workflow tasks and refine retry behaviour:
+By default, mcp-agent limits activity retries to **3 attempts** to prevent runaway executions. You can customize this behaviour at multiple levels:
+
+### Default retry limits
+
+The `temporal.default_maximum_attempts` setting controls the default retry limit for all activities without an explicit retry policy:
+
+```yaml
+execution_engine: temporal
+
+temporal:
+  host: "localhost:7233"
+  task_queue: "mcp-agent"
+  default_maximum_attempts: 3
+```
+
+Set `default_maximum_attempts: null` to restore Temporal's default unlimited retry behaviour (not recommended).
+
+### Per-activity retry policies
+
+For granular control, use `workflow_task_retry_policies` to override retry behaviour for specific activities:
 
 ```yaml
 execution_engine: temporal

--- a/examples/cloud/temporal/mcp_agent.config.yaml
+++ b/examples/cloud/temporal/mcp_agent.config.yaml
@@ -19,6 +19,7 @@ temporal:
   namespace: "default" # Default Temporal namespace
   task_queue: "mcp-agent" # Task queue for workflows and activities
   max_concurrent_activities: 10 # Maximum number of concurrent activities
+  default_maximum_attempts: 3 # Limit number of retries
 
 logger:
   transports: [console]

--- a/examples/mcp_agent_server/temporal/mcp_agent.config.yaml
+++ b/examples/mcp_agent_server/temporal/mcp_agent.config.yaml
@@ -19,6 +19,7 @@ temporal:
   namespace: "default" # Default Temporal namespace
   task_queue: "mcp-agent" # Task queue for workflows and activities
   max_concurrent_activities: 10 # Maximum number of concurrent activities
+  default_maximum_attempts: 3 # Limit number of retries
 
 # Logger settings
 logger:

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -637,6 +637,9 @@ class TemporalSettings(BaseModel):
     workflow_task_modules: List[str] = Field(default_factory=list)
     """Additional module paths to import before creating a Temporal worker. Each should be importable."""
 
+    default_maximum_attempts: int | None = 3
+    """Default maximum retry attempts for activities without explicit retry policy. Set to None for unlimited retries (Temporal default)."""
+
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 

--- a/src/mcp_agent/data/examples/cloud/temporal/mcp_agent.config.yaml
+++ b/src/mcp_agent/data/examples/cloud/temporal/mcp_agent.config.yaml
@@ -18,6 +18,7 @@ temporal:
   namespace: "default" # Default Temporal namespace
   task_queue: "mcp-agent" # Task queue for workflows and activities
   max_concurrent_activities: 10 # Maximum number of concurrent activities
+  default_maximum_attempts: 3 # Limit number of retries
 
 logger:
   transports: [console]


### PR DESCRIPTION
# Add default retry limits for Temporal activities

### TL;DR

Adds a configurable default retry limit for Temporal activities to prevent runaway executions.

### What changed?

- Added `default_maximum_attempts: 3` setting to the Temporal configuration
- Updated the executor to apply this default limit to activities without explicit retry policies
- Enhanced documentation to explain retry policy configuration options
- Set the default to 3 attempts in example configurations

### How to test?

1. Configure a Temporal workflow with the new setting:
   ```yaml
   temporal:
     default_maximum_attempts: 5  # Or any desired value
   ```
2. Run a workflow with activities that might fail
3. Verify activities stop retrying after the configured number of attempts
4. Set `default_maximum_attempts: null` to restore unlimited retries (Temporal's default)

### Why make this change?

Without retry limits, failed Temporal activities can continuously retry indefinitely, potentially causing resource exhaustion or unexpected costs. This change provides sensible defaults while maintaining flexibility through configuration options at both global and per-activity levels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable default maximum retry attempts for task execution (including option for unlimited retries)
  * Support per-task retry policies with exact and wildcard matching and non-retryable error exclusions

* **Documentation**
  * Expanded guidance on configuring default retry limits, per-task policy overrides, and YAML examples

* **Tests**
  * Added unit tests covering default and per-task retry behaviors and timeout interactions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->