### PR TITLE
docs: clarify how deploy auth works after login

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,8 @@ uvx mcp-agent deploy my-agent
 uvx mcp-agent cloud apps list
 ```
 
+`uvx mcp-agent login` stores your Cloud credential under `~/.mcp-agent/`. If you are deploying from CI or another non-interactive environment, set `MCP_API_KEY` or pass `--api-key` to `uvx mcp-agent deploy`.
+
 Docs: [Cloud overview](https://docs.mcp-agent.com/cloud/overview) • [Deployment quickstart](https://docs.mcp-agent.com/cloud/deployment-quickstart) • Examples: [`examples/cloud`](./examples/cloud/).
 
 ## Examples
@@ -714,7 +716,7 @@ You can use mcp-agent applications in a standalone fashion (i.e. they aren't par
 
 ### How do I deploy to Cloud?
 
-Run `uvx mcp-agent deploy <app-name>` after logging in with `uvx mcp-agent login`. The CLI packages your project, provisions secrets, and exposes an MCP endpoint backed by a durable Temporal runtime. See the [Cloud quickstart](https://docs.mcp-agent.com/get-started/
+Run `uvx mcp-agent deploy <app-name>` after logging in with `uvx mcp-agent login`. That login flow stores credentials under `~/.mcp-agent/`, so later deploys can reuse them automatically. If you prefer, you can also set `MCP_API_KEY` or pass `--api-key` directly to the deploy command. The CLI packages your project, provisions secrets, and exposes an MCP endpoint backed by a durable Temporal runtime. See the [Cloud quickstart](https://docs.mcp-agent.com/get-started/
 cloud) for step-by-step screenshots and CLI output.
 
 ### Where is the API reference?

--- a/docs/cloud/deployment-quickstart.mdx
+++ b/docs/cloud/deployment-quickstart.mdx
@@ -28,6 +28,19 @@ uvx mcp-agent login
 
 The CLI opens a browser window so you can sign in with GitHub or Google and generate an API key. Credentials are cached under `~/.mcp-agent/credentials.json`. In CI, set the `MCP_API_KEY` environment variable instead.
 
+If you need to deploy from another shell, machine, or CI runner, you can use the same key with either:
+
+```bash
+uvx mcp-agent deploy my-agent --api-key "$MCP_API_KEY"
+```
+
+or:
+
+```bash
+export MCP_API_KEY=lm_mcp_api_...
+uvx mcp-agent deploy my-agent
+```
+
 ## 2. Confirm your project layout
 
 Minimal structure:

--- a/docs/get-started/cloud.mdx
+++ b/docs/get-started/cloud.mdx
@@ -39,7 +39,16 @@ With that context, the steps below show exactly how to deploy.
 uvx mcp-agent login
 ```
 
-The CLI opens the Cloud dashboard so you can generate an API token. Credentials are stored under `~/.mcp-agent/`.
+The CLI opens the Cloud dashboard so you can generate an API token. Credentials are stored under `~/.mcp-agent/`, so later `deploy`, `cloud`, and `install` commands can reuse them automatically.
+
+If you want to deploy from CI or another non-interactive environment, set `MCP_API_KEY` or pass `--api-key` directly:
+
+```bash
+export MCP_API_KEY=<your-api-key>
+uvx mcp-agent deploy my-agent
+# or
+uvx mcp-agent deploy my-agent --api-key <your-api-key>
+```
 
 ## 2. Deploy
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -161,7 +161,7 @@ uvx mcp-agent login
 uvx mcp-agent deploy
 ```
 
-`uvx mcp-agent login` opens a browser so you can sign in and generate an API key for cloud deployments. The CLI stores that key locally so later `deploy`, `cloud`, and `install` commands can reuse it automatically. If you are deploying from CI or another non-interactive environment, set `MCP_API_KEY` instead or pass `--api-key` directly to `uvx mcp-agent deploy`.
+`uvx mcp-agent login` opens a browser so you can sign in and generate an API key for cloud deployments. The CLI stores that key under `~/.mcp-agent/` so later `deploy`, `cloud`, and `install` commands can reuse it automatically. If you are deploying from CI or another non-interactive environment, set `MCP_API_KEY` instead or pass `--api-key` directly to `uvx mcp-agent deploy`.
 
 ## Next steps
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -161,6 +161,8 @@ uvx mcp-agent login
 uvx mcp-agent deploy
 ```
 
+`uvx mcp-agent login` opens a browser so you can sign in and generate an API key for cloud deployments. The CLI stores that key locally so later `deploy`, `cloud`, and `install` commands can reuse it automatically. If you are deploying from CI or another non-interactive environment, set `MCP_API_KEY` instead or pass `--api-key` directly to `uvx mcp-agent deploy`.
+
 ## Next steps
 
 - Check out the generated README (if you used the CLI) for tips on extending the agent.

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -34,7 +34,14 @@ uvx mcp-agent login
 | `--api-key TEXT` | Provide an existing API key (also reads `MCP_API_KEY`). |
 | `--no-open` | Prevent the CLI from opening a browser tab during login. |
 
-After authenticating, `uvx mcp-agent cloud auth whoami` confirms the active account (use `uv run mcp-agent …` if you prefer to stay inside your project environment). Run `uvx mcp-agent cloud auth logout` to clear stored credentials.
+After authenticating, the CLI stores credentials under `~/.mcp-agent/`. `uvx mcp-agent cloud auth whoami` confirms the active account (use `uv run mcp-agent …` if you prefer to stay inside your project environment). Run `uvx mcp-agent cloud auth logout` to clear stored credentials.
+
+If you prefer not to rely on stored credentials, set `MCP_API_KEY` or pass `--api-key` when deploying:
+
+```bash
+export MCP_API_KEY=<your-api-key>
+uvx mcp-agent deploy research-agent
+```
 
 ### Initialise a project (`mcp-agent init`)
 


### PR DESCRIPTION
## Summary
- clarify that mcp-agent login opens a browser and generates a reusable API key
- explain that the CLI stores credentials locally for later deploy/cloud/install commands
- add explicit MCP_API_KEY and --api-key examples for CI or other non-interactive deployments

Closes #618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for non-interactive/CI deployments showing how to supply API keys via an environment variable or a deploy-time flag.
  * Clarified that the CLI’s browser-based login generates and persists cloud credentials for reuse by deploy, cloud, and install commands.
  * Included concrete command examples demonstrating both interactive and delegated (key-based) deployment flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->