### PR TITLE
feat: add AG2 (formerly Autogen) example

### DIFF
--- a/examples/ag2/.env.example
+++ b/examples/ag2/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=changethis

--- a/examples/ag2/.env.example
+++ b/examples/ag2/.env.example
@@ -1,1 +1,2 @@
-OPENAI_API_KEY=changethis
+# No additional API keys needed for this example
+# DuckDuckGo search requires no credentials

--- a/examples/ag2/README.md
+++ b/examples/ag2/README.md
@@ -1,8 +1,11 @@
-# AG2 ConversableAgent Integration Example
+# AG2 Tools Integration Example
 
-This example demonstrates integrating an AG2 (formerly AutoGen) ConversableAgent into
-MCP Agent as a tool. The AG2 agent acts as a specialist — when the MCP Agent needs to
-solve a math problem, it delegates to the AG2 ConversableAgent and uses its reply.
+This example demonstrates integrating tools from the AG2 (formerly AutoGen) framework
+into MCP Agent. Similar to the LangChain and CrewAI examples, this shows how to reuse
+existing tools from the broader AI ecosystem.
+
+In this example, we use AG2's DuckDuckGo search tool within an MCP Agent workflow.
+No additional API keys are needed beyond OpenAI — DuckDuckGo search is free and keyless.
 
 ## App Setup
 

--- a/examples/ag2/README.md
+++ b/examples/ag2/README.md
@@ -1,0 +1,48 @@
+# AG2 ConversableAgent Integration Example
+
+This example demonstrates integrating an AG2 (formerly AutoGen) ConversableAgent into
+MCP Agent as a tool. The AG2 agent acts as a specialist — when the MCP Agent needs to
+solve a math problem, it delegates to the AG2 ConversableAgent and uses its reply.
+
+## App Setup
+
+Clone the repo and navigate to the AG2 example:
+
+```bash
+git clone https://github.com/lastmile-ai/mcp-agent.git
+cd mcp-agent/examples/ag2
+```
+
+Install `uv` (if you don't have it):
+
+```bash
+pip install uv
+```
+
+Sync `mcp-agent` project dependencies:
+
+```bash
+uv sync --extra ag2
+```
+
+Install requirements specific to this example:
+
+```bash
+uv pip install -r requirements.txt
+```
+
+## Set up API Keys
+
+Create a `.env` file in this directory with your OpenAI API key:
+
+```bash
+OPENAI_API_KEY=your_openai_api_key_here
+```
+
+## Run the Example
+
+Run your MCP Agent app:
+
+```bash
+uv run main.py
+```

--- a/examples/ag2/main.py
+++ b/examples/ag2/main.py
@@ -1,0 +1,62 @@
+import asyncio
+import os
+import time
+
+from dotenv import load_dotenv
+
+from mcp_agent.app import MCPApp
+from mcp_agent.agents.agent import Agent
+from mcp_agent.tools.ag2_tool import from_ag2_agent
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+from autogen import ConversableAgent, LLMConfig
+
+# Load env variables
+load_dotenv()
+
+app = MCPApp(name="ag2_example")
+
+
+async def example_usage():
+    async with app.run() as agent_app:
+        logger = agent_app.logger
+
+        # Create an AG2 ConversableAgent as a specialist
+        llm_config = LLMConfig(
+            api_type="openai",
+            model="gpt-4o-mini",
+            api_key=os.environ.get("OPENAI_API_KEY"),
+        )
+
+        with llm_config:
+            math_agent = ConversableAgent(
+                name="math_expert",
+                system_message="You are a math expert. Solve math problems step by step and return the final answer.",
+                human_input_mode="NEVER",
+                description="A math expert agent that can solve mathematical problems.",
+            )
+
+        # Wrap the AG2 agent as a tool for mcp-agent
+        agent = Agent(
+            name="assistant",
+            instruction="You are a helpful assistant. Use the math_expert tool to solve any math problems.",
+            server_names=[],
+            functions=[from_ag2_agent(math_agent)],
+        )
+
+        async with agent:
+            llm = await agent.attach_llm(OpenAIAugmentedLLM)
+
+            result = await llm.generate_str(
+                message="What is the sum of the first 10 prime numbers?",
+            )
+
+            logger.info(f"Result: {result}")
+
+
+if __name__ == "__main__":
+    start = time.time()
+    asyncio.run(example_usage())
+    end = time.time()
+    t = end - start
+
+    print(f"Total run time: {t:.2f}s")

--- a/examples/ag2/main.py
+++ b/examples/ag2/main.py
@@ -1,14 +1,13 @@
 import asyncio
-import os
 import time
 
 from dotenv import load_dotenv
 
 from mcp_agent.app import MCPApp
 from mcp_agent.agents.agent import Agent
-from mcp_agent.tools.ag2_tool import from_ag2_agent
+from mcp_agent.tools.ag2_tool import from_ag2_tool
 from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
-from autogen import ConversableAgent, LLMConfig
+from autogen.tools.experimental import DuckDuckGoSearchTool
 
 # Load env variables
 load_dotenv()
@@ -20,34 +19,21 @@ async def example_usage():
     async with app.run() as agent_app:
         logger = agent_app.logger
 
-        # Create an AG2 ConversableAgent as a specialist
-        llm_config = LLMConfig(
-            api_type="openai",
-            model="gpt-4o-mini",
-            api_key=os.environ.get("OPENAI_API_KEY"),
-        )
+        # Instantiate AG2 tool
+        search_tool = DuckDuckGoSearchTool()
 
-        with llm_config:
-            math_agent = ConversableAgent(
-                name="math_expert",
-                system_message="You are a math expert. Solve math problems step by step and return the final answer.",
-                human_input_mode="NEVER",
-                description="A math expert agent that can solve mathematical problems.",
-            )
-
-        # Wrap the AG2 agent as a tool for mcp-agent
-        agent = Agent(
-            name="assistant",
-            instruction="You are a helpful assistant. Use the math_expert tool to solve any math problems.",
+        search_agent = Agent(
+            name="search_agent",
+            instruction="""You are a helpful assistant.""",
             server_names=[],
-            functions=[from_ag2_agent(math_agent)],
+            functions=[from_ag2_tool(search_tool)],
         )
 
-        async with agent:
-            llm = await agent.attach_llm(OpenAIAugmentedLLM)
+        async with search_agent:
+            llm = await search_agent.attach_llm(OpenAIAugmentedLLM)
 
             result = await llm.generate_str(
-                message="What is the sum of the first 10 prime numbers?",
+                message="Who is Singapore's current prime minister?",
             )
 
             logger.info(f"Result: {result}")

--- a/examples/ag2/mcp_agent.config.yaml
+++ b/examples/ag2/mcp_agent.config.yaml
@@ -1,0 +1,17 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+logger:
+  transports: [console, file]
+  level: debug
+  progress_display: true
+  path_settings:
+    path_pattern: "logs/mcp-agent-{unique_id}.jsonl"
+    unique_id: "timestamp" # Options: "timestamp" or "session_id"
+    timestamp_format: "%Y%m%d_%H%M%S"
+
+# mcp:
+#   servers:
+
+openai:
+  default_model: "gpt-4o-mini"

--- a/examples/ag2/mcp_agent.secrets.yaml.example
+++ b/examples/ag2/mcp_agent.secrets.yaml.example
@@ -1,0 +1,4 @@
+$schema: ../../schema/mcp-agent.config.schema.json
+
+openai:
+  api_key: openai_api_key

--- a/examples/ag2/requirements.txt
+++ b/examples/ag2/requirements.txt
@@ -1,0 +1,6 @@
+# Core framework dependency
+mcp-agent @ file://../../  # Link to the local mcp-agent project root
+
+# Additional dependencies specific to this example
+openai
+ag2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ redis = [
 crewai = [
     "crewai>=0.126.0",
 ]
+ag2 = [
+    "ag2>=0.11.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/mcp_agent/tools/ag2_tool.py
+++ b/src/mcp_agent/tools/ag2_tool.py
@@ -1,23 +1,20 @@
 import inspect
 from typing import Callable, Any, Optional
 
-from autogen import ConversableAgent
+from autogen.tools import Tool as AG2Tool
 
 
-def from_ag2_agent(
-    agent: ConversableAgent,
+def from_ag2_tool(
+    ag2_tool: AG2Tool,
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
 ) -> Callable[..., Any]:
     """
-    Convert an AG2 ConversableAgent to a plain Python function.
-
-    The resulting function takes a message string, sends it to the agent,
-    and returns the agent's reply as a string.
+    Convert an AG2 tool to a plain Python function.
 
     Args:
-        agent: The AG2 ConversableAgent to convert.
+        ag2_tool: The AG2 Tool to convert.
         name: Optional override for the function name.
         description: Optional override for the function docstring.
 
@@ -27,41 +24,42 @@ def from_ag2_agent(
     # Set name with fallback
     if name:
         func_name = name
-    elif hasattr(agent, "name") and agent.name:
-        func_name = agent.name.replace(" ", "_").lower()
+    elif hasattr(ag2_tool, "name") and ag2_tool.name:
+        func_name = ag2_tool.name.replace(" ", "_").lower()
     else:
-        func_name = "ag2_agent_func"
+        func_name = "ag2_tool_func"
 
     # Set description with fallback
     if description:
         func_doc = description
-    elif hasattr(agent, "description") and agent.description:
-        func_doc = agent.description
-    elif hasattr(agent, "system_message") and agent.system_message:
-        func_doc = agent.system_message
+    elif hasattr(ag2_tool, "description") and ag2_tool.description:
+        func_doc = ag2_tool.description
     else:
-        func_doc = f"Send a message to the {func_name} agent and get a reply."
+        func_doc = ""
 
-    def wrapper(message: str) -> str:
-        """Send a message to the AG2 agent and return its reply."""
-        reply = agent.generate_reply(
-            messages=[{"content": message, "role": "user"}],
+    # AG2 Tool exposes .func property with the underlying callable
+    if hasattr(ag2_tool, "func") and ag2_tool.func is not None:
+        func = ag2_tool.func
+        func.__name__ = func_name
+        func.__doc__ = func_doc
+        return func
+
+    elif callable(ag2_tool):
+        # Tool is directly callable via __call__
+        def wrapper(*args, **kwargs):
+            return ag2_tool(*args, **kwargs)
+
+        wrapper.__name__ = func_name
+        wrapper.__doc__ = func_doc
+
+        try:
+            wrapper.__signature__ = inspect.signature(ag2_tool.func)
+        except (ValueError, TypeError, AttributeError):
+            pass
+
+        return wrapper
+
+    else:
+        raise ValueError(
+            "AG2 tool must have a 'func' property or be callable."
         )
-
-        # Handle different reply types
-        if isinstance(reply, dict):
-            return reply.get("content", "")
-        elif isinstance(reply, str):
-            return reply
-        else:
-            return ""
-
-    # Set metadata
-    wrapper.__name__ = func_name
-    wrapper.__doc__ = func_doc
-    wrapper.__signature__ = inspect.Signature(
-        [inspect.Parameter("message", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=str)]
-    )
-    wrapper.__annotations__ = {"message": str, "return": str}
-
-    return wrapper

--- a/src/mcp_agent/tools/ag2_tool.py
+++ b/src/mcp_agent/tools/ag2_tool.py
@@ -1,0 +1,67 @@
+import inspect
+from typing import Callable, Any, Optional
+
+from autogen import ConversableAgent
+
+
+def from_ag2_agent(
+    agent: ConversableAgent,
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> Callable[..., Any]:
+    """
+    Convert an AG2 ConversableAgent to a plain Python function.
+
+    The resulting function takes a message string, sends it to the agent,
+    and returns the agent's reply as a string.
+
+    Args:
+        agent: The AG2 ConversableAgent to convert.
+        name: Optional override for the function name.
+        description: Optional override for the function docstring.
+
+    Returns:
+        Callable[..., Any]: Function with correct signature and metadata.
+    """
+    # Set name with fallback
+    if name:
+        func_name = name
+    elif hasattr(agent, "name") and agent.name:
+        func_name = agent.name.replace(" ", "_").lower()
+    else:
+        func_name = "ag2_agent_func"
+
+    # Set description with fallback
+    if description:
+        func_doc = description
+    elif hasattr(agent, "description") and agent.description:
+        func_doc = agent.description
+    elif hasattr(agent, "system_message") and agent.system_message:
+        func_doc = agent.system_message
+    else:
+        func_doc = f"Send a message to the {func_name} agent and get a reply."
+
+    def wrapper(message: str) -> str:
+        """Send a message to the AG2 agent and return its reply."""
+        reply = agent.generate_reply(
+            messages=[{"content": message, "role": "user"}],
+        )
+
+        # Handle different reply types
+        if isinstance(reply, dict):
+            return reply.get("content", "")
+        elif isinstance(reply, str):
+            return reply
+        else:
+            return ""
+
+    # Set metadata
+    wrapper.__name__ = func_name
+    wrapper.__doc__ = func_doc
+    wrapper.__signature__ = inspect.Signature(
+        [inspect.Parameter("message", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=str)]
+    )
+    wrapper.__annotations__ = {"message": str, "return": str}
+
+    return wrapper


### PR DESCRIPTION
## Add AG2 (formerly AutoGen) integration example

Adds support for using AG2 ConversableAgent as a tool within mcp-agent, following the same pattern as the existing LangChain and CrewAI integrations.

### Changes
- **`src/mcp_agent/tools/ag2_tool.py`** — New `from_ag2_agent()` converts AG2 wrapped tools to be use by mcp_agent
- **`examples/ag2/`** — Example showing a DuckDuckGoSearchTool imported by AG2 in a mcp-agent Agent
- **`pyproject.toml`** — Added `ag2` optional dependency (`ag2>=0.11.0`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AG2 (formerly AutoGen) agent integration for MCP Agent workflows, plus an optional "ag2" dependency group.
  * Added a utility to adapt AG2 tools for use within MCP Agent workflows.

* **Examples**
  * New runnable example, configuration and secrets templates, requirements, and environment sample for the AG2 integration.

* **Documentation**
  * Added README with end-to-end setup and run instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->