### PR TITLE
setting up framework for fine-grained authorization and filtering

### DIFF
--- a/examples/basic/mcp_basic_agent_with_auth/README.md
+++ b/examples/basic/mcp_basic_agent_with_auth/README.md
@@ -1,0 +1,15 @@
+# Basic MCP Agent with authorization example 
+
+The basic example is identical to `mcp_basic_agent` except that it adds an authorization configuration using a `BasicAgentDemoAuthEngine` derived class to intercept the Agent class's `list_tools` API. Please follow that `mcp_basic_agent` example's README for basic setup.
+
+The authorization engine configuration is this stanza from `mcp_agent.config.yaml`
+
+```yaml
+authorization_engines:
+  agents:
+    finder:
+      # api->engines map. "demo-auth" is registered in main.py
+      api_engines: { list_tools: "demo-auth", attach_llm: "demo-auth" }
+```
+
+Different Agents (such as `finder` Agent in the example) can have different API engines hooked to various APIs. Different APIs within the same agent can specify different registered authorized engines as well. APIs not configured for authorization will be invoked directly.

--- a/examples/basic/mcp_basic_agent_with_auth/main.py
+++ b/examples/basic/mcp_basic_agent_with_auth/main.py
@@ -1,0 +1,204 @@
+import asyncio
+import os
+import time
+from typing import Callable, Dict, Set, Any
+from pydantic import AnyUrl
+
+from mcp.types import (
+    ListToolsResult,
+)
+
+from mcp_agent.app import MCPApp
+from mcp_agent.config import (
+    Settings,
+    LoggerSettings,
+    MCPSettings,
+    MCPServerSettings,
+    OpenAISettings,
+    AnthropicSettings,
+)
+
+from mcp_agent.agents.agent import Agent, LLM
+from mcp_agent.workflows.llm.augmented_llm import RequestParams
+from mcp_agent.workflows.llm.llm_selector import ModelPreferences
+from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLLM
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+from mcp_agent.tracing.token_counter import TokenSummary
+from mcp_agent.authorization.authorizer import AuthorizationEngine
+
+settings = Settings(
+    execution_engine="asyncio",
+    logger=LoggerSettings(type="file", level="debug"),
+    mcp=MCPSettings(
+        servers={
+            "fetch": MCPServerSettings(
+                command="uvx",
+                args=["mcp-server-fetch"],
+            ),
+            "filesystem": MCPServerSettings(
+                command="npx",
+                args=["-y", "@modelcontextprotocol/server-filesystem"],
+            ),
+        }
+    ),
+    openai=OpenAISettings(
+        api_key="sk-my-openai-api-key",
+        default_model="gpt-4o-mini",
+    ),
+    anthropic=AnthropicSettings(
+        api_key="sk-my-anthropic-api-key",
+    ),
+)
+
+
+# Settings can either be specified programmatically,
+# or loaded from mcp_agent.config.yaml/mcp_agent.secrets.yaml
+app = MCPApp(name="mcp_basic_agent_with_auth")  # settings=settings)
+
+
+class BasicAgentDemoAuthEngine(AuthorizationEngine):
+    """
+    An example AuthorizationEngine that just overrides list_tools authorizer
+    """
+
+    async def list_tools_authorize(
+        self,
+        agent,
+        fn: Callable[..., ListToolsResult],
+        *args,
+        **kwargs,
+    ) -> ListToolsResult:
+        """
+        Overrides but just prints the tools ...but could do serious
+        auth based on agent, app and dynamic request config/context
+        """
+
+        result = await fn(agent, *args, **kwargs)
+
+        print(f"Authorizable tools {result.tools}")
+
+        return result
+
+
+# typically we will have a blessed authorization engines built into
+# the mcp_agent framework. Users can create and register their own
+# just as easily by deriving their own AuthorizationEngine
+app.authorization_registry.register_authorization_engine(
+    "demo-auth", BasicAgentDemoAuthEngine()
+)
+
+@app.tool()
+async def example_usage() -> str:
+    """
+    An example function/tool that uses an agent with access to the fetch and filesystem
+    mcp servers. The agent will read the contents of mcp_agent.config.yaml, print the
+    first 2 paragraphs of the mcp homepage, and summarize the paragraphs into a tweet.
+    The example uses both OpenAI, Anthropic, and simulates a multi-turn conversation.
+    """
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+        context = agent_app.context
+        result = ""
+
+        logger.info("Current config:", data=context.config.model_dump())
+
+        # Add the current directory to the filesystem server's args
+        context.config.mcp.servers["filesystem"].args.extend([os.getcwd()])
+
+        finder_agent = Agent(
+            name="finder",
+            instruction="""You are an agent with access to the filesystem, 
+            as well as the ability to fetch URLs. Your job is to identify 
+            the closest match to a user's request, make the appropriate tool calls, 
+            and return the URI and CONTENTS of the closest match.""",
+            server_names=["fetch", "filesystem"],
+        )
+
+        async with finder_agent:
+            logger.info("finder: Connected to server, calling list_tools...")
+            tools_list = await finder_agent.list_tools()
+            logger.info("Tools available:", data=tools_list.model_dump())
+
+            llm = await finder_agent.attach_llm(OpenAIAugmentedLLM)
+            result += await llm.generate_str(
+                message="Print the contents of mcp_agent.config.yaml verbatim",
+            )
+            logger.info(f"mcp_agent.config.yaml contents: {result}")
+
+            # Let's switch the same agent to a different LLM
+            llm = await finder_agent.attach_llm(AnthropicAugmentedLLM)
+
+            result += await llm.generate_str(
+                message="Print the first 2 paragraphs of https://modelcontextprotocol.io/introduction",
+            )
+            logger.info(f"First 2 paragraphs of Model Context Protocol docs: {result}")
+            result += "\n\n"
+
+            # Multi-turn conversations
+            result += await llm.generate_str(
+                message="Summarize those paragraphs in a 128 character tweet",
+                # You can configure advanced options by setting the request_params object
+                request_params=RequestParams(
+                    # See https://modelcontextprotocol.io/docs/concepts/sampling#model-preferences for more details
+                    modelPreferences=ModelPreferences(
+                        costPriority=0.1, speedPriority=0.2, intelligencePriority=0.7
+                    ),
+                    # You can also set the model directly using the 'model' field
+                    # Generally request_params type aligns with the Sampling API type in MCP
+                ),
+            )
+            logger.info(f"Paragraph as a tweet: {result}")
+
+        # Display final comprehensive token usage summary (use app convenience)
+        await display_token_summary(agent_app)
+
+    return result
+
+
+async def display_token_summary(app_ctx: MCPApp, agent: Agent | None = None):
+    """Display comprehensive token usage summary using app/agent convenience APIs."""
+    summary: TokenSummary = await app_ctx.get_token_summary()
+
+    print("\n" + "=" * 50)
+    print("TOKEN USAGE SUMMARY")
+    print("=" * 50)
+
+    # Total usage and cost
+    print("\nTotal Usage:")
+    print(f"  Total tokens: {summary.usage.total_tokens:,}")
+    print(f"  Input tokens: {summary.usage.input_tokens:,}")
+    print(f"  Output tokens: {summary.usage.output_tokens:,}")
+    print(f"  Total cost: ${summary.cost:.4f}")
+
+    # Breakdown by model
+    if summary.model_usage:
+        print("\nBreakdown by Model:")
+        for model_key, data in summary.model_usage.items():
+            print(f"\n  {model_key}:")
+            print(
+                f"    Tokens: {data.usage.total_tokens:,} (input: {data.usage.input_tokens:,}, output: {data.usage.output_tokens:,})"
+            )
+            print(f"    Cost: ${data.cost:.4f}")
+
+    print("\n" + "=" * 50)
+
+    # Optional: show a specific agent's aggregated usage
+    if agent is not None:
+        agent_usage = await agent.get_token_usage()
+        if agent_usage:
+            print("\nAgent Usage:")
+            print(f"  Agent: {agent.name}")
+            print(f"  Total tokens: {agent_usage.total_tokens:,}")
+            print(f"  Input tokens: {agent_usage.input_tokens:,}")
+            print(f"  Output tokens: {agent_usage.output_tokens:,}")
+
+    print("\n" + "=" * 50)
+
+
+if __name__ == "__main__":
+    start = time.time()
+    asyncio.run(example_usage())
+    end = time.time()
+    t = end - start
+
+    print(f"Total run time: {t:.2f}s")

--- a/examples/basic/mcp_basic_agent_with_auth/mcp_agent.config.yaml
+++ b/examples/basic/mcp_basic_agent_with_auth/mcp_agent.config.yaml
@@ -1,0 +1,32 @@
+$schema: ../../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  transports: [console, file]
+  level: debug
+  progress_display: true
+  path_settings:
+    path_pattern: "logs/mcp-agent-{unique_id}.jsonl"
+    unique_id: "timestamp" # Options: "timestamp" or "session_id"
+    timestamp_format: "%Y%m%d_%H%M%S"
+
+authorization_engines:
+  agents:
+    finder:
+      # api->engines map. "demo-auth" is registered in main.py
+      api_engines: { list_tools: "demo-auth", attach_llm: "demo-auth" }
+
+mcp:
+  servers:
+    fetch:
+      command: "uvx"
+      args: ["mcp-server-fetch"]
+    filesystem:
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-filesystem"]
+
+openai:
+  # Secrets (API keys, etc.) are stored in an mcp_agent.secrets.yaml file which can be gitignored
+  default_model: "gpt-5"
+anthropic:
+  default_model: claude-sonnet-4-20250514

--- a/examples/basic/mcp_basic_agent_with_auth/mcp_agent.secrets.yaml.example
+++ b/examples/basic/mcp_basic_agent_with_auth/mcp_agent.secrets.yaml.example
@@ -1,0 +1,30 @@
+$schema: ../../../schema/mcp-agent.config.schema.json
+
+# Copy this file to mcp_agent.secrets.yaml and fill in your API keys.
+# This file should be gitignored.
+
+openai:
+  api_key: "sk-your-openai-key"
+
+anthropic:
+  api_key: "sk-your-anthropic-key"
+
+# Optional: Azure OpenAI
+# azure:
+#   api_key: "..."
+#   endpoint: "https://<your-endpoint>.openai.azure.com"
+
+# Optional: Google
+# google:
+#   api_key: "..."
+#   # vertexai: true
+#   # project: your-gcp-project-id
+#   # location: us-central1
+
+# Optional: AWS / Bedrock
+# bedrock:
+#   aws_access_key_id: "..."
+#   aws_secret_access_key: "..."
+#   # aws_session_token: "..."
+#   aws_region: "us-east-1"
+#   # profile: "default"

--- a/examples/basic/mcp_basic_agent_with_auth/requirements.txt
+++ b/examples/basic/mcp_basic_agent_with_auth/requirements.txt
@@ -1,0 +1,6 @@
+# Core framework dependency
+mcp-agent @ file://../../../  # Link to the local mcp-agent project root
+
+# Additional dependencies specific to this example
+anthropic
+openai

--- a/src/mcp_agent/agents/agent.py
+++ b/src/mcp_agent/agents/agent.py
@@ -1,7 +1,9 @@
 import asyncio
 import json
 import uuid
-from typing import Callable, Dict, List, Optional, Set, TypeVar, TYPE_CHECKING, Any
+import functools
+
+from typing import Callable, Dict, List, Optional, Set, Awaitable, Any
 from contextlib import asynccontextmanager
 
 from opentelemetry import trace
@@ -21,6 +23,8 @@ from mcp.types import (
     PromptMessage,
     EmbeddedResource,
 )
+
+from mcp_agent.authorization.authorizer import AuthorizationEngine
 
 from mcp_agent.core.context import Context
 from mcp_agent.tracing.semconv import GEN_AI_AGENT_NAME, GEN_AI_TOOL_NAME
@@ -44,15 +48,9 @@ from mcp_agent.human_input.types import (
 
 from mcp_agent.logging.logger import get_logger
 
-if TYPE_CHECKING:
-    from mcp_agent.workflows.llm.augmented_llm import AugmentedLLM
+from mcp_agent.agents.types import LLM
 
-    # Define a TypeVar for AugmentedLLM and its subclasses that's only used at type checking time
-    LLM = TypeVar("LLM", bound="AugmentedLLM")
-else:
-    # Define a TypeVar without the bound for runtime
-    LLM = TypeVar("LLM")
-
+from mcp_agent.config import AgentApiName
 
 logger = get_logger(__name__)
 
@@ -154,6 +152,55 @@ class Agent(BaseModel):
             (tool := FastTool.from_function(fn)).name: tool for fn in self.functions
         }
 
+    def get_authorization_engine(
+        self, api_name: AgentApiName
+    ) -> AuthorizationEngine | None:
+        """
+        Returns the AuthorizationEngine configured for given API for an Agent, if any.
+        """
+        if self.context is None or getattr(self.context, "config", None) is None:
+            return None
+
+        if getattr(self.context, "app", None) is None:
+            return None
+
+        auth_cfg = getattr(self.context.config, "authorization_engines", None)
+        agents_cfg = getattr(auth_cfg, "agents", None) if auth_cfg is not None else None
+        if agents_cfg is not None:
+            agent_auth_cfg = self.context.config.authorization_engines.agents.get(
+                self.name
+            )
+            if agent_auth_cfg is not None and agent_auth_cfg.api_engines is not None:
+                engine_name = agent_auth_cfg.api_engines.get(api_name)
+                if engine_name is not None:
+                    # return the engine if one was registered
+                    registry = getattr(self.context.app, "authorization_registry", None)
+                    return (
+                        registry.get_authorization_engine(engine_name)
+                        if registry is not None
+                        else None
+                    )
+        return None
+
+    def attach_llm_authorize(fn) -> Callable[..., Awaitable[LLM]]:
+        """
+        Decorator for an Agent's 'attach_llm' method.  Different authorization engines
+        can use this to customize behavior for an Agent's 'attach_llm' execution.
+        """
+
+        @functools.wraps(fn)
+        async def wrapper(self, *args, **kwargs) -> LLM:
+            auth_engine = self.get_authorization_engine("attach_llm")
+
+            if auth_engine is None:
+                return await fn(self, *args, **kwargs)
+
+            # this will do the auth and call fn
+            return await auth_engine.attach_llm_authorize(self, fn, *args, **kwargs)
+
+        return wrapper
+
+    @attach_llm_authorize
     async def attach_llm(
         self, llm_factory: Callable[..., LLM] | None = None, llm: LLM | None = None
     ) -> LLM:
@@ -490,6 +537,25 @@ class Agent(BaseModel):
         # No non_namespaced_tools key and no wildcard - include by default (no filter for non-namespaced)
         return True, None
 
+    def list_tools_authorize(fn) -> Callable[..., Awaitable[ListToolsResult]]:
+        """
+        Decorator for an Agent's 'list_tools' method.  Different authorization engines
+        can use this to customize behavior for an Agent's 'list_tools' execution.
+        """
+
+        @functools.wraps(fn)
+        async def wrapper(self, *args, **kwargs) -> ListToolsResult:
+            auth_engine = self.get_authorization_engine("list_tools")
+
+            if auth_engine is None:
+                return await fn(self, *args, **kwargs)
+
+            # this will do the auth and call fn
+            return await auth_engine.list_tools_authorize(self, fn, *args, **kwargs)
+
+        return wrapper
+
+    @list_tools_authorize
     async def list_tools(
         self,
         server_name: str | None = None,
@@ -721,6 +787,25 @@ class Agent(BaseModel):
 
             return result
 
+    def list_resources_authorize(fn) -> Callable[..., Awaitable[ListResourcesResult]]:
+        """
+        Decorator for an Agent's 'list_resources' method.  Different authorization engines
+        can use this to customize behavior for an Agent's 'list_resources' execution.
+        """
+
+        @functools.wraps(fn)
+        async def wrapper(self, *args, **kwargs) -> ListResourcesResult:
+            auth_engine = self.get_authorization_engine("list_resources")
+
+            if auth_engine is None:
+                return await fn(self, *args, **kwargs)
+
+            # this will do the auth and call fn
+            return await auth_engine.list_resources_authorize(self, fn, *args, **kwargs)
+
+        return wrapper
+
+    @list_resources_authorize
     async def list_resources(
         self, server_name: str | None = None
     ) -> ListResourcesResult:
@@ -746,6 +831,25 @@ class Agent(BaseModel):
             )
             return result
 
+    def read_resource_authorize(fn) -> Callable[..., Awaitable[Any]]:
+        """
+        Decorator for an Agent's 'read_resource' method.  Different authorization engines
+        can use this to customize behavior for an Agent's 'read_resource' execution.
+        """
+
+        @functools.wraps(fn)
+        async def wrapper(self, *args, **kwargs) -> Any:
+            auth_engine = self.get_authorization_engine("read_resource")
+
+            if auth_engine is None:
+                return await fn(self, *args, **kwargs)
+
+            # this will do the auth and call fn
+            return await auth_engine.read_resource_authorize(self, fn, *args, **kwargs)
+
+        return wrapper
+
+    @read_resource_authorize
     async def read_resource(self, uri: str, server_name: str | None = None):
         """
         Read a resource from an MCP server.
@@ -772,6 +876,25 @@ class Agent(BaseModel):
             )
             return result
 
+    def create_prompt_authorize(fn) -> Callable[..., Awaitable[list[PromptMessage]]]:
+        """
+        Decorator for an Agent's 'create_prompt' method.  Different authorization engines
+        can use this to customize behavior for an Agent's 'create_prompt' execution.
+        """
+
+        @functools.wraps(fn)
+        async def wrapper(self, *args, **kwargs) -> list[PromptMessage]:
+            auth_engine = self.get_authorization_engine("create_prompt")
+
+            if auth_engine is None:
+                return await fn(self, *args, **kwargs)
+
+            # this will do the auth and call fn
+            return await auth_engine.create_prompt_authorize(self, fn, *args, **kwargs)
+
+        return wrapper
+
+    @create_prompt_authorize
     async def create_prompt(
         self,
         *,
@@ -865,6 +988,25 @@ class Agent(BaseModel):
 
         return messages
 
+    def list_prompts_authorize(fn) -> Callable[..., Awaitable[ListPromptsResult]]:
+        """
+        Decorator for an Agent's 'list_prompts' method.  Different authorization engines
+        can use this to customize behavior for an Agent's 'list_prompts' execution.
+        """
+
+        @functools.wraps(fn)
+        async def wrapper(self, *args, **kwargs) -> ListPromptsResult:
+            auth_engine = self.get_authorization_engine("list_prompts")
+
+            if auth_engine is None:
+                return await fn(self, *args, **kwargs)
+
+            # this will do the auth and call fn
+            return await auth_engine.list_prompts_authorize(self, fn, *args, **kwargs)
+
+        return wrapper
+
+    @list_prompts_authorize
     async def list_prompts(self, server_name: str | None = None) -> ListPromptsResult:
         # Check if the agent is initialized
         if not self.initialized:
@@ -909,6 +1051,25 @@ class Agent(BaseModel):
 
             return result
 
+    def get_prompt_authorize(fn) -> Callable[..., Awaitable[GetPromptResult]]:
+        """
+        Decorator for an Agent's 'get_prompt' method.  Different authorization engines
+        can use this to customize behavior for an Agent's 'get_prompt' execution.
+        """
+
+        @functools.wraps(fn)
+        async def wrapper(self, *args, **kwargs) -> GetPromptResult:
+            auth_engine = self.get_authorization_engine("get_prompt")
+
+            if auth_engine is None:
+                return await fn(self, *args, **kwargs)
+
+            # this will do the auth and call fn
+            return await auth_engine.get_prompt_authorize(self, fn, *args, **kwargs)
+
+        return wrapper
+
+    @get_prompt_authorize
     async def get_prompt(
         self,
         name: str,
@@ -1069,6 +1230,25 @@ class Agent(BaseModel):
             logger.debug("Received human input signal", data=result)
             return result
 
+    def call_tool_authorize(fn) -> Callable[..., Awaitable[CallToolResult]]:
+        """
+        Decorator for an Agent's 'call_tool' method.  Different authorization engines
+        can use this to customize behavior for an Agent's 'call_tool' execution.
+        """
+
+        @functools.wraps(fn)
+        async def wrapper(self, *args, **kwargs) -> CallToolResult:
+            auth_engine = self.get_authorization_engine("call_tool")
+
+            if auth_engine is None:
+                return await fn(self, *args, **kwargs)
+
+            # this will do the auth and call fn
+            return await auth_engine.call_tool_authorize(self, fn, *args, **kwargs)
+
+        return wrapper
+
+    @call_tool_authorize
     async def call_tool(
         self, name: str, arguments: dict | None = None, server_name: str | None = None
     ) -> CallToolResult:

--- a/src/mcp_agent/agents/types.py
+++ b/src/mcp_agent/agents/types.py
@@ -1,0 +1,10 @@
+from typing import TypeVar, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mcp_agent.workflows.llm.augmented_llm import AugmentedLLM
+
+    # Define a TypeVar for AugmentedLLM and its subclasses that's only used at type checking time
+    LLM = TypeVar("LLM", bound="AugmentedLLM")
+else:
+    # Define a TypeVar without the bound for runtime
+    LLM = TypeVar("LLM")

--- a/src/mcp_agent/app.py
+++ b/src/mcp_agent/app.py
@@ -35,6 +35,7 @@ from mcp_agent.executor.decorator_registry import (
     register_asyncio_decorators,
     register_temporal_decorators,
 )
+from mcp_agent.authorization.registry import AuthorizationRegistry
 from mcp_agent.executor.task_registry import ActivityRegistry
 from mcp_agent.executor.workflow_signal import SignalWaitCallback
 from mcp_agent.executor.workflow_task import GlobalWorkflowTaskRegistry
@@ -142,6 +143,11 @@ class MCPApp:
         register_temporal_decorators(self._decorator_registry)
         self._registered_global_workflow_tasks = set()
 
+        # API Authorization related decorators will use this registry to perform
+        # authorization and filtering on the APIs based on various contexts available
+        # to the call.
+        self._authorization_registry = AuthorizationRegistry()
+
         self._human_input_callback = human_input_callback
         self._elicitation_callback = elicitation_callback
         self._signal_notification = signal_notification
@@ -244,6 +250,10 @@ class MCPApp:
                 self._logger._bound_context = self._context
 
         return self._logger
+
+    @property
+    def authorization_registry(self) -> AuthorizationRegistry:
+        return self._authorization_registry
 
     def _apply_environment_bindings(self) -> None:
         """Populate os.environ with values declared in settings.env when the value is available."""

--- a/src/mcp_agent/authorization/authorizer.py
+++ b/src/mcp_agent/authorization/authorizer.py
@@ -1,0 +1,108 @@
+from typing import Callable, Any
+
+from mcp_agent.agents.types import LLM
+
+from mcp.types import (
+    CallToolResult,
+    GetPromptResult,
+    ListPromptsResult,
+    ListToolsResult,
+    ListResourcesResult,
+    PromptMessage,
+)
+
+
+class AuthorizationEngine:
+    """
+    Base class for authorization engines. Provides default noop implementation
+    for APIs that support authorization. This can be extended to cover APIs from
+    different parts of the framework such as from the Agent.
+    """
+
+    async def list_tools_authorize(
+        self,
+        agent,
+        fn: Callable[..., ListToolsResult],
+        *args,
+        **kwargs,
+    ) -> ListToolsResult:
+        """Authorizer function for list_tools Agent API."""
+
+        return await fn(agent, *args, **kwargs)
+
+    async def attach_llm_authorize(
+        self,
+        agent,
+        fn: Callable[..., LLM],
+        *args,
+        **kwargs,
+    ) -> LLM:
+        """Authorizer function for attach_llm Agent API."""
+
+        return await fn(agent, *args, **kwargs)
+
+    async def list_resources_authorize(
+        self,
+        agent,
+        fn: Callable[..., ListResourcesResult],
+        *args,
+        **kwargs,
+    ) -> ListResourcesResult:
+        """Authorizer function for list_resources Agent API."""
+
+        return await fn(agent, *args, **kwargs)
+
+    async def read_resource_authorize(
+        self,
+        agent,
+        fn: Callable[..., Any],
+        *args,
+        **kwargs,
+    ) -> Any:
+        """Authorizer function for read_resource Agent API."""
+
+        return await fn(agent, *args, **kwargs)
+
+    async def create_prompt_authorize(
+        self,
+        agent,
+        fn: Callable[..., list[PromptMessage]],
+        *args,
+        **kwargs,
+    ) -> list[PromptMessage]:
+        """Authorizer function for create_prompt Agent API."""
+
+        return await fn(agent, *args, **kwargs)
+
+    async def list_prompts_authorize(
+        self,
+        agent,
+        fn: Callable[..., ListPromptsResult],
+        *args,
+        **kwargs,
+    ) -> ListPromptsResult:
+        """Authorizer function for list_prompts Agent API."""
+
+        return await fn(agent, *args, **kwargs)
+
+    async def get_prompt_authorize(
+        self,
+        agent,
+        fn: Callable[..., GetPromptResult],
+        *args,
+        **kwargs,
+    ) -> GetPromptResult:
+        """Authorizer function for get_prompt Agent API."""
+
+        return await fn(agent, *args, **kwargs)
+
+    async def call_tool_authorize(
+        self,
+        agent,
+        fn: Callable[..., CallToolResult],
+        *args,
+        **kwargs,
+    ) -> CallToolResult:
+        """Authorizer function for call_tool Agent API."""
+
+        return await fn(agent, *args, **kwargs)

--- a/src/mcp_agent/authorization/registry.py
+++ b/src/mcp_agent/authorization/registry.py
@@ -1,0 +1,44 @@
+"""
+Keep track of all authorization engines registered with the framework.  Each engine
+can have its own concept/implementation of authorization.
+"""
+
+from typing import Dict
+
+from mcp_agent.authorization.authorizer import AuthorizationEngine
+
+
+class AuthorizationRegistry:
+    """
+    Centralized registration of authorization engines for authorizing entities in
+    the framework such as Agent APIs. These are invoked by authorization decorators
+    in various APIs and hooks that need authorization.
+    """
+
+    def __init__(self):
+        # Agent's "list_tools" authorizer registry
+        self._engines: Dict[str, AuthorizationEngine] = {}
+
+    def register_authorization_engine(
+        self,
+        name: str,
+        engine: AuthorizationEngine,
+    ) -> None:
+        """
+        Registers authorization engine with the registry
+
+        :param name: Unique name of the authorization engine.
+        :param engin: The engine associated with the name.
+        """
+        if name in self._engines:
+            print(f"Authorization engine already registered for '{name}'. Overwriting.")
+        self._engines[name] = engine
+
+    def get_authorization_engine(self, name: str) -> AuthorizationEngine | None:
+        """
+        Retrieves authorization engine with the given name.
+
+        :param name: Unique name of the authorization engine.
+        :return: The authorization engine.
+        """
+        return self._engines.get(name)

--- a/src/mcp_agent/config.py
+++ b/src/mcp_agent/config.py
@@ -1133,6 +1133,31 @@ class LoggerSettings(BaseModel):
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
 
 
+AgentApiName = Literal[
+    "attach_llm",
+    "list_tools",
+    "list_resources",
+    "read_resource",
+    "create_prompt",
+    "list_prompts",
+    "get_prompt",
+    "call_tool",
+]
+
+
+class AgentAuthorizationEngineSettings(BaseModel):
+    """Authorization engine specific configuration for an Agent."""
+
+    # list of Agent's API for which an auth. engine can be specified.
+    api_engines: Dict[AgentApiName, str] = Field(default_factory=dict)
+
+
+class AuthorizationEngineSettings(BaseModel):
+    """Authorization engine specific configuration for a named Agent."""
+
+    agents: Dict[str, AgentAuthorizationEngineSettings] = Field(default_factory=dict)
+
+
 class Settings(BaseSettings):
     """
     Settings class for the MCP Agent application.
@@ -1207,6 +1232,11 @@ class Settings(BaseSettings):
 
     oauth: OAuthSettings | None = Field(default_factory=OAuthSettings)
     """Global OAuth client configuration (token store, delegated auth defaults)"""
+
+    authorization_engines: AuthorizationEngineSettings = Field(
+        default_factory=AuthorizationEngineSettings
+    )
+    """Setting for exposing configuration related to authorization engines."""
 
     env: list[str | dict[str, str]] = Field(default_factory=list)
     """Environment variables to materialize for deployments."""


### PR DESCRIPTION
Expand the framework so we can do fine-grained authorization (for instance at individual API call level). There is potential for using dynamic context such as from OAuth in addition to configuration driven context such as from an Agent or App. It is hoped that this proposal will pave way for implementation of authorization engines which can be registered and used with the framework.

The example `examples/basic/mcp_basic_agent_with_auth` hopefully illustrates all aspects of this extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Pluggable per-API authorization framework with an app-level registry and a noop base engine.

* **Examples**
  - New runnable example showing an authorized agent, multi-LLM interactions, example tool, and token-usage reporting.

* **Configuration**
  - New config and secrets example mapping agent APIs to authorization engines and sample server/model settings.

* **Documentation**
  - README and secrets/config templates illustrating authorization setup and usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->