### PR TITLE
fix(openai): send tool results as string content

### DIFF
--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -369,7 +369,10 @@ class OpenAIAugmentedLLM(
                     self.logger.debug(
                         f"Iteration {i}: Tool call results: {str(tool_results) if tool_results else 'None'}"
                     )
-                    # Add non-None results to messages.
+                    # Keep tool-role messages together before any follow-up messages
+                    # produced from mixed-content tool results.
+                    tool_messages: List[ChatCompletionMessageParam] = []
+                    follow_up_messages: List[ChatCompletionMessageParam] = []
                     for result in tool_results:
                         if isinstance(result, BaseException):
                             self.logger.error(
@@ -379,9 +382,19 @@ class OpenAIAugmentedLLM(
                             continue
                         if result is not None:
                             if isinstance(result, list):
-                                messages.extend(result)
+                                for result_message in result:
+                                    if result_message.get("role") == "tool":
+                                        tool_messages.append(result_message)
+                                    else:
+                                        follow_up_messages.append(result_message)
                             else:
-                                messages.append(result)
+                                if result.get("role") == "tool":
+                                    tool_messages.append(result)
+                                else:
+                                    follow_up_messages.append(result)
+
+                    messages.extend(tool_messages)
+                    messages.extend(follow_up_messages)
                 elif choice.finish_reason == "length":
                     # We have reached the max tokens limit
                     self.logger.debug(

--- a/src/mcp_agent/workflows/llm/augmented_llm_openai.py
+++ b/src/mcp_agent/workflows/llm/augmented_llm_openai.py
@@ -378,7 +378,10 @@ class OpenAIAugmentedLLM(
                             span.record_exception(result)
                             continue
                         if result is not None:
-                            messages.append(result)
+                            if isinstance(result, list):
+                                messages.extend(result)
+                            else:
+                                messages.append(result)
                 elif choice.finish_reason == "length":
                     # We have reached the max tokens limit
                     self.logger.debug(
@@ -605,10 +608,9 @@ class OpenAIAugmentedLLM(
     async def execute_tool_call(
         self,
         tool_call: ChatCompletionMessageToolCall,
-    ) -> ChatCompletionToolMessageParam:
+    ) -> List[ChatCompletionMessageParam]:
         """
-        Execute a single tool call and return the result message.
-        Returns a single ChatCompletionToolMessageParam object.
+        Execute a single tool call and return the result messages.
         """
         tracer = get_tracer(self.context)
         with tracer.start_as_current_span(
@@ -630,11 +632,13 @@ class OpenAIAugmentedLLM(
             except json.JSONDecodeError as e:
                 span.record_exception(e)
                 span.set_status(trace.Status(trace.StatusCode.ERROR))
-                return ChatCompletionToolMessageParam(
-                    role="tool",
-                    tool_call_id=tool_call_id,
-                    content=f"Invalid JSON provided in tool call arguments for '{tool_name}'. Failed to load JSON: {str(e)}",
-                )
+                return [
+                    ChatCompletionToolMessageParam(
+                        role="tool",
+                        tool_call_id=tool_call_id,
+                        content=f"Invalid JSON provided in tool call arguments for '{tool_name}'. Failed to load JSON: {str(e)}",
+                    )
+                ]
 
             tool_call_request = CallToolRequest(
                 method="tools/call",
@@ -647,11 +651,16 @@ class OpenAIAugmentedLLM(
 
             self._annotate_span_for_call_tool_result(span, result)
 
-            return ChatCompletionToolMessageParam(
-                role="tool",
+            converted = OpenAIConverter.convert_tool_result_to_openai(
+                tool_result=result,
                 tool_call_id=tool_call_id,
-                content=[mcp_content_to_openai_content_part(c) for c in result.content],
             )
+
+            if isinstance(converted, tuple):
+                tool_message, additional_messages = converted
+                return [tool_message, *additional_messages]
+
+            return [converted]
 
     def message_param_str(self, message: ChatCompletionMessageParam) -> str:
         """Convert an input message to a string representation."""

--- a/tests/workflows/llm/test_augmented_llm_openai.py
+++ b/tests/workflows/llm/test_augmented_llm_openai.py
@@ -11,7 +11,7 @@ from openai.types.chat import (
 )
 from pydantic import BaseModel
 
-from mcp.types import TextContent, SamplingMessage, PromptMessage
+from mcp.types import CallToolResult, ImageContent, TextContent, SamplingMessage, PromptMessage
 
 from mcp_agent.config import OpenAISettings
 from mcp_agent.workflows.llm.augmented_llm_openai import (
@@ -111,6 +111,40 @@ class TestOpenAIAugmentedLLM:
                         "arguments": json.dumps(tool_args),
                     },
                 )
+            ],
+        )
+        choice = Choice(
+            finish_reason=finish_reason,
+            index=0,
+            message=message,
+        )
+        return ChatCompletion(
+            id="chatcmpl-123",
+            choices=[choice],
+            created=1677858242,
+            model="gpt-4o",
+            object="chat.completion",
+            usage=usage,
+        )
+
+    @staticmethod
+    def create_multi_tool_use_response(tool_calls, finish_reason="tool_calls", usage=None):
+        """
+        Creates a tool use response with multiple tool calls for testing.
+        """
+        message = ChatCompletionMessage(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                ChatCompletionMessageToolCall(
+                    id=tool_call["id"],
+                    type="function",
+                    function={
+                        "name": tool_call["name"],
+                        "arguments": json.dumps(tool_call["arguments"]),
+                    },
+                )
+                for tool_call in tool_calls
             ],
         )
         choice = Choice(
@@ -382,10 +416,19 @@ class TestOpenAIAugmentedLLM:
             call_count += 1
 
             if call_count == 1:
-                return self.create_tool_use_response(
-                    "test_tool",
-                    {"query": "test query"},
-                    "tool_123",
+                return self.create_multi_tool_use_response(
+                    [
+                        {
+                            "name": "test_tool",
+                            "arguments": {"query": "first query"},
+                            "id": "tool_123",
+                        },
+                        {
+                            "name": "test_tool",
+                            "arguments": {"query": "second query"},
+                            "id": "tool_456",
+                        },
+                    ],
                     usage=default_usage,
                 )
             elif call_count == 2:
@@ -399,11 +442,23 @@ class TestOpenAIAugmentedLLM:
         mock_llm.executor.execute = AsyncMock(side_effect=custom_side_effect)
         mock_llm.executor.execute_many = AsyncMock(side_effect=execute_many_side_effect)
         mock_llm.call_tool = AsyncMock(
-            return_value=MagicMock(
-                content=[TextContent(type="text", text="Tool result")],
-                isError=False,
-                tool_call_id="tool_123",
-            )
+            side_effect=[
+                CallToolResult(
+                    content=[TextContent(type="text", text="First tool result")],
+                    isError=False,
+                ),
+                CallToolResult(
+                    content=[
+                        TextContent(type="text", text="Second tool result"),
+                        ImageContent(
+                            type="image",
+                            data="YmFzZTY0ZGF0YQ==",
+                            mimeType="image/png",
+                        ),
+                    ],
+                    isError=False,
+                ),
+            ]
         )
 
         responses = await mock_llm.generate("Test query with tool")
@@ -412,12 +467,22 @@ class TestOpenAIAugmentedLLM:
 
         second_call_args = mock_llm.executor.execute.call_args_list[1][0]
         request_obj = second_call_args[1]
-        tool_message = request_obj.payload["messages"][-1]
+        result_messages = request_obj.payload["messages"][-3:]
 
-        assert tool_message["role"] == "tool"
-        assert tool_message["tool_call_id"] == "tool_123"
-        assert tool_message["content"] == "Tool result"
-        assert not isinstance(tool_message["content"], list)
+        assert [message["role"] for message in result_messages] == ["tool", "tool", "user"]
+
+        first_tool_message, second_tool_message, follow_up_message = result_messages
+
+        assert first_tool_message["tool_call_id"] == "tool_123"
+        assert first_tool_message["content"] == "First tool result"
+        assert not isinstance(first_tool_message["content"], list)
+
+        assert second_tool_message["tool_call_id"] == "tool_456"
+        assert second_tool_message["content"] == "Second tool result"
+        assert not isinstance(second_tool_message["content"], list)
+
+        assert follow_up_message["tool_call_id"] == "tool_456"
+        assert follow_up_message["role"] == "user"
 
     # Test 8: API Error Handling
     @pytest.mark.asyncio

--- a/tests/workflows/llm/test_augmented_llm_openai.py
+++ b/tests/workflows/llm/test_augmented_llm_openai.py
@@ -21,6 +21,11 @@ from mcp_agent.workflows.llm.augmented_llm_openai import (
 )
 
 
+class ConcreteOpenAIAugmentedLLM(OpenAIAugmentedLLM):
+    async def generate_stream(self, message, request_params=None):
+        raise NotImplementedError
+
+
 class TestOpenAIAugmentedLLM:
     """
     Tests for the OpenAIAugmentedLLM class.
@@ -41,7 +46,7 @@ class TestOpenAIAugmentedLLM:
         )
 
         # Create LLM instance
-        llm = OpenAIAugmentedLLM(name="test", context=mock_context)
+        llm = ConcreteOpenAIAugmentedLLM(name="test", context=mock_context)
 
         # Apply common mocks
         llm.history = MagicMock()
@@ -362,6 +367,57 @@ class TestOpenAIAugmentedLLM:
         # Assertions
         assert len(responses) == 2
         assert responses[1].content == "Response after tool error"
+
+    @pytest.mark.asyncio
+    async def test_tool_results_are_sent_as_string_messages(
+        self, mock_llm, default_usage
+    ):
+        """
+        Tests that tool results sent back to OpenAI use string content instead of content-part lists.
+        """
+        call_count = 0
+
+        async def custom_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            if call_count == 1:
+                return self.create_tool_use_response(
+                    "test_tool",
+                    {"query": "test query"},
+                    "tool_123",
+                    usage=default_usage,
+                )
+            elif call_count == 2:
+                return self.create_text_response(
+                    "Final response after tool use", usage=default_usage
+                )
+
+        async def execute_many_side_effect(tasks):
+            return [await task() for task in tasks]
+
+        mock_llm.executor.execute = AsyncMock(side_effect=custom_side_effect)
+        mock_llm.executor.execute_many = AsyncMock(side_effect=execute_many_side_effect)
+        mock_llm.call_tool = AsyncMock(
+            return_value=MagicMock(
+                content=[TextContent(type="text", text="Tool result")],
+                isError=False,
+                tool_call_id="tool_123",
+            )
+        )
+
+        responses = await mock_llm.generate("Test query with tool")
+
+        assert len(responses) == 2
+
+        second_call_args = mock_llm.executor.execute.call_args_list[1][0]
+        request_obj = second_call_args[1]
+        tool_message = request_obj.payload["messages"][-1]
+
+        assert tool_message["role"] == "tool"
+        assert tool_message["tool_call_id"] == "tool_123"
+        assert tool_message["content"] == "Tool result"
+        assert not isinstance(tool_message["content"], list)
 
     # Test 8: API Error Handling
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Fix OpenAI tool-response formatting so tool messages are sent back as string content instead of content-part lists.

## Problem
When a tool returns `TextContent`, `execute_tool_call()` was converting the result into a `tool` message with `content=[...]`. OpenAI ChatCompletion expects tool message content to be a string, which can trigger validation errors on the next completion call.

## Fix
- route tool results through `OpenAIConverter.convert_tool_result_to_openai()`
- flatten any additional follow-up messages returned by the converter
- add a regression test that asserts the second OpenAI request contains a tool message with string content
- make the OpenAI LLM test fixture concrete so the regression test file runs again

## Verification
- `uv sync --extra openai --dev`
- `uv run pytest tests/workflows/llm/test_augmented_llm_openai.py -q`

Fixes #25


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ordering of tool-related messages after tool execution to keep follow-up content consistent.
  * Enhanced handling of tool call results when tools return multiple messages, ensuring the full sequence is sent back correctly.
  * Fixed tool-result message formatting so tool content is always sent as plain text (including mixed text/image cases) with matching tool-call IDs.
* **Tests**
  * Extended tool-call mocking and added coverage for multi-tool result formatting and message payload expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->