### PR TITLE
fix: redact API key in deploy MCP config output

### DIFF
--- a/src/mcp_agent/cli/cloud/commands/deploy/main.py
+++ b/src/mcp_agent/cli/cloud/commands/deploy/main.py
@@ -47,6 +47,21 @@ from .materialize import materialize_deployment_artifacts
 from .wrangler_wrapper import wrangler_deploy
 
 
+DISPLAY_API_KEY_PLACEHOLDER = "<YOUR_API_KEY>"
+
+
+def create_mcp_config_example(app_name: str, server_url: str) -> dict:
+    return {
+        "mcpServers": {
+            app_name: {
+                "url": f"{server_url}/sse",
+                "transport": "sse",
+                "headers": {"Authorization": f"Bearer {DISPLAY_API_KEY_PLACEHOLDER}"},
+            }
+        }
+    }
+
+
 def deploy_config(
     ctx: typer.Context,
     app_name: Optional[str] = typer.Argument(
@@ -456,18 +471,12 @@ def deploy_config(
                 print_info(f"Authentication: {auth_text}")
 
             print_info(
-                f"Use this app as an MCP server at {server_url}/sse\n\nMCP configuration example:"
+                f"Use this app as an MCP server at {server_url}/sse\n\n"
+                "MCP configuration example "
+                f"(replace {DISPLAY_API_KEY_PLACEHOLDER} with your API key):"
             )
 
-            mcp_config = {
-                "mcpServers": {
-                    app_name: {
-                        "url": f"{server_url}/sse",
-                        "transport": "sse",
-                        "headers": {"Authorization": f"Bearer {effective_api_key}"},
-                    }
-                }
-            }
+            mcp_config = create_mcp_config_example(app_name, server_url)
 
             console.print(
                 f"[bright_black]{json.dumps(mcp_config, indent=2)}[/bright_black]",

--- a/src/mcp_agent/cli/cloud/commands/deploy/main.py
+++ b/src/mcp_agent/cli/cloud/commands/deploy/main.py
@@ -473,7 +473,8 @@ def deploy_config(
             print_info(
                 f"Use this app as an MCP server at {server_url}/sse\n\n"
                 "MCP configuration example "
-                f"(replace {DISPLAY_API_KEY_PLACEHOLDER} with your API key):"
+                f"(replace {DISPLAY_API_KEY_PLACEHOLDER} with the API key "
+                "clients should use to access this MCP server):"
             )
 
             mcp_config = create_mcp_config_example(app_name, server_url)

--- a/tests/cli/commands/test_deploy_command.py
+++ b/tests/cli/commands/test_deploy_command.py
@@ -1,5 +1,6 @@
 """Tests for the deploy command functionality in the CLI."""
 
+import json
 import os
 import re
 import tempfile
@@ -9,6 +10,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
+from mcp_agent.cli.cloud.commands.deploy.main import (
+    DISPLAY_API_KEY_PLACEHOLDER,
+    create_mcp_config_example,
+)
 from mcp_agent.cli.cloud.main import app
 from mcp_agent.cli.core.constants import (
     MCP_CONFIG_FILENAME,
@@ -77,6 +82,88 @@ def test_deploy_command_help(runner):
     assert "--no-auth" in clean_text
     assert "--ignore-file" in clean_text
     assert "mcpacignore" in clean_text
+
+
+def test_create_mcp_config_example_uses_api_key_placeholder():
+    """The displayed MCP config example should never include a live API key."""
+    config = create_mcp_config_example(
+        app_name="test-app",
+        server_url="https://test-app.example.com",
+    )
+
+    assert config["mcpServers"]["test-app"]["headers"]["Authorization"] == (
+        f"Bearer {DISPLAY_API_KEY_PLACEHOLDER}"
+    )
+    assert "live-api-key" not in json.dumps(config)
+
+
+def test_deploy_command_redacts_api_key_in_mcp_config(runner, temp_config_dir):
+    """The CLI output should not print the live deployment API key."""
+    live_api_key = "live-api-key-123"
+    server_url = "https://test-app.example.com"
+    output_path = temp_config_dir / MCP_DEPLOYED_SECRETS_FILENAME
+
+    async def mock_process_secrets(*args, **kwargs):
+        with open(kwargs.get("output_path", output_path), "w", encoding="utf-8") as f:
+            f.write("# Transformed file\ntest: value\n")
+        return {
+            "deployment_secrets": [],
+            "user_secrets": [],
+            "reused_secrets": [],
+            "skipped_secrets": [],
+        }
+
+    mock_client = AsyncMock()
+    mock_client.get_app_by_name = AsyncMock(return_value=None)
+
+    mock_created_app = MagicMock()
+    mock_created_app.appId = MOCK_APP_ID
+    mock_client.create_app = AsyncMock(return_value=mock_created_app)
+
+    mock_deployed_app = MagicMock()
+    mock_deployed_app.appId = MOCK_APP_ID
+    mock_deployed_app.appServerInfo = MagicMock(
+        status="APP_SERVER_STATUS_ONLINE",
+        serverUrl=server_url,
+        unauthenticatedAccess=False,
+    )
+
+    async def mock_deploy_with_retry(*args, **kwargs):
+        return mock_deployed_app
+
+    with (
+        patch(
+            "mcp_agent.cli.secrets.processor.process_config_secrets",
+            side_effect=mock_process_secrets,
+        ),
+        patch(
+            "mcp_agent.cli.cloud.commands.deploy.main.MCPAppClient",
+            return_value=mock_client,
+        ),
+        patch(
+            "mcp_agent.cli.cloud.commands.deploy.main._deploy_with_retry",
+            side_effect=mock_deploy_with_retry,
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "deploy",
+                MOCK_APP_NAME,
+                "--config-dir",
+                temp_config_dir,
+                "--api-url",
+                "http://test-api.com",
+                "--api-key",
+                live_api_key,
+                "--non-interactive",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    assert live_api_key not in result.stdout
+    assert f"Bearer {DISPLAY_API_KEY_PLACEHOLDER}" in result.stdout
+    assert f"{server_url}/sse" in result.stdout
 
 
 def test_deploy_command_basic(runner, temp_config_dir):


### PR DESCRIPTION
## Summary

- Replace the live deployment API key in the printed MCP configuration example with `<YOUR_API_KEY>`.
- Add a small helper for building the display-only MCP config so credential redaction is centralized.
- Add regression coverage for both the helper and the CLI output path to ensure the live key is not printed to stdout.

## Related Issue

Fixes #669

## Verification

- [x] `uv run ruff format src\mcp_agent\cli\cloud\commands\deploy\main.py tests\cli\commands\test_deploy_command.py`
- [x] `uv run ruff check src\mcp_agent\cli\cloud\commands\deploy\main.py tests\cli\commands\test_deploy_command.py`
- [x] `uv run pytest tests\cli\commands\test_deploy_command.py -q -k "redacts_api_key or placeholder or deploy_command_basic"`
- [x] `git diff --check`

## Notes

- The live API key is still used for deployment API calls; only the copied terminal example is redacted.
- Focused tests passed with `3 passed, 13 deselected`.
- Running the full `tests\cli\commands\test_deploy_command.py` file on native Windows produced an unrelated existing failure in `test_deploy_uses_cwd_mcpacignore_when_config_dir_lacks_one`: the test changes into a `TemporaryDirectory`, then Windows refuses to remove the current working directory during cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deploy command now shows a placeholder API key in MCP server configuration examples instead of actual credentials, preventing accidental exposure.
  * Console output during deployment provides clearer instructions for replacing the placeholder with your real API key.

* **Tests**
  * Added tests to verify the placeholder is used and that live API keys are not printed to stdout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->