### PR TITLE
Add tamper-evident execution integrity example for agent runs

### DIFF
--- a/examples/execution_integrity/README.md
+++ b/examples/execution_integrity/README.md
@@ -1,0 +1,14 @@
+# Execution Integrity Example
+
+This is an optional example demonstrating tamper-evident execution traces.
+
+## Run
+python3 demo.py
+python3 verify_export.py execution_log.json
+
+Expected:
+- Verification before tamper: True
+- Verification after tamper: False
+- EXPORT_VERIFY: PASS
+
+No dependencies. No changes to core logic.

--- a/examples/execution_integrity/demo.py
+++ b/examples/execution_integrity/demo.py
@@ -1,0 +1,16 @@
+from execution_integrity_core import ExecutionIntegrityCore
+from verify_export import verify_export
+
+core = ExecutionIntegrityCore()
+
+core.record("tool_call", {"tool": "search", "q": "agent execution"}, {"ok": True}, ts=1700000000.0)
+core.record("tool_call", {"tool": "calc", "expr": "2+2"}, {"result": 4}, ts=1700000001.0)
+
+print("Verification before tamper:", core.verify())
+
+path = core.export(filename="execution_log.json", exported_at=1700000002.0)
+
+core.chain[0]["output"] = {"ok": False}
+print("Verification after tamper:", core.verify())
+
+verify_export(path)

--- a/examples/execution_integrity/demo.py
+++ b/examples/execution_integrity/demo.py
@@ -3,7 +3,11 @@ from verify_export import verify_export
 
 core = ExecutionIntegrityCore()
 
-core.record("tool_call", {"tool": "search", "q": "agent execution"}, {"ok": True}, ts=1700000000.0)
+first_input = {"tool": "search", "q": "agent execution"}
+core.record("tool_call", first_input, {"ok": True}, ts=1700000000.0)
+first_input["q"] = "mutated later"
+print("Verification after harmless input mutation:", core.verify())
+
 core.record("tool_call", {"tool": "calc", "expr": "2+2"}, {"result": 4}, ts=1700000001.0)
 
 print("Verification before tamper:", core.verify())

--- a/examples/execution_integrity/execution_integrity_core.py
+++ b/examples/execution_integrity/execution_integrity_core.py
@@ -1,3 +1,4 @@
+import copy
 import hashlib
 import json
 import time
@@ -15,8 +16,8 @@ class ExecutionIntegrityCore:
         entry = {
             "timestamp": ts,
             "action": action,
-            "input": input_data,
-            "output": output_data,
+            "input": copy.deepcopy(input_data),
+            "output": copy.deepcopy(output_data),
             "previous_hash": self.previous_hash,
         }
 

--- a/examples/execution_integrity/execution_integrity_core.py
+++ b/examples/execution_integrity/execution_integrity_core.py
@@ -1,0 +1,62 @@
+import hashlib
+import json
+import time
+
+
+class ExecutionIntegrityCore:
+    def __init__(self):
+        self.chain = []
+        self.previous_hash = "GENESIS"
+
+    def record(self, action, input_data, output_data, ts=None):
+        if ts is None:
+            ts = time.time()
+
+        entry = {
+            "timestamp": ts,
+            "action": action,
+            "input": input_data,
+            "output": output_data,
+            "previous_hash": self.previous_hash,
+        }
+
+        raw = json.dumps(entry, sort_keys=True).encode()
+        current_hash = hashlib.sha256(raw).hexdigest()
+
+        entry["hash"] = current_hash
+        self.previous_hash = current_hash
+        self.chain.append(entry)
+
+    def export(self, filename="execution_log.json", exported_at=None):
+        if exported_at is None:
+            exported_at = time.time()
+
+        envelope = {
+            "spec": "execution-integrity-core",
+            "version": "0.1.2",
+            "exported_at": exported_at,
+            "hash_alg": "sha256",
+            "chain": self.chain,
+        }
+
+        with open(filename, "w") as f:
+            json.dump(envelope, f, indent=2, sort_keys=True)
+
+        return filename
+
+    def verify(self):
+        prev = "GENESIS"
+        for entry in self.chain:
+            expected = entry["hash"]
+            temp = dict(entry)
+            temp.pop("hash", None)
+
+            raw = json.dumps(temp, sort_keys=True).encode()
+            recalculated = hashlib.sha256(raw).hexdigest()
+
+            if recalculated != expected or entry["previous_hash"] != prev:
+                return False
+
+            prev = expected
+
+        return True

--- a/examples/execution_integrity/execution_integrity_core.py
+++ b/examples/execution_integrity/execution_integrity_core.py
@@ -48,14 +48,19 @@ class ExecutionIntegrityCore:
     def verify(self):
         prev = "GENESIS"
         for entry in self.chain:
-            expected = entry["hash"]
+            try:
+                expected = entry["hash"]
+                prev_hash = entry["previous_hash"]
+            except KeyError:
+                return False
+
             temp = dict(entry)
             temp.pop("hash", None)
 
             raw = json.dumps(temp, sort_keys=True).encode()
             recalculated = hashlib.sha256(raw).hexdigest()
 
-            if recalculated != expected or entry["previous_hash"] != prev:
+            if recalculated != expected or prev_hash != prev:
                 return False
 
             prev = expected

--- a/examples/execution_integrity/execution_integrity_core.py
+++ b/examples/execution_integrity/execution_integrity_core.py
@@ -4,6 +4,10 @@ import json
 import time
 
 
+def _serialize(obj):
+    return json.dumps(obj, sort_keys=True, default=str).encode()
+
+
 class ExecutionIntegrityCore:
     def __init__(self):
         self.chain = []
@@ -21,10 +25,7 @@ class ExecutionIntegrityCore:
             "previous_hash": self.previous_hash,
         }
 
-        try:
-            raw = json.dumps(entry, sort_keys=True).encode()
-        except (TypeError, ValueError):
-            raw = json.dumps(entry, sort_keys=True, default=str).encode()
+        raw = _serialize(entry)
         current_hash = hashlib.sha256(raw).hexdigest()
 
         entry["hash"] = current_hash
@@ -44,7 +45,7 @@ class ExecutionIntegrityCore:
         }
 
         with open(filename, "w") as f:
-            json.dump(envelope, f, indent=2, sort_keys=True)
+            json.dump(envelope, f, indent=2, sort_keys=True, default=str)
 
         return filename
 
@@ -55,7 +56,7 @@ class ExecutionIntegrityCore:
                 temp = dict(entry)
                 expected = temp.pop("hash")
 
-                raw = json.dumps(temp, sort_keys=True).encode()
+                raw = _serialize(temp)
                 recalculated = hashlib.sha256(raw).hexdigest()
 
                 if recalculated != expected or entry.get("previous_hash") != prev:

--- a/examples/execution_integrity/verify_export.py
+++ b/examples/execution_integrity/verify_export.py
@@ -1,0 +1,53 @@
+import hashlib
+import json
+import sys
+
+
+def sha256_of_entry_without_hash(entry):
+    temp = dict(entry)
+    temp.pop("hash", None)
+    raw = json.dumps(temp, sort_keys=True).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def verify_export(path):
+    with open(path, "r") as f:
+        data = json.load(f)
+
+    required_top = ["spec", "version", "exported_at", "hash_alg", "chain"]
+    for key in required_top:
+        if key not in data:
+            print(f"EXPORT_VERIFY: FAIL (missing top-level key: {key})")
+            return 2
+
+    if data["hash_alg"] != "sha256":
+        print("EXPORT_VERIFY: FAIL (unsupported hash_alg)")
+        return 2
+
+    prev = "GENESIS"
+    for idx, entry in enumerate(data["chain"], start=1):
+        expected = entry.get("hash")
+        if not expected:
+            print(f"EXPORT_VERIFY: FAIL (entry {idx} missing hash)")
+            return 2
+
+        recalculated = sha256_of_entry_without_hash(entry)
+        if recalculated != expected:
+            print(f"EXPORT_VERIFY: FAIL (entry {idx} hash mismatch)")
+            return 2
+
+        if entry.get("previous_hash") != prev:
+            print(f"EXPORT_VERIFY: FAIL (entry {idx} previous_hash mismatch)")
+            return 2
+
+        prev = expected
+
+    print("EXPORT_VERIFY: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    path = "execution_log.json"
+    if len(sys.argv) >= 2:
+        path = sys.argv[1]
+    raise SystemExit(verify_export(path))

--- a/examples/execution_integrity/verify_export.py
+++ b/examples/execution_integrity/verify_export.py
@@ -11,8 +11,18 @@ def sha256_of_entry_without_hash(entry):
 
 
 def verify_export(path):
-    with open(path, "r") as f:
-        data = json.load(f)
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        print("EXPORT_VERIFY: FAIL (file not found)")
+        return 2
+    except json.JSONDecodeError:
+        print("EXPORT_VERIFY: FAIL (invalid json)")
+        return 2
+    except Exception:
+        print("EXPORT_VERIFY: FAIL (unexpected error)")
+        return 2
 
     required_top = ["spec", "version", "exported_at", "hash_alg", "chain"]
     for key in required_top:


### PR DESCRIPTION
This PR adds a minimal execution integrity demo (hash-chained, deterministic export).
No dependency. No core changes.
Feel free to close if not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Execution Integrity example to record an append-only execution log and export tamper-evident traces.
  * Added a demo that records events, simulates tampering, and shows verification before and after tampering.
  * Added a command-line verifier to validate exported logs and report pass/fail status.

* **Documentation**
  * New README with run commands, expected verification results, and usage notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->