### PR TITLE
fix(agent): skip failed server capability results

### DIFF
--- a/src/mcp_agent/agents/agent.py
+++ b/src/mcp_agent/agents/agent.py
@@ -1538,11 +1538,20 @@ class AgentTasks:
             if not server_name:
                 # If no server name is provided, get capabilities for all servers
                 server_names: List[str] = aggregator.server_names
-                capabilities: List[ServerCapabilities] = await asyncio.gather(
+                capabilities: List[
+                    ServerCapabilities | BaseException
+                ] = await asyncio.gather(
                     *[aggregator.get_capabilities(server_name=n) for n in server_names],
                     return_exceptions=True,
                 )
-                server_capabilities = dict(zip(server_names, capabilities))
+                for name, capability in zip(server_names, capabilities):
+                    if isinstance(capability, BaseException):
+                        logger.warning(
+                            f"Failed to get capabilities for server '{name}': {capability}"
+                        )
+                        continue
+
+                    server_capabilities[name] = capability
             else:
                 # If a server name is provided, get capabilities for that server
                 server_capabilities[server_name] = await aggregator.get_capabilities(

--- a/tests/agents/test_agent_tasks_concurrency.py
+++ b/tests/agents/test_agent_tasks_concurrency.py
@@ -3,10 +3,11 @@ import pytest
 
 from types import SimpleNamespace
 
-from mcp.types import ListToolsResult
+from mcp.types import ListToolsResult, ServerCapabilities
 
 from mcp_agent.agents.agent import (
     AgentTasks,
+    GetCapabilitiesRequest,
     InitAggregatorRequest,
     ListToolsRequest,
 )
@@ -22,6 +23,10 @@ class FakeAggregator:
         self.initialized_count = 0
         self.closed = False
         self.calls = 0
+        self.capabilities_by_server = {
+            server_name: ServerCapabilities() for server_name in server_names
+        }
+        self.capability_errors_by_server = {}
         self._block = False
         self._block_event = anyio.Event()
         # Mimic MCPAggregator internal maps expected by AgentTasks.initialize_aggregator_task
@@ -50,6 +55,11 @@ class FakeAggregator:
         if self._block:
             await self._block_event.wait()
         return ListToolsResult(tools=[])
+
+    async def get_capabilities(self, server_name: str) -> ServerCapabilities:
+        if server_name in self.capability_errors_by_server:
+            raise self.capability_errors_by_server[server_name]
+        return self.capabilities_by_server[server_name]
 
     async def close(self):
         self.closed = True
@@ -148,3 +158,34 @@ async def test_shutdown_deferred_until_inflight_complete(monkeypatch):
     await anyio.sleep(0)
     async with tasks.server_aggregators_for_agent_lock:
         assert agent_name not in tasks.server_aggregators_for_agent
+
+
+@pytest.mark.asyncio
+async def test_get_capabilities_filters_failed_servers(monkeypatch):
+    from mcp_agent.agents import agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "MCPAggregator", FakeAggregator)
+
+    ctx = SimpleNamespace()
+    tasks = AgentTasks(context=ctx)
+
+    agent_name = "writer"
+    await tasks.initialize_aggregator_task(
+        InitAggregatorRequest(
+            agent_name=agent_name,
+            server_names=["healthy", "unavailable"],
+            connection_persistence=True,
+            force=False,
+        )
+    )
+
+    aggregator = tasks.server_aggregators_for_agent[agent_name]
+    aggregator.capability_errors_by_server["unavailable"] = RuntimeError(
+        "server unavailable"
+    )
+
+    result = await tasks.get_capabilities_task(
+        GetCapabilitiesRequest(agent_name=agent_name, server_name=None)
+    )
+
+    assert result == {"healthy": aggregator.capabilities_by_server["healthy"]}


### PR DESCRIPTION
## Summary

Fixes `get_capabilities_task` when fetching capabilities for all servers and one server fails. The previous implementation used `asyncio.gather(..., return_exceptions=True)` and then zipped the raw results into the returned dict, which let exception objects masquerade as `ServerCapabilities` values.

This now logs failed server capability lookups and omits those failed entries from the aggregate result, keeping the return value type-consistent for the servers that did respond.

## Tests

- `uv run ruff check src/mcp_agent/agents/agent.py tests/agents/test_agent_tasks_concurrency.py`
- `uv run pytest tests/agents/test_agent_tasks_concurrency.py`

Note: pytest emits existing deprecation warnings from pytest-asyncio/Pydantic, but the targeted tests pass.

Fixes #671


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error resilience when retrieving capabilities from multiple servers. The agent now logs warnings for failed connections and continues processing with available servers instead of stopping entirely.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lastmile-ai/mcp-agent/pull/686)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->