### PR TITLE
fix: stringify OpenAI tool result content

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -1201,6 +1201,9 @@ def mcp_content_to_openai_tool_result_content(
         else:
             text_parts.append(json.dumps(mcp_content_to_openai_content_part(part)))
 
+    if not text_parts:
+        return "[No content in tool result]"
+
     return "\n".join(text_parts)
 
 

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -650,7 +650,7 @@ class OpenAIAugmentedLLM(
             return ChatCompletionToolMessageParam(
                 role="tool",
                 tool_call_id=tool_call_id,
-                content=[mcp_content_to_openai_content_part(c) for c in result.content],
+                content=mcp_content_to_openai_tool_result_content(result.content),
             )
 
     def message_param_str(self, message: ChatCompletionMessageParam) -> str:
@@ -1187,6 +1187,21 @@ def mcp_content_to_openai_content_part(
     else:
         # Last effort to convert the content to a string
         return ChatCompletionContentPartTextParam(type="text", text=str(content))
+
+
+def mcp_content_to_openai_tool_result_content(
+    content: Iterable[TextContent | ImageContent | EmbeddedResource],
+) -> str:
+    """Convert MCP tool result content to OpenAI ChatCompletion tool content."""
+    text_parts: list[str] = []
+
+    for part in content:
+        if isinstance(part, TextContent):
+            text_parts.append(part.text)
+        else:
+            text_parts.append(json.dumps(mcp_content_to_openai_content_part(part)))
+
+    return "\n".join(text_parts)
 
 
 def openai_content_to_mcp_content(

--- a/tests/workflows/llm/test_augmented_llm_openai.py
+++ b/tests/workflows/llm/test_augmented_llm_openai.py
@@ -21,6 +21,12 @@ from mcp_agent.workflows.llm.augmented_llm_openai import (
 )
 
 
+class MockableOpenAIAugmentedLLM(OpenAIAugmentedLLM):
+    async def generate_stream(self, message, request_params=None):
+        if False:
+            yield message
+
+
 class TestOpenAIAugmentedLLM:
     """
     Tests for the OpenAIAugmentedLLM class.
@@ -41,7 +47,7 @@ class TestOpenAIAugmentedLLM:
         )
 
         # Create LLM instance
-        llm = OpenAIAugmentedLLM(name="test", context=mock_context)
+        llm = MockableOpenAIAugmentedLLM(name="test", context=mock_context)
 
         # Apply common mocks
         llm.history = MagicMock()
@@ -362,6 +368,32 @@ class TestOpenAIAugmentedLLM:
         # Assertions
         assert len(responses) == 2
         assert responses[1].content == "Response after tool error"
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_call_returns_string_content(self, mock_llm):
+        """
+        Tests that OpenAI tool messages use string content for provider compatibility.
+        """
+        tool_call = ChatCompletionMessageToolCall(
+            id="tool_123",
+            type="function",
+            function={"name": "test_tool", "arguments": json.dumps({"query": "test"})},
+        )
+        mock_llm.call_tool = AsyncMock(
+            return_value=MagicMock(
+                content=[
+                    TextContent(type="text", text="first result"),
+                    TextContent(type="text", text="second result"),
+                ],
+                isError=False,
+            )
+        )
+
+        result = await mock_llm.execute_tool_call(tool_call)
+
+        assert result["role"] == "tool"
+        assert result["tool_call_id"] == "tool_123"
+        assert result["content"] == "first result\nsecond result"
 
     # Test 8: API Error Handling
     @pytest.mark.asyncio

--- a/tests/workflows/llm/test_augmented_llm_openai.py
+++ b/tests/workflows/llm/test_augmented_llm_openai.py
@@ -11,7 +11,14 @@ from openai.types.chat import (
 )
 from pydantic import BaseModel
 
-from mcp.types import TextContent, SamplingMessage, PromptMessage
+from mcp.types import (
+    EmbeddedResource,
+    ImageContent,
+    PromptMessage,
+    SamplingMessage,
+    TextContent,
+    TextResourceContents,
+)
 
 from mcp_agent.config import OpenAISettings
 from mcp_agent.workflows.llm.augmented_llm_openai import (
@@ -394,6 +401,55 @@ class TestOpenAIAugmentedLLM:
         assert result["role"] == "tool"
         assert result["tool_call_id"] == "tool_123"
         assert result["content"] == "first result\nsecond result"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("content", "expected_content"),
+        [
+            ([], "[No content in tool result]"),
+            ([TextContent(type="text", text="only text")], "only text"),
+            (
+                [
+                    TextContent(type="text", text="text result"),
+                    ImageContent(type="image", data="base64data", mimeType="image/png"),
+                ],
+                'text result\n{"type": "image_url", "image_url": {"url": "data:image/png;base64,base64data"}}',
+            ),
+            (
+                [
+                    EmbeddedResource(
+                        type="resource",
+                        resource=TextResourceContents(
+                            uri="file:///result.txt",
+                            text="resource result",
+                            mimeType="text/plain",
+                        ),
+                    )
+                ],
+                '{"type": "text", "text": "resource result"}',
+            ),
+        ],
+    )
+    async def test_execute_tool_call_handles_tool_result_content(
+        self, mock_llm, content, expected_content
+    ):
+        """
+        Tests OpenAI tool message content for empty, text, and non-text MCP results.
+        """
+        tool_call = ChatCompletionMessageToolCall(
+            id="tool_123",
+            type="function",
+            function={"name": "test_tool", "arguments": json.dumps({"query": "test"})},
+        )
+        mock_llm.call_tool = AsyncMock(
+            return_value=MagicMock(content=content, isError=False)
+        )
+
+        result = await mock_llm.execute_tool_call(tool_call)
+
+        assert result["role"] == "tool"
+        assert result["tool_call_id"] == "tool_123"
+        assert result["content"] == expected_content
 
     # Test 8: API Error Handling
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Convert OpenAI ChatCompletion tool result messages to string content instead of a list of content parts.
- Preserve multiple text content items by joining them with newlines.
- Add coverage for `execute_tool_call()` to prevent OpenAI-compatible providers from receiving list-valued tool message content.

## Related Issue

Fixes #25

## Verification

- [x] `uv run ruff format src\mcp_agent\workflows\llm\augmented_llm_openai.py tests\workflows\llm\test_augmented_llm_openai.py`
- [x] `uv run ruff check src\mcp_agent\workflows\llm\augmented_llm_openai.py tests\workflows\llm\test_augmented_llm_openai.py`
- [x] `uv run pytest tests\workflows\llm\test_augmented_llm_openai.py -q`

## Notes

- The focused OpenAI LLM test file passed with `25 passed`.
- Warnings observed were existing Pydantic/global context warnings and pytest-asyncio loop-scope deprecation warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool-call result serialization so multi-part results (text, images, embedded resources) are combined into a single, consistently formatted message, and empty results yield a clear placeholder.

* **Tests**
  * Added tests covering formatting for empty, plain text, image, and embedded-resource tool results and overall tool-call behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->