### PR TITLE
fix: improve streaming support for Bedrock

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm.py
@@ -378,7 +378,6 @@ class AugmentedLLM(ContextDependent, AugmentedLLMProtocol[MessageParamT, Message
     ) -> ModelT:
         """Request a structured LLM generation and return the result as a Pydantic model."""
 
-    @abstractmethod
     async def generate_stream(
         self,
         message: MessageTypes,

--- a/src/mcp_agent/workflows/llm/augmented_llm_bedrock.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_bedrock.py
@@ -237,24 +237,13 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                             request=tool_call_request, tool_call_id=tool_use_id
                         )
 
-                        tool_results.append(
-                            {
-                                "toolResult": {
-                                    "content": mcp_content_to_bedrock_content(
-                                        result.content
-                                    ),
-                                    "toolUseId": tool_use_id,
-                                    "status": "error" if result.isError else "success",
-                                }
-                            }
-                        )
+                        tool_results.append((tool_use_id, result))
 
                 # Create a single message with all tool results
                 if tool_results:
-                    tool_result_message = {
-                        "role": "user",
-                        "content": tool_results,
-                    }
+                    tool_result_message = BedrockConverter.create_tool_results_message(
+                        tool_results
+                    )
 
                     messages.append(tool_result_message)
                     responses.append(tool_result_message)
@@ -271,9 +260,11 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
         """Parse tool input from JSON string to dict if needed.
 
         Bedrock streams tool input as a JSON string that needs parsing.
-        Returns empty dict for empty strings (tools with no arguments).
+        Returns empty dict for None and empty strings (tools with no arguments).
         Falls back to the original value if parsing fails.
         """
+        if tool_input is None:
+            return {}
         if isinstance(tool_input, str):
             # Handle empty string as no arguments
             if tool_input == "":
@@ -569,19 +560,7 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                             )
 
                             # Collect tool result
-                            tool_results.append(
-                                {
-                                    "toolResult": {
-                                        "content": mcp_content_to_bedrock_content(
-                                            result.content
-                                        ),
-                                        "toolUseId": tool_use_id,
-                                        "status": "error"
-                                        if result.isError
-                                        else "success",
-                                    }
-                                }
-                            )
+                            tool_results.append((tool_use_id, result))
 
                             # Yield tool use end event
                             yield StreamEvent(
@@ -593,10 +572,9 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
 
                     # Create a single message with all tool results
                     if tool_results:
-                        tool_result_message: MessageUnionTypeDef = {
-                            "role": "user",
-                            "content": tool_results,
-                        }
+                        tool_result_message = BedrockConverter.create_tool_results_message(
+                            tool_results
+                        )
                         messages.append(tool_result_message)
                         responses.append(tool_result_message)
 

--- a/src/mcp_agent/workflows/llm/augmented_llm_bedrock.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_bedrock.py
@@ -536,7 +536,6 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                             yield StreamEvent(
                                 type=StreamEventType.TOOL_USE_START,
                                 content={
-                                    "id": tool_use_id,
                                     "name": tool_name,
                                     "input": tool_args,
                                 },
@@ -563,7 +562,6 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                                 content={
                                     "result": str(result.content),
                                     "is_error": result.isError,
-                                    "tool_use_id": tool_use_id,
                                 },
                                 iteration=i,
                                 model=model,

--- a/src/mcp_agent/workflows/llm/augmented_llm_bedrock.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_bedrock.py
@@ -561,9 +561,9 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                             yield StreamEvent(
                                 type=StreamEventType.TOOL_RESULT,
                                 content={
-                                    "tool_use_id": tool_use_id,
-                                    "content": str(result.content),
+                                    "result": str(result.content),
                                     "is_error": result.isError,
+                                    "tool_use_id": tool_use_id,
                                 },
                                 iteration=i,
                                 model=model,

--- a/src/mcp_agent/workflows/llm/augmented_llm_bedrock.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_bedrock.py
@@ -576,7 +576,6 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                             tool_results
                         )
                         messages.append(tool_result_message)
-                        responses.append(tool_result_message)
 
                     # Refresh tools to pick up any newly available tools enabled by previous execution
                     tool_config = await update_tools()

--- a/src/mcp_agent/workflows/llm/augmented_llm_bedrock.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_bedrock.py
@@ -223,7 +223,7 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                     if content.get("toolUse"):
                         tool_use_block = content["toolUse"]
                         tool_name = tool_use_block["name"]
-                        tool_args = tool_use_block["input"]
+                        tool_args = self._parse_tool_input(tool_use_block["input"])
                         tool_use_id = tool_use_block["toolUseId"]
 
                         tool_call_request = CallToolRequest(
@@ -271,9 +271,13 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
         """Parse tool input from JSON string to dict if needed.
 
         Bedrock streams tool input as a JSON string that needs parsing.
+        Returns empty dict for empty strings (tools with no arguments).
         Falls back to the original value if parsing fails.
         """
         if isinstance(tool_input, str):
+            # Handle empty string as no arguments
+            if tool_input == "":
+                return {}
             try:
                 return json.loads(tool_input)
             except json.JSONDecodeError:
@@ -418,7 +422,7 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                     if "contentBlockStart" in event:
                         block_start = event["contentBlockStart"]
                         if "toolUse" in block_start.get("start", {}):
-                            current_tool_use_block = block_start["start"]["toolUse"]
+                            current_tool_use_block = dict(block_start["start"]["toolUse"])
 
                     # Handle text deltas
                     elif "contentBlockDelta" in event:
@@ -515,7 +519,9 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                     )
                     break
                 elif stop_reason == "tool_use":
-                    # Process tool calls
+                    # Collect all tool results first
+                    tool_results = []
+
                     for content in response_message["content"]:
                         if content.get("toolUse"):
                             tool_use_block = content["toolUse"]
@@ -530,6 +536,7 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                             yield StreamEvent(
                                 type=StreamEventType.TOOL_USE_START,
                                 content={
+                                    "id": tool_use_id,
                                     "name": tool_name,
                                     "input": tool_args,
                                 },
@@ -554,7 +561,8 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                             yield StreamEvent(
                                 type=StreamEventType.TOOL_RESULT,
                                 content={
-                                    "result": str(result.content),
+                                    "tool_use_id": tool_use_id,
+                                    "content": str(result.content),
                                     "is_error": result.isError,
                                 },
                                 iteration=i,
@@ -562,24 +570,20 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                                 metadata={"tool_id": tool_use_id},
                             )
 
-                            # Add tool result to messages
-                            tool_result_message: MessageUnionTypeDef = {
-                                "role": "user",
-                                "content": [
-                                    {
-                                        "toolResult": {
-                                            "content": mcp_content_to_bedrock_content(
-                                                result.content
-                                            ),
-                                            "toolUseId": tool_use_id,
-                                            "status": "error"
-                                            if result.isError
-                                            else "success",
-                                        }
+                            # Collect tool result
+                            tool_results.append(
+                                {
+                                    "toolResult": {
+                                        "content": mcp_content_to_bedrock_content(
+                                            result.content
+                                        ),
+                                        "toolUseId": tool_use_id,
+                                        "status": "error"
+                                        if result.isError
+                                        else "success",
                                     }
-                                ],
-                            }
-                            messages.append(tool_result_message)
+                                }
+                            )
 
                             # Yield tool use end event
                             yield StreamEvent(
@@ -588,6 +592,15 @@ class BedrockAugmentedLLM(AugmentedLLM[MessageUnionTypeDef, MessageUnionTypeDef]
                                 model=model,
                                 metadata={"tool_id": tool_use_id},
                             )
+
+                    # Create a single message with all tool results
+                    if tool_results:
+                        tool_result_message: MessageUnionTypeDef = {
+                            "role": "user",
+                            "content": tool_results,
+                        }
+                        messages.append(tool_result_message)
+                        responses.append(tool_result_message)
 
                     # Refresh tools to pick up any newly available tools enabled by previous execution
                     tool_config = await update_tools()

--- a/tests/workflows/llm/test_bedrock_streaming.py
+++ b/tests/workflows/llm/test_bedrock_streaming.py
@@ -405,3 +405,8 @@ class TestBedrockStreaming:
         assert len(tool_result_events) == 1
         assert tool_result_events[0].content is not None
         assert tool_result_events[0].content.get("is_error") is False
+        assert tool_result_events[0].content.get("tool_use_id") is not None
+        assert isinstance(tool_result_events[0].content.get("tool_use_id"), str)
+        assert len(tool_result_events[0].content.get("tool_use_id")) > 0
+        assert tool_result_events[0].content.get("result") is not None
+        assert isinstance(tool_result_events[0].content.get("result"), str)

--- a/tests/workflows/llm/test_bedrock_streaming.py
+++ b/tests/workflows/llm/test_bedrock_streaming.py
@@ -405,8 +405,6 @@ class TestBedrockStreaming:
         assert len(tool_result_events) == 1
         assert tool_result_events[0].content is not None
         assert tool_result_events[0].content.get("is_error") is False
-        assert tool_result_events[0].content.get("tool_use_id") is not None
-        assert isinstance(tool_result_events[0].content.get("tool_use_id"), str)
-        assert len(tool_result_events[0].content.get("tool_use_id")) > 0
         assert tool_result_events[0].content.get("result") is not None
         assert isinstance(tool_result_events[0].content.get("result"), str)
+        assert tool_result_events[0].metadata.get("tool_id") == "calc_1"

--- a/tests/workflows/llm/test_bedrock_streaming.py
+++ b/tests/workflows/llm/test_bedrock_streaming.py
@@ -131,7 +131,7 @@ class TestBedrockStreaming:
     @pytest.mark.asyncio
     async def test_multi_iteration_with_tool_calls(self, mock_llm):
         """Test multi-iteration streaming with tool calls."""
-        # First iteration: tool use
+        # First iteration: tool use with populated input
         tool_use_events = [
             self.create_content_block_start_event(
                 {"name": "search", "toolUseId": "tool_1", "input": {"query": "test"}}
@@ -141,7 +141,17 @@ class TestBedrockStreaming:
             self.create_metadata_event(input_tokens=50, output_tokens=20),
         ]
 
-        # Second iteration: final text
+        # Second iteration: tool use with empty input (no-arg tool)
+        empty_tool_events = [
+            self.create_content_block_start_event(
+                {"name": "ping", "toolUseId": "tool_empty"}
+            ),
+            self.create_content_block_stop_event(),
+            self.create_message_stop_event("tool_use"),
+            self.create_metadata_event(input_tokens=30, output_tokens=10),
+        ]
+
+        # Third iteration: final text
         text_events = [
             self.create_text_delta_event("Based"),
             self.create_text_delta_event(" on search"),
@@ -161,9 +171,13 @@ class TestBedrockStreaming:
 
         def mock_converse_stream(**kwargs):
             call_count[0] += 1
-            call_history.append(kwargs)
+            # Deep-copy kwargs before storing to capture the exact request state
+            import copy
+            call_history.append(copy.deepcopy(kwargs))
             if call_count[0] == 1:
                 return self.create_mock_stream_response(tool_use_events)
+            elif call_count[0] == 2:
+                return self.create_mock_stream_response(empty_tool_events)
             else:
                 return self.create_mock_stream_response(text_events)
 
@@ -180,45 +194,78 @@ class TestBedrockStreaming:
             async for event in mock_llm.generate_stream("Search for something"):
                 events.append(event)
 
-            # Verify converse_stream was called twice
-            assert call_count[0] == 2
+            # Verify converse_stream was called three times (2 tool calls + 1 text)
+            assert call_count[0] == 3
 
             # Verify the second call's payload contains a single role="user" tool-result message
-            assert len(call_history) == 2
+            assert len(call_history) == 3
             second_call_kwargs = call_history[1]
             assert "messages" in second_call_kwargs
             second_call_messages = second_call_kwargs["messages"]
 
-            # Find the user message with tool results
+            # Find the user message with tool results for the first tool
             user_tool_result_messages = [
                 m for m in second_call_messages
                 if m.get("role") == "user" and any(c.get("toolResult") for c in m.get("content", []))
             ]
             assert len(user_tool_result_messages) == 1, "Expected exactly one user message with tool results"
 
+            # Verify the third call's payload contains tool result for the empty-input tool
+            # At this point, both tool results are accumulated in the messages
+            third_call_kwargs = call_history[2]
+            assert "messages" in third_call_kwargs
+            third_call_messages = third_call_kwargs["messages"]
+
+            # Find user messages with tool results (should have 2: one for each tool)
+            second_user_tool_result_messages = [
+                m for m in third_call_messages
+                if m.get("role") == "user" and any(c.get("toolResult") for c in m.get("content", []))
+            ]
+            assert len(second_user_tool_result_messages) == 2, "Expected two user messages with tool results (one for each tool)"
+
         # Verify we have multiple iterations
         iteration_start_events = [
             e for e in events if e.type == StreamEventType.ITERATION_START
         ]
-        assert len(iteration_start_events) == 2
+        assert len(iteration_start_events) == 3
 
         # Check tool events
         tool_use_start_events = [
             e for e in events if e.type == StreamEventType.TOOL_USE_START
         ]
-        assert len(tool_use_start_events) == 1
+        assert len(tool_use_start_events) == 2
+
+        # First tool: search with populated input
         assert tool_use_start_events[0].content is not None
         assert tool_use_start_events[0].content.get("name") == "search"
+
+        # Second tool: ping with empty input - should parse to {}
+        assert tool_use_start_events[1].content is not None
+        assert tool_use_start_events[1].content.get("name") == "ping"
+        assert tool_use_start_events[1].content.get("input") == {}
 
         tool_result_events = [
             e for e in events if e.type == StreamEventType.TOOL_RESULT
         ]
-        assert len(tool_result_events) == 1
+        assert len(tool_result_events) == 2
 
         tool_use_end_events = [
             e for e in events if e.type == StreamEventType.TOOL_USE_END
         ]
-        assert len(tool_use_end_events) == 1
+        assert len(tool_use_end_events) == 2
+
+        # Verify call_tool was invoked with correct arguments
+        assert mock_llm.call_tool.call_count == 2
+        first_call_args = mock_llm.call_tool.call_args_list[0]
+        second_call_args = mock_llm.call_tool.call_args_list[1]
+
+        # First tool call: search with populated input
+        assert first_call_args.kwargs["request"].params.name == "search"
+        assert first_call_args.kwargs["request"].params.arguments == {"query": "test"}
+
+        # Second tool call: ping with empty dict (no arguments)
+        assert second_call_args.kwargs["request"].params.name == "ping"
+        assert second_call_args.kwargs["request"].params.arguments == {}
 
         # Check final completion
         complete_events = [e for e in events if e.type == StreamEventType.COMPLETE]

--- a/tests/workflows/llm/test_bedrock_streaming.py
+++ b/tests/workflows/llm/test_bedrock_streaming.py
@@ -65,6 +65,11 @@ class TestBedrockStreaming:
         """Creates a Bedrock content block stop event."""
         return {"contentBlockStop": {}}
 
+    @staticmethod
+    def create_metadata_event(input_tokens=100, output_tokens=50):
+        """Creates a Bedrock metadata event with usage information."""
+        return {"metadata": {"usage": {"inputTokens": input_tokens, "outputTokens": output_tokens}}}
+
     @pytest.mark.asyncio
     async def test_single_turn_text_streaming(self, mock_llm):
         """Test single-turn text generation with streaming."""
@@ -73,6 +78,7 @@ class TestBedrockStreaming:
         mock_events = [self.create_text_delta_event(delta) for delta in text_deltas]
         mock_events.append(self.create_content_block_stop_event())
         mock_events.append(self.create_message_stop_event("end_turn"))
+        mock_events.append(self.create_metadata_event(input_tokens=100, output_tokens=50))
 
         mock_stream_response = self.create_mock_stream_response(mock_events)
 
@@ -132,6 +138,7 @@ class TestBedrockStreaming:
             ),
             self.create_content_block_stop_event(),
             self.create_message_stop_event("tool_use"),
+            self.create_metadata_event(input_tokens=50, output_tokens=20),
         ]
 
         # Second iteration: final text
@@ -140,6 +147,7 @@ class TestBedrockStreaming:
             self.create_text_delta_event(" on search"),
             self.create_content_block_stop_event(),
             self.create_message_stop_event("end_turn"),
+            self.create_metadata_event(input_tokens=80, output_tokens=10),
         ]
 
         # Mock tool execution
@@ -208,6 +216,7 @@ class TestBedrockStreaming:
                 self.create_text_delta_event("Text"),
                 self.create_content_block_stop_event(),
                 self.create_message_stop_event(stop_reason),
+                self.create_metadata_event(),
             ]
             mock_stream_response = self.create_mock_stream_response(mock_events)
 
@@ -240,6 +249,7 @@ class TestBedrockStreaming:
             self.create_text_delta_event("third"),
             self.create_content_block_stop_event(),
             self.create_message_stop_event("end_turn"),
+            self.create_metadata_event(),
         ]
 
         mock_stream_response = self.create_mock_stream_response(mock_events)
@@ -293,6 +303,7 @@ class TestBedrockStreaming:
             self.create_text_delta_event("Response"),
             self.create_content_block_stop_event(),
             self.create_message_stop_event("end_turn"),
+            self.create_metadata_event(),
         ]
         mock_stream_response = self.create_mock_stream_response(mock_events)
 
@@ -316,6 +327,7 @@ class TestBedrockStreaming:
         mock_events = [self.create_text_delta_event(delta) for delta in text_deltas]
         mock_events.append(self.create_content_block_stop_event())
         mock_events.append(self.create_message_stop_event("end_turn"))
+        mock_events.append(self.create_metadata_event())
 
         mock_stream_response = self.create_mock_stream_response(mock_events)
 
@@ -348,6 +360,7 @@ class TestBedrockStreaming:
             ),
             self.create_content_block_stop_event(),
             self.create_message_stop_event("tool_use"),
+            self.create_metadata_event(input_tokens=30, output_tokens=15),
         ]
 
         # Mock tool execution
@@ -361,6 +374,7 @@ class TestBedrockStreaming:
             self.create_text_delta_event("The answer is 3"),
             self.create_content_block_stop_event(),
             self.create_message_stop_event("end_turn"),
+            self.create_metadata_event(input_tokens=50, output_tokens=10),
         ]
 
         call_count = [0]

--- a/tests/workflows/llm/test_bedrock_streaming.py
+++ b/tests/workflows/llm/test_bedrock_streaming.py
@@ -157,9 +157,11 @@ class TestBedrockStreaming:
         mock_llm.call_tool = AsyncMock(return_value=mock_tool_result)
 
         call_count = [0]
+        call_history = []
 
         def mock_converse_stream(**kwargs):
             call_count[0] += 1
+            call_history.append(kwargs)
             if call_count[0] == 1:
                 return self.create_mock_stream_response(tool_use_events)
             else:
@@ -177,6 +179,22 @@ class TestBedrockStreaming:
             events = []
             async for event in mock_llm.generate_stream("Search for something"):
                 events.append(event)
+
+            # Verify converse_stream was called twice
+            assert call_count[0] == 2
+
+            # Verify the second call's payload contains a single role="user" tool-result message
+            assert len(call_history) == 2
+            second_call_kwargs = call_history[1]
+            assert "messages" in second_call_kwargs
+            second_call_messages = second_call_kwargs["messages"]
+
+            # Find the user message with tool results
+            user_tool_result_messages = [
+                m for m in second_call_messages
+                if m.get("role") == "user" and any(c.get("toolResult") for c in m.get("content", []))
+            ]
+            assert len(user_tool_result_messages) == 1, "Expected exactly one user message with tool results"
 
         # Verify we have multiple iterations
         iteration_start_events = [


### PR DESCRIPTION
## Summary
This PR contains additional fixes for streaming support following the previous feature/streaming-support branch changes.

## Changes
- **augmented_llm.py**: Remove `@abstractmethod` decorator from `generate_stream` method to allow default implementations
- **augmented_llm_bedrock.py**: 
  - Fix tool input parsing to handle empty strings (tools with no arguments)
  - Create deep copy of tool use block dict to avoid mutation issues
  - Restructure tool result collection to batch all tool results into a single message
- **test_bedrock_streaming.py**: Add metadata events to test cases for completeness

## Test plan
- [x] Run existing tests
- [x] Verify streaming with tool calls works correctly
- [x] Test tools with empty arguments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool invocation parsing improved and tool results are now sent as aggregated messages in both streaming and non‑streaming flows.

* **Bug Fixes**
  * Empty or missing tool inputs are handled gracefully; tool-result collection and consolidation are more robust.

* **Tests**
  * Added metadata/usage event helper and extended tests to validate aggregated tool-result payloads and metadata inclusion.

* **Refactor**
  * Streaming support for LLM integrations made optional for implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->