### PR TITLE
fix(agent): skip failed capability lookups for unavailable servers

### DIFF
--- a/src/mcp_agent/agents/agent.py
+++ b/src/mcp_agent/agents/agent.py
@@ -1538,11 +1538,19 @@ class AgentTasks:
             if not server_name:
                 # If no server name is provided, get capabilities for all servers
                 server_names: List[str] = aggregator.server_names
-                capabilities: List[ServerCapabilities] = await asyncio.gather(
+                capabilities = await asyncio.gather(
                     *[aggregator.get_capabilities(server_name=n) for n in server_names],
                     return_exceptions=True,
                 )
-                server_capabilities = dict(zip(server_names, capabilities))
+                for name, capability in zip(server_names, capabilities):
+                    if isinstance(capability, BaseException):
+                        logger.warning(
+                            "Failed to get capabilities for server '%s': %s",
+                            name,
+                            capability,
+                        )
+                        continue
+                    server_capabilities[name] = capability
             else:
                 # If a server name is provided, get capabilities for that server
                 server_capabilities[server_name] = await aggregator.get_capabilities(

--- a/src/mcp_agent/agents/agent.py
+++ b/src/mcp_agent/agents/agent.py
@@ -1550,6 +1550,12 @@ class AgentTasks:
                             capability,
                         )
                         continue
+                    if capability is None:
+                        logger.warning(
+                            "Failed to get capabilities for server '%s': no capabilities returned",
+                            name,
+                        )
+                        continue
                     server_capabilities[name] = capability
             else:
                 # If a server name is provided, get capabilities for that server

--- a/tests/agents/test_agent_tasks_concurrency.py
+++ b/tests/agents/test_agent_tasks_concurrency.py
@@ -54,9 +54,11 @@ class FakeAggregator:
 
     async def get_capabilities(
         self, server_name: str | None = None
-    ) -> ServerCapabilities:
+    ) -> ServerCapabilities | None:
         if server_name in self.fail_capabilities_for:
             raise RuntimeError(f"{server_name} unavailable")
+        if server_name in getattr(self, "return_none_for", set()):
+            return None
         return ServerCapabilities()
 
     async def close(self):
@@ -186,3 +188,38 @@ async def test_get_capabilities_skips_failed_servers(monkeypatch):
 
     assert list(result.keys()) == ["srv1"]
     assert isinstance(result["srv1"], ServerCapabilities)
+
+
+@pytest.mark.anyio
+async def test_get_capabilities_skips_none_results(monkeypatch):
+    """MCPAggregator.get_capabilities can return None after logging a connection
+    or initialization error. The aggregator must treat that as a failed lookup
+    (same as a raised exception) instead of leaking {name: None} into the
+    capabilities dict."""
+    from mcp_agent.agents import agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "MCPAggregator", FakeAggregator)
+
+    ctx = SimpleNamespace()
+    tasks = AgentTasks(context=ctx)
+
+    agent_name = "writer"
+    req = InitAggregatorRequest(
+        agent_name=agent_name,
+        server_names=["srv1", "srv2"],
+        connection_persistence=True,
+        force=False,
+    )
+
+    await tasks.initialize_aggregator_task(req)
+
+    agg = tasks.server_aggregators_for_agent[agent_name]
+    agg.return_none_for = {"srv2"}
+
+    result = await tasks.get_capabilities_task(
+        agent_mod.GetCapabilitiesRequest(agent_name=agent_name, server_name=None)
+    )
+
+    assert list(result.keys()) == ["srv1"]
+    assert isinstance(result["srv1"], ServerCapabilities)
+    assert "srv2" not in result

--- a/tests/agents/test_agent_tasks_concurrency.py
+++ b/tests/agents/test_agent_tasks_concurrency.py
@@ -3,7 +3,7 @@ import pytest
 
 from types import SimpleNamespace
 
-from mcp.types import ListToolsResult
+from mcp.types import ListToolsResult, ServerCapabilities
 
 from mcp_agent.agents.agent import (
     AgentTasks,
@@ -31,6 +31,7 @@ class FakeAggregator:
         self._server_to_prompt_map = {}
         self._namespaced_resource_map = {}
         self._server_to_resource_map = {}
+        self.fail_capabilities_for: set[str] = set()
 
     def set_block(self, block: bool):
         self._block = block
@@ -50,6 +51,13 @@ class FakeAggregator:
         if self._block:
             await self._block_event.wait()
         return ListToolsResult(tools=[])
+
+    async def get_capabilities(
+        self, server_name: str | None = None
+    ) -> ServerCapabilities:
+        if server_name in self.fail_capabilities_for:
+            raise RuntimeError(f"{server_name} unavailable")
+        return ServerCapabilities()
 
     async def close(self):
         self.closed = True
@@ -148,3 +156,33 @@ async def test_shutdown_deferred_until_inflight_complete(monkeypatch):
     await anyio.sleep(0)
     async with tasks.server_aggregators_for_agent_lock:
         assert agent_name not in tasks.server_aggregators_for_agent
+
+
+@pytest.mark.anyio
+async def test_get_capabilities_skips_failed_servers(monkeypatch):
+    from mcp_agent.agents import agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "MCPAggregator", FakeAggregator)
+
+    ctx = SimpleNamespace()
+    tasks = AgentTasks(context=ctx)
+
+    agent_name = "writer"
+    req = InitAggregatorRequest(
+        agent_name=agent_name,
+        server_names=["srv1", "srv2"],
+        connection_persistence=True,
+        force=False,
+    )
+
+    await tasks.initialize_aggregator_task(req)
+
+    agg = tasks.server_aggregators_for_agent[agent_name]
+    agg.fail_capabilities_for.add("srv2")
+
+    result = await tasks.get_capabilities_task(
+        agent_mod.GetCapabilitiesRequest(agent_name=agent_name, server_name=None)
+    )
+
+    assert list(result.keys()) == ["srv1"]
+    assert isinstance(result["srv1"], ServerCapabilities)


### PR DESCRIPTION
## Summary
- stop mixing exception objects into the get_capabilities_task result map when one server fails
- log and skip failed capability lookups instead of returning a corrupt Dict[str, ServerCapabilities]
- add a regression test covering partial failure across multiple servers

Closes #671

## Verification
- python3 -m pytest tests/agents/test_agent_tasks_concurrency.py -k get_capabilities_skips_failed_servers (not runnable here because the sandbox Python environment is missing the mcp package required by tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When fetching capabilities from multiple servers, failed or missing responses are now skipped instead of appearing in results.
  * Added warning logs that identify which servers failed capability retrieval and why, improving troubleshooting visibility.

* **Tests**
  * Added tests verifying failed or None capability responses are omitted from aggregated results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->