### PR TITLE
fix: send OpenAI tool results as string content

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -650,7 +650,7 @@ class OpenAIAugmentedLLM(
             return ChatCompletionToolMessageParam(
                 role="tool",
                 tool_call_id=tool_call_id,
-                content=[mcp_content_to_openai_content_part(c) for c in result.content],
+                content=mcp_content_to_openai_tool_message_content(result.content),
             )
 
     def message_param_str(self, message: ChatCompletionMessageParam) -> str:
@@ -1187,6 +1187,23 @@ def mcp_content_to_openai_content_part(
     else:
         # Last effort to convert the content to a string
         return ChatCompletionContentPartTextParam(type="text", text=str(content))
+
+
+def mcp_content_to_openai_tool_message_content(
+    content: Iterable[TextContent | ImageContent | EmbeddedResource],
+) -> str:
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, TextContent):
+            parts.append(item.text)
+        elif isinstance(item, EmbeddedResource) and isinstance(
+            item.resource, TextResourceContents
+        ):
+            parts.append(item.resource.text)
+        else:
+            parts.append(str(mcp_content_to_openai_content_part(item)))
+
+    return "\n".join(parts)
 
 
 def openai_content_to_mcp_content(

--- a/tests/workflows/llm/test_augmented_llm_openai.py
+++ b/tests/workflows/llm/test_augmented_llm_openai.py
@@ -18,7 +18,14 @@ from mcp_agent.workflows.llm.augmented_llm_openai import (
     OpenAIAugmentedLLM,
     RequestParams,
     MCPOpenAITypeConverter,
+    mcp_content_to_openai_tool_message_content,
 )
+
+
+class _OpenAITestLLM(OpenAIAugmentedLLM):
+    async def generate_stream(self, message, request_params=None):
+        return
+        yield
 
 
 class TestOpenAIAugmentedLLM:
@@ -41,7 +48,7 @@ class TestOpenAIAugmentedLLM:
         )
 
         # Create LLM instance
-        llm = OpenAIAugmentedLLM(name="test", context=mock_context)
+        llm = _OpenAITestLLM(name="test", context=mock_context)
 
         # Apply common mocks
         llm.history = MagicMock()
@@ -362,6 +369,43 @@ class TestOpenAIAugmentedLLM:
         # Assertions
         assert len(responses) == 2
         assert responses[1].content == "Response after tool error"
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_call_returns_string_content(self, mock_llm):
+        """
+        Tests execute_tool_call() returns a string tool message content for
+        OpenAI-compatible providers that reject content part arrays for tool messages.
+        """
+        tool_call = ChatCompletionMessageToolCall(
+            id="tool_123",
+            type="function",
+            function={
+                "name": "test_tool",
+                "arguments": json.dumps({"query": "test query"}),
+            },
+        )
+        mock_llm.call_tool = AsyncMock(
+            return_value=MagicMock(
+                content=[TextContent(type="text", text="Tool result")],
+                isError=False,
+            )
+        )
+
+        result = await mock_llm.execute_tool_call(tool_call)
+
+        assert result["tool_call_id"] == "tool_123"
+        assert result["content"] == "Tool result"
+        assert isinstance(result["content"], str)
+
+    def test_tool_message_content_conversion_joins_text_parts(self):
+        content = mcp_content_to_openai_tool_message_content(
+            [
+                TextContent(type="text", text="First result"),
+                TextContent(type="text", text="Second result"),
+            ]
+        )
+
+        assert content == "First result\nSecond result"
 
     # Test 8: API Error Handling
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #25.

## Summary
- Convert MCP tool results to string content for OpenAI tool messages instead of sending content part arrays
- Preserve text and text resources directly, joining multiple text parts with newlines
- Keep existing OpenAI content part conversion as the fallback for non-text content
- Add regression coverage for execute_tool_call and multi-part text tool results

## Tests
- uv run ruff format src/mcp_agent/workflows/llm/augmented_llm_openai.py tests/workflows/llm/test_augmented_llm_openai.py
- uv run ruff check src/mcp_agent/workflows/llm/augmented_llm_openai.py tests/workflows/llm/test_augmented_llm_openai.py
- uv run pytest tests/workflows/llm/test_augmented_llm_openai.py -k "execute_tool_call_returns_string_content or tool_message_content_conversion_joins_text_parts" -q
- uv run pytest tests/workflows/llm/test_augmented_llm_openai.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for tool message content formatting and multi-part content concatenation

* **Refactor**
  * Improved the formatting of tool call results to use a streamlined content conversion approach

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lastmile-ai/mcp-agent/pull/688)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->