### PR TITLE
fix(openai): send MCP text content as strings

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -1192,6 +1192,7 @@ def mcp_content_to_openai_content_part(
 def mcp_content_to_openai_message_content(
     content: TextContent | ImageContent | EmbeddedResource,
 ) -> str | list[ChatCompletionContentPartParam]:
+    """Convert a single MCP content item into OpenAI chat message content."""
     if isinstance(content, TextContent):
         return content.text
     if isinstance(content, EmbeddedResource) and isinstance(
@@ -1204,6 +1205,7 @@ def mcp_content_to_openai_message_content(
 def mcp_contents_to_openai_tool_result(
     contents: Iterable[TextContent | ImageContent | EmbeddedResource],
 ) -> str:
+    """Convert MCP tool result content into the string payload OpenAI expects."""
     parts: list[str] = []
     for content in contents:
         if isinstance(content, TextContent):

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -650,7 +650,7 @@ class OpenAIAugmentedLLM(
             return ChatCompletionToolMessageParam(
                 role="tool",
                 tool_call_id=tool_call_id,
-                content=[mcp_content_to_openai_content_part(c) for c in result.content],
+                content=mcp_contents_to_openai_tool_result(result.content),
             )
 
     def message_param_str(self, message: ChatCompletionMessageParam) -> str:
@@ -1088,14 +1088,14 @@ class MCPOpenAITypeConverter(
             extras = param.model_dump(exclude={"role", "content"})
             return ChatCompletionAssistantMessageParam(
                 role="assistant",
-                content=[mcp_content_to_openai_content_part(param.content)],
+                content=mcp_content_to_openai_message_content(param.content),
                 **extras,
             )
         elif param.role == "user":
             extras = param.model_dump(exclude={"role", "content"})
             return ChatCompletionUserMessageParam(
                 role="user",
-                content=[mcp_content_to_openai_content_part(param.content)],
+                content=mcp_content_to_openai_message_content(param.content),
                 **extras,
             )
         else:
@@ -1187,6 +1187,39 @@ def mcp_content_to_openai_content_part(
     else:
         # Last effort to convert the content to a string
         return ChatCompletionContentPartTextParam(type="text", text=str(content))
+
+
+def mcp_content_to_openai_message_content(
+    content: TextContent | ImageContent | EmbeddedResource,
+) -> str | list[ChatCompletionContentPartParam]:
+    if isinstance(content, TextContent):
+        return content.text
+    if isinstance(content, EmbeddedResource) and isinstance(
+        content.resource, TextResourceContents
+    ):
+        return content.resource.text
+    return [mcp_content_to_openai_content_part(content)]
+
+
+def mcp_contents_to_openai_tool_result(
+    contents: Iterable[TextContent | ImageContent | EmbeddedResource],
+) -> str:
+    parts: list[str] = []
+    for content in contents:
+        if isinstance(content, TextContent):
+            parts.append(content.text)
+        elif isinstance(content, EmbeddedResource) and isinstance(
+            content.resource, TextResourceContents
+        ):
+            parts.append(content.resource.text)
+        else:
+            converted = mcp_content_to_openai_content_part(content)
+            if converted["type"] == "text":
+                parts.append(converted["text"])
+            else:
+                parts.append(str(converted))
+
+    return "\n".join(parts)
 
 
 def openai_content_to_mcp_content(

--- a/tests/workflows/llm/test_augmented_llm_openai.py
+++ b/tests/workflows/llm/test_augmented_llm_openai.py
@@ -18,6 +18,7 @@ from mcp_agent.workflows.llm.augmented_llm_openai import (
     OpenAIAugmentedLLM,
     RequestParams,
     MCPOpenAITypeConverter,
+    mcp_contents_to_openai_tool_result,
 )
 
 
@@ -450,8 +451,33 @@ class TestOpenAIAugmentedLLM:
         )
         openai_param = MCPOpenAITypeConverter.from_mcp_message_param(mcp_message)
         assert openai_param["role"] == "user"
-        assert isinstance(openai_param["content"], list)
-        assert openai_param["content"][0]["text"] == "Test MCP content"
+        assert openai_param["content"] == "Test MCP content"
+
+    def test_assistant_type_conversion_uses_string_content(self):
+        """
+        Tests text-only MCP assistant messages are converted to string content.
+        """
+        mcp_message = SamplingMessage(
+            role="assistant", content=TextContent(type="text", text="Assistant text")
+        )
+
+        openai_param = MCPOpenAITypeConverter.from_mcp_message_param(mcp_message)
+
+        assert openai_param["role"] == "assistant"
+        assert openai_param["content"] == "Assistant text"
+
+    def test_tool_result_conversion_uses_string_content(self):
+        """
+        Tests tool call results are converted to string content for compatible APIs.
+        """
+        result = mcp_contents_to_openai_tool_result(
+            [
+                TextContent(type="text", text="First result"),
+                TextContent(type="text", text="Second result"),
+            ]
+        )
+
+        assert result == "First result\nSecond result"
 
     # Test: Generate with String Input
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- convert OpenAI tool-call result content to a newline-joined string instead of a list of content parts
- convert text-only MCP user/assistant sampling messages to string content
- add focused coverage for user, assistant, and tool result conversion shapes

Fixes #25.

## Testing
- uv run --extra openai pytest tests/workflows/llm/test_augmented_llm_openai.py::TestOpenAIAugmentedLLM::test_type_conversion tests/workflows/llm/test_augmented_llm_openai.py::TestOpenAIAugmentedLLM::test_assistant_type_conversion_uses_string_content tests/workflows/llm/test_augmented_llm_openai.py::TestOpenAIAugmentedLLM::test_tool_result_conversion_uses_string_content
- uv run --extra openai ruff check src/mcp_agent/workflows/llm/augmented_llm_openai.py tests/workflows/llm/test_augmented_llm_openai.py

Note: the full OpenAI test module still hits the existing abstract generate_stream fixture error when instantiating OpenAIAugmentedLLM; this patch keeps the new coverage focused on the conversion helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved OpenAI content conversion: assistant and user message contents now convert to plain text when appropriate, and tool call results are concatenated into single newline-delimited strings for clearer tool outputs.

* **Tests**
  * Updated and added unit tests to cover the new message and tool-result conversion behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lastmile-ai/mcp-agent/pull/687)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->