### PR TITLE
fix(evaluator): avoid duplicating evaluator instructions

### DIFF
--- a/src/mcp_agent/workflows/evaluator_optimizer/evaluator_optimizer.py
+++ b/src/mcp_agent/workflows/evaluator_optimizer/evaluator_optimizer.py
@@ -436,8 +436,7 @@ class EvaluatorOptimizerLLM(AugmentedLLM[MessageParamT, MessageT]):
     ) -> str:
         """Build the evaluation prompt for the evaluator"""
         return f"""
-        Evaluate the following response based on these criteria:
-        {self.evaluator.instruction}
+        Evaluate the following response.
 
         Original Request: {original_request}
         Current Response (Iteration {iteration + 1}): {current_response}

--- a/tests/workflows/evaluator_optimizer/test_evaluator_optimizer.py
+++ b/tests/workflows/evaluator_optimizer/test_evaluator_optimizer.py
@@ -108,6 +108,21 @@ def test_build_eval_prompt(mock_optimizer, mock_evaluator):
     assert "Provide your evaluation as a structured response" in prompt
 
 
+
+def test_build_eval_prompt_does_not_repeat_evaluator_instruction(
+    mock_optimizer, mock_evaluator
+):
+    eo = EvaluatorOptimizerLLM(
+        optimizer=mock_optimizer,
+        evaluator=mock_evaluator,
+    )
+    prompt = eo._build_eval_prompt(
+        original_request="What is the capital of France?",
+        current_response="Paris",
+        iteration=0,
+    )
+    assert "Evaluate the following response." in prompt
+    assert "Evaluate this." not in prompt
 def test_build_refinement_prompt(mock_optimizer, mock_evaluator):
     eo = EvaluatorOptimizerLLM(
         optimizer=mock_optimizer,


### PR DESCRIPTION
## Summary
- stop injecting the evaluator agent instruction into the evaluation user prompt
- keep the evaluator criteria in the evaluator's system instruction only
- add a regression test covering the duplicated-instruction case

## Problem
`EvaluatorOptimizerLLM._build_eval_prompt()` was embedding `self.evaluator.instruction` directly into the evaluation prompt even though the evaluator LLM already receives that instruction through its own configured system prompt. That causes evaluator instructions to appear twice.

## Notes
This keeps the existing evaluation rubric intact while avoiding duplicate evaluator guidance in the user message.

Fixes #381


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the evaluation prompt so it uses a generic instruction instead of repeating the evaluator’s own guidance.
  * Kept the rest of the response review format unchanged, including rating, feedback, improvement flags, and focus areas.

* **Tests**
  * Added coverage to ensure the evaluation prompt no longer includes duplicated instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->