### PR TITLE
feat(examples): add persistent_memory_agent — cross-session memory via Dakera MCP (closes #12)

### DIFF
--- a/examples/usecases/persistent_memory_agent/README.md
+++ b/examples/usecases/persistent_memory_agent/README.md
@@ -1,0 +1,60 @@
+# Persistent Memory Agent
+
+Demonstrates cross-session memory using [Dakera](https://dakera.ai) MCP — a self-hosted vector memory server. Directly addresses the feature request in [#12](https://github.com/lastmile-ai/mcp-agent/issues/12).
+
+## The three memory tiers
+
+| Tier | Storage | Survives restart? | Tool |
+|------|---------|-------------------|------|
+| Short-term | mcp-agent `Context` | No | Built-in |
+| Session | Dakera per-session | Yes (in Dakera) | `dakera_session_start` / `dakera_store` |
+| Long-term | Dakera semantic index | Yes | `dakera_recall` |
+
+## Prerequisites
+
+```bash
+# 1. Start Dakera (local Docker — no external API needed)
+docker run -d -p 3000:3000 \
+    -e DAKERA_API_KEY=demo \
+    dakera/dakera:latest
+
+# 2. Verify the MCP server starts
+uvx dakera-mcp --help
+
+# 3. Set env vars
+export DAKERA_API_URL=http://localhost:3000
+export DAKERA_API_KEY=demo
+export ANTHROPIC_API_KEY=your-key
+```
+
+## Run
+
+```bash
+cd examples/usecases/persistent_memory_agent
+
+# First run: researches and stores findings
+python main.py
+
+# Second run: agent recalls prior findings from Dakera before continuing
+python main.py
+```
+
+## MCP tools available
+
+Once connected, your agent has access to 14 Dakera tools:
+
+| Tool | Purpose |
+|------|---------|
+| `dakera_store` | Persist a memory entry |
+| `dakera_recall` | Semantic recall (decay-weighted) |
+| `dakera_search` | Hybrid BM25 + vector search |
+| `dakera_session_start` | Begin a named session |
+| `dakera_session_end` | Close a session |
+| `dakera_extract_entities` | NER → knowledge graph |
+| `dakera_knowledge_graph` | Query entity relationships |
+| `dakera_forget` | Delete specific memories |
+| `dakera_consolidate` | Deduplicate related memories |
+
+## Config
+
+See `mcp_agent.config.yaml`. The Dakera MCP server runs via `uvx dakera-mcp` (npm: `@dakera-ai/dakera-mcp`).

--- a/examples/usecases/persistent_memory_agent/README.md
+++ b/examples/usecases/persistent_memory_agent/README.md
@@ -41,19 +41,24 @@ python main.py
 
 ## MCP tools available
 
-Once connected, your agent has access to 14 Dakera tools:
+Key Dakera tools exposed via MCP:
 
 | Tool | Purpose |
 |------|---------|
 | `dakera_store` | Persist a memory entry |
 | `dakera_recall` | Semantic recall (decay-weighted) |
 | `dakera_search` | Hybrid BM25 + vector search |
+| `dakera_batch_recall` | Recall across multiple queries at once |
 | `dakera_session_start` | Begin a named session |
 | `dakera_session_end` | Close a session |
+| `dakera_session_memories` | Retrieve all memories in a session |
 | `dakera_extract_entities` | NER → knowledge graph |
 | `dakera_knowledge_graph` | Query entity relationships |
 | `dakera_forget` | Delete specific memories |
 | `dakera_consolidate` | Deduplicate related memories |
+| `dakera_memory_get` | Fetch a specific memory by ID |
+| `dakera_memory_update` | Update an existing memory |
+| `dakera_memory_feedback` | Signal memory quality for adaptive ranking |
 
 ## Config
 

--- a/examples/usecases/persistent_memory_agent/README.md
+++ b/examples/usecases/persistent_memory_agent/README.md
@@ -52,17 +52,18 @@ run stored before adding anything new.
 ## Prerequisites
 
 ```bash
-# 1. Start Dakera (local Docker — no external API needed)
-docker run -d -p 3300:3300 \
-    -e DAKERA_API_KEY=demo \
-    ghcr.io/dakera-ai/dakera:latest
+# 1. Start Dakera locally (self-hosted server + MinIO object store) via docker-compose.
+#    The server needs the object store the compose provisions, so use dakera-deploy
+#    rather than a bare `docker run`.
+git clone https://github.com/dakera-ai/dakera-deploy
+cd dakera-deploy && docker compose up -d   # REST API on http://localhost:3000
 
 # 2. Verify the MCP server starts
 npx @dakera-ai/dakera-mcp --help
 
-# 3. Set env vars
-export DAKERA_API_URL=http://localhost:3300
-export DAKERA_API_KEY=demo
+# 3. Set env vars (API key is the one configured in dakera-deploy, e.g. dk-...)
+export DAKERA_API_URL=http://localhost:3000
+export DAKERA_API_KEY=dk-...
 export ANTHROPIC_API_KEY=your-key
 ```
 

--- a/examples/usecases/persistent_memory_agent/README.md
+++ b/examples/usecases/persistent_memory_agent/README.md
@@ -1,14 +1,53 @@
 # Persistent Memory Agent
 
-Demonstrates cross-session memory using [Dakera](https://dakera.ai) MCP — a self-hosted vector memory server. Directly addresses the feature request in [#12](https://github.com/lastmile-ai/mcp-agent/issues/12).
+Cross-session memory for mcp-agent using [Dakera](https://dakera.ai) MCP — a
+self-hosted, decay-weighted vector memory server. Directly addresses the
+long-term memory feature request in [#12](https://github.com/lastmile-ai/mcp-agent/issues/12).
+
+Unlike a naive "store everything the agent said" loop, this example models
+memory as a **project-continuity layer**: only *promoted*, *typed* facts enter
+long-term memory, and they are retrieved deliberately by scope — not as a
+semantic soup of every message ever exchanged.
 
 ## The three memory tiers
 
-| Tier | Storage | Survives restart? | Tool |
-|------|---------|-------------------|------|
-| Short-term | mcp-agent `Context` | No | Built-in |
-| Session | Dakera per-session | Yes (in Dakera) | `dakera_session_start` / `dakera_store` |
-| Long-term | Dakera semantic index | Yes | `dakera_recall` |
+| Tier | What it holds | Storage | Survives restart? | Tools |
+|------|---------------|---------|-------------------|-------|
+| Working context | Current in-process state | mcp-agent `Context` | No | Built-in |
+| Session trace | What happened this run (auditable) | Dakera session | Yes | `dakera_session_start` / `dakera_session_end` |
+| Project memory | Durable, promoted, typed facts | Dakera long-term index | Yes | `dakera_store` / `dakera_batch_recall` / `dakera_recall` |
+
+## The memory contract
+
+The core idea (see [#713](https://github.com/lastmile-ai/mcp-agent/issues/713)):
+`dakera_store` should not become a transcript dump. The agent only **promotes**
+durable facts, and each record is tagged so it can be scoped and filtered later:
+
+```text
+type:<decision | convention | failed_path | bug_fix | open_question>
+project:<scope>                 e.g. project:multi-agent-frameworks
+status:<accepted | candidate | superseded>
+```
+
+`accepted` facts are stored with high importance (0.8–0.9) so they survive
+decay; everything else stays a `candidate` until confirmed.
+
+## What the example demonstrates
+
+The script (`main.py`) runs three phases that map onto the tiers in #12:
+
+1. **Research & promote** — the agent loads prior accepted facts, researches
+   the gap, and stores only promotable, typed records.
+2. **Scope-filtered recall** — a *fresh* agent (simulating a restart) uses
+   `dakera_batch_recall` filtered by `project:…` + `status:accepted`, so it
+   pulls back only durable facts for this project. This is the **scope-based
+   retrieval** from #12.
+3. **Entity / knowledge-graph memory** — `dakera_extract_entities` +
+   `dakera_knowledge_graph` turn the stored prose into a queryable entity
+   graph. This is the **graph/entity memory** tier from #12.
+
+Re-run the whole script to see continuity: Phase 1 recalls what the previous
+run stored before adding anything new.
 
 ## Prerequisites
 
@@ -32,34 +71,31 @@ export ANTHROPIC_API_KEY=your-key
 ```bash
 cd examples/usecases/persistent_memory_agent
 
-# First run: researches and stores findings
+# First run: researches and promotes typed facts
 python main.py
 
-# Second run: agent recalls prior findings from Dakera before continuing
+# Second run: fresh agents recall prior accepted facts by scope
 python main.py
 ```
 
-## MCP tools available
+## Dakera MCP tools used here
 
-Key Dakera tools exposed via MCP:
+| Tool | Purpose | Used in |
+|------|---------|---------|
+| `dakera_session_start` / `dakera_session_end` | Bracket the session trace | All phases |
+| `dakera_store` | Promote a typed, scoped fact | Phase 1 |
+| `dakera_batch_recall` | Scope-filtered retrieval by tags | Phases 2–3 |
+| `dakera_recall` | Semantic (decay-weighted) recall | Optional |
+| `dakera_extract_entities` | NER → knowledge-graph entities | Phase 3 |
+| `dakera_knowledge_graph` | Query entity relationships | Phase 3 |
 
-| Tool | Purpose |
-|------|---------|
-| `dakera_store` | Persist a memory entry |
-| `dakera_recall` | Semantic recall (decay-weighted) |
-| `dakera_search` | Hybrid BM25 + vector search |
-| `dakera_batch_recall` | Recall across multiple queries at once |
-| `dakera_session_start` | Begin a named session |
-| `dakera_session_end` | Close a session |
-| `dakera_session_memories` | Retrieve all memories in a session |
-| `dakera_extract_entities` | NER → knowledge graph |
-| `dakera_knowledge_graph` | Query entity relationships |
-| `dakera_forget` | Delete specific memories |
-| `dakera_consolidate` | Deduplicate related memories |
-| `dakera_memory_get` | Fetch a specific memory by ID |
-| `dakera_memory_update` | Update an existing memory |
-| `dakera_memory_feedback` | Signal memory quality for adaptive ranking |
+Other tools the server exposes (not needed for this example): `dakera_search`
+(hybrid BM25 + vector), `dakera_session_memories`, `dakera_forget`,
+`dakera_consolidate`, `dakera_memory_get`, `dakera_memory_update`,
+`dakera_memory_feedback`.
 
 ## Config
 
-See `mcp_agent.config.yaml`. The Dakera MCP server runs via `npx @dakera-ai/dakera-mcp`.
+See `mcp_agent.config.yaml`. The Dakera MCP server runs via
+`npx @dakera-ai/dakera-mcp`; `DAKERA_API_URL` / `DAKERA_API_KEY` are read from
+the environment.

--- a/examples/usecases/persistent_memory_agent/README.md
+++ b/examples/usecases/persistent_memory_agent/README.md
@@ -14,15 +14,15 @@ Demonstrates cross-session memory using [Dakera](https://dakera.ai) MCP — a se
 
 ```bash
 # 1. Start Dakera (local Docker — no external API needed)
-docker run -d -p 3000:3000 \
+docker run -d -p 3300:3300 \
     -e DAKERA_API_KEY=demo \
-    dakera/dakera:latest
+    ghcr.io/dakera-ai/dakera:latest
 
 # 2. Verify the MCP server starts
 npx @dakera-ai/dakera-mcp --help
 
 # 3. Set env vars
-export DAKERA_API_URL=http://localhost:3000
+export DAKERA_API_URL=http://localhost:3300
 export DAKERA_API_KEY=demo
 export ANTHROPIC_API_KEY=your-key
 ```

--- a/examples/usecases/persistent_memory_agent/README.md
+++ b/examples/usecases/persistent_memory_agent/README.md
@@ -62,4 +62,4 @@ Key Dakera tools exposed via MCP:
 
 ## Config
 
-See `mcp_agent.config.yaml`. The Dakera MCP server runs via `uvx dakera-mcp` (npm: `@dakera-ai/dakera-mcp`).
+See `mcp_agent.config.yaml`. The Dakera MCP server runs via `npx @dakera-ai/dakera-mcp`.

--- a/examples/usecases/persistent_memory_agent/README.md
+++ b/examples/usecases/persistent_memory_agent/README.md
@@ -19,7 +19,7 @@ docker run -d -p 3000:3000 \
     dakera/dakera:latest
 
 # 2. Verify the MCP server starts
-uvx dakera-mcp --help
+npx @dakera-ai/dakera-mcp --help
 
 # 3. Set env vars
 export DAKERA_API_URL=http://localhost:3000

--- a/examples/usecases/persistent_memory_agent/main.py
+++ b/examples/usecases/persistent_memory_agent/main.py
@@ -1,9 +1,30 @@
-"""Persistent cross-session memory using Dakera MCP.
+"""Persistent, *typed* cross-session memory using Dakera MCP.
 
-Demonstrates the three memory tiers discussed in issue #12:
-  - Short-term:  mcp-agent Context object (in-process, ephemeral)
-  - Session:     Dakera dakera_session_start / dakera_store
-  - Long-term:   Dakera dakera_recall (semantic search, decay-weighted)
+Most "memory" demos treat `store` as "save everything the agent said" — a
+transcript dump that gets noisy and useless within a few runs. This example
+instead models memory as a **project-continuity layer** with an explicit
+contract, following the three-tier model discussed in issue #12:
+
+    working context  -> in-process mcp-agent state (ephemeral, not stored)
+    session trace    -> what happened this run   (Dakera session, auditable)
+    project memory   -> durable, *promoted* facts (Dakera long-term, typed)
+
+The teaching point: only **promoted** records enter project memory, and each
+one carries a type and scope so it can be retrieved deliberately later:
+
+    MEMORY CONTRACT (encoded as Dakera tags on each stored record)
+      type:<decision|convention|failed_path|bug_fix|open_question>
+      project:<scope>          e.g. project:multi-agent-frameworks
+      status:<accepted|candidate|superseded>
+
+This unlocks the two capabilities from #12 that a plain store/recall loop
+misses, and which this example demonstrates end to end:
+
+  * scope-filtered retrieval — `dakera_batch_recall` filtered by the scope and
+    status tags, so a new session pulls back *only* accepted project facts
+    instead of a semantic soup of everything ever stored.
+  * entity / knowledge-graph memory — `dakera_extract_entities` +
+    `dakera_knowledge_graph` turn stored prose into a queryable entity graph.
 
 Prereq:
     docker run -d -p 3300:3300 \\
@@ -12,84 +33,151 @@ Prereq:
     npx @dakera-ai/dakera-mcp --help  # confirms the MCP server starts
 
 Usage:
-    # First run: research and store
+    # First run: research and promote typed facts to project memory
     DAKERA_API_URL=http://localhost:3300 DAKERA_API_KEY=demo python main.py
 
-    # Second run: notice the agent recalls prior findings from Dakera
+    # Second run: a fresh agent recalls prior *accepted* facts by scope
     DAKERA_API_URL=http://localhost:3300 DAKERA_API_KEY=demo python main.py
 """
 
 import asyncio
-from mcp_agent.app import MCPApp
+
 from mcp_agent.agents.agent import Agent
+from mcp_agent.app import MCPApp
 from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLLM
 
 app = MCPApp(name="persistent_memory_agent")
 
+# Scope for this demo. Everything promoted to project memory is tagged with it,
+# so retrieval can be filtered to exactly this project (see recall_phase).
+PROJECT_SCOPE = "project:multi-agent-frameworks"
+
+# The promotion contract, injected into every agent so storage stays disciplined
+# rather than becoming a transcript dump.
+MEMORY_CONTRACT = f"""\
+You have persistent project memory via Dakera. Treat it as a continuity layer,
+NOT a transcript. Follow this contract exactly:
+
+1. At the start, call dakera_session_start, then dakera_batch_recall with
+   tags ["{PROJECT_SCOPE}", "status:accepted"] to load what is already known.
+   Do not re-research anything already recorded.
+2. Only PROMOTE durable facts to memory with dakera_store. A fact is promotable
+   if it is a decision, a convention, a failed path worth avoiding, a bug fix,
+   or an open question — never a greeting, a restatement, or chit-chat.
+3. Every dakera_store call MUST include tags:
+     - "{PROJECT_SCOPE}"
+     - one of "type:decision" | "type:convention" | "type:failed_path"
+              | "type:bug_fix" | "type:open_question"
+     - "status:accepted" for facts you are confident in (else "status:candidate")
+   Use importance 0.8-0.9 for accepted facts so they survive decay.
+4. Keep each record self-contained and one idea per record.
+5. Call dakera_session_end with a short summary when finished.
+"""
+
 
 async def research_phase() -> None:
-    """Phase 1: Research a topic and persist findings to Dakera.
+    """Phase 1 — research a topic and *promote* typed facts to project memory.
 
-    The agent explicitly uses dakera_store to save each key finding.
-    These memories persist across process restarts.
+    The agent first loads prior accepted facts (so a re-run does not duplicate
+    work), researches the gap, then stores only promotable records under the
+    memory contract. Nothing about the raw conversation is dumped to storage.
     """
-    async with app.run() as mcp_app:
+    async with app.run():
         agent = Agent(
             name="researcher",
-            instruction="""You are a research assistant with persistent memory.
-
-When you discover important information, store it immediately using dakera_store
-with a clear, self-contained summary. Use dakera_session_start at the beginning
-of each session and dakera_session_end when done.
-
-Start by calling dakera_recall with query "prior research findings" to check
-what you already know before starting new research.""",
+            instruction=MEMORY_CONTRACT
+            + """
+Task: research the current state of multi-agent AI frameworks. Identify the top
+frameworks by adoption and their key architectural differences. Promote each
+distinct architectural decision or convention as its own typed memory record.
+""",
             server_names=["dakera", "fetch"],
         )
-
         async with agent:
             llm = await agent.attach_llm(AnthropicAugmentedLLM)
             result = await llm.generate_str(
-                "Research the current state of multi-agent AI frameworks in 2025. "
-                "Find the top 3 frameworks by adoption and their key architectural differences. "
-                "Store each finding as a separate memory entry using dakera_store.",
+                "Research multi-agent AI frameworks and promote your findings as "
+                "typed project-memory records per the contract. Report what you stored."
             )
-            print(f"[Phase 1 — Research complete]\n{result[:500]}...\n")
+            print(f"[Phase 1 — Research & promote]\n{result[:600]}...\n")
 
 
 async def recall_phase() -> None:
-    """Phase 2: A fresh agent recalls what Phase 1 stored.
+    """Phase 2 — a fresh agent recalls prior facts via *scope-filtered* retrieval.
 
-    This simulates a new process / container restart. The agent has no
-    in-process state from Phase 1 but can recall via Dakera.
+    This simulates a process/container restart: no in-process state survives.
+    The agent uses ``dakera_batch_recall`` filtered by the project scope and
+    ``status:accepted`` so it pulls back only durable, promoted facts for this
+    project — not a semantic soup of everything ever stored.
     """
-    async with app.run() as mcp_app:
+    async with app.run():
         agent = Agent(
             name="analyst",
-            instruction="""You are an analyst with access to persistent memory.
+            instruction=f"""You are an analyst with persistent project memory.
 
-Always start by calling dakera_recall to retrieve relevant prior knowledge
-before answering. Your analysis should build on what was previously stored.""",
+Start by calling dakera_batch_recall with tags
+["{PROJECT_SCOPE}", "status:accepted"] to load the accepted facts for this
+project. Base your analysis only on those recalled facts and say which record
+IDs you relied on. If a fact is missing, flag it as an open question rather
+than inventing it.""",
             server_names=["dakera"],
         )
-
         async with agent:
             llm = await agent.attach_llm(AnthropicAugmentedLLM)
             result = await llm.generate_str(
-                "Based on prior research about multi-agent AI frameworks, "
-                "which framework would you recommend for a production enterprise deployment "
-                "and why? Use dakera_recall to check prior findings first.",
+                "Using only the accepted project-memory facts for "
+                f'"{PROJECT_SCOPE}", recommend a multi-agent framework for a '
+                "production enterprise deployment and justify it from the recalled records."
             )
-            print(f"[Phase 2 — Recall + Analysis]\n{result}")
+            print(f"[Phase 2 — Scope-filtered recall & analysis]\n{result}\n")
+
+
+async def knowledge_graph_phase() -> None:
+    """Phase 3 — build and query entity/knowledge-graph memory.
+
+    Beyond flat store/recall, Dakera can turn stored prose into a queryable
+    entity graph. The agent extracts entities from the accepted facts with
+    ``dakera_extract_entities`` and then traverses relationships with
+    ``dakera_knowledge_graph`` — the graph/entity memory tier from issue #12.
+    """
+    async with app.run():
+        agent = Agent(
+            name="graph_explorer",
+            instruction=f"""You explore the knowledge graph built from project memory.
+
+1. Call dakera_batch_recall with tags ["{PROJECT_SCOPE}", "status:accepted"].
+2. For each recalled fact, call dakera_extract_entities to pull out frameworks,
+   organizations, and architectural concepts as graph entities.
+3. Call dakera_knowledge_graph to inspect how those entities relate.
+Report the entities discovered and any relationships between frameworks.""",
+            server_names=["dakera"],
+        )
+        async with agent:
+            llm = await agent.attach_llm(AnthropicAugmentedLLM)
+            result = await llm.generate_str(
+                "Extract entities from the accepted project facts and describe the "
+                "relationships in the knowledge graph between the frameworks you find."
+            )
+            print(f"[Phase 3 — Entity / knowledge-graph memory]\n{result}\n")
 
 
 async def main() -> None:
-    print("=== Phase 1: Research (storing to Dakera) ===\n")
+    """Run the three phases in sequence to demonstrate the full memory lifecycle.
+
+    Phase 1 promotes typed facts; Phase 2 restarts fresh and recalls them by
+    scope; Phase 3 explores the entity graph built from those facts. Re-running
+    the whole script shows continuity: Phase 1 recalls what a prior run stored
+    before adding anything new.
+    """
+    print("=== Phase 1: Research — promote typed facts to Dakera ===\n")
     await research_phase()
 
-    print("\n--- Simulating new agent session (process restart equivalent) ---\n")
-    print("=== Phase 2: Recall (reading from Dakera) ===\n")
+    print("\n--- Simulating a new agent session (process-restart equivalent) ---\n")
+    print("=== Phase 2: Scope-filtered recall from Dakera ===\n")
     await recall_phase()
+
+    print("\n=== Phase 3: Entity / knowledge-graph memory ===\n")
+    await knowledge_graph_phase()
 
 
 if __name__ == "__main__":

--- a/examples/usecases/persistent_memory_agent/main.py
+++ b/examples/usecases/persistent_memory_agent/main.py
@@ -26,18 +26,18 @@ misses, and which this example demonstrates end to end:
   * entity / knowledge-graph memory — `dakera_extract_entities` +
     `dakera_knowledge_graph` turn stored prose into a queryable entity graph.
 
-Prereq:
-    docker run -d -p 3300:3300 \\
-        -e DAKERA_API_KEY=demo \\
-        ghcr.io/dakera-ai/dakera:latest
+Prereq (self-hosted server + MinIO via docker-compose; the server needs the
+object store the compose provisions, so use dakera-deploy, not a bare docker run):
+    git clone https://github.com/dakera-ai/dakera-deploy
+    cd dakera-deploy && docker compose up -d   # REST API on http://localhost:3000
     npx @dakera-ai/dakera-mcp --help  # confirms the MCP server starts
 
 Usage:
     # First run: research and promote typed facts to project memory
-    DAKERA_API_URL=http://localhost:3300 DAKERA_API_KEY=demo python main.py
+    DAKERA_API_URL=http://localhost:3000 DAKERA_API_KEY=dk-... python main.py
 
     # Second run: a fresh agent recalls prior *accepted* facts by scope
-    DAKERA_API_URL=http://localhost:3300 DAKERA_API_KEY=demo python main.py
+    DAKERA_API_URL=http://localhost:3000 DAKERA_API_KEY=dk-... python main.py
 """
 
 import asyncio

--- a/examples/usecases/persistent_memory_agent/main.py
+++ b/examples/usecases/persistent_memory_agent/main.py
@@ -9,7 +9,7 @@ Prereq:
     docker run -d -p 3000:3000 \\
         -e DAKERA_API_KEY=demo \\
         dakera/dakera:latest
-    uvx dakera-mcp  # confirms the MCP server starts
+    npx @dakera-ai/dakera-mcp --help  # confirms the MCP server starts
 
 Usage:
     # First run: research and store

--- a/examples/usecases/persistent_memory_agent/main.py
+++ b/examples/usecases/persistent_memory_agent/main.py
@@ -1,0 +1,96 @@
+"""Persistent cross-session memory using Dakera MCP.
+
+Demonstrates the three memory tiers discussed in issue #12:
+  - Short-term:  mcp-agent Context object (in-process, ephemeral)
+  - Session:     Dakera dakera_session_start / dakera_store
+  - Long-term:   Dakera dakera_recall (semantic search, decay-weighted)
+
+Prereq:
+    docker run -d -p 3000:3000 \\
+        -e DAKERA_API_KEY=demo \\
+        dakera/dakera:latest
+    uvx dakera-mcp  # confirms the MCP server starts
+
+Usage:
+    # First run: research and store
+    DAKERA_API_URL=http://localhost:3000 DAKERA_API_KEY=demo python main.py
+
+    # Second run: notice the agent recalls prior findings from Dakera
+    DAKERA_API_URL=http://localhost:3000 DAKERA_API_KEY=demo python main.py
+"""
+
+import asyncio
+from mcp_agent.app import MCPApp
+from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLLM
+
+app = MCPApp(name="persistent_memory_agent")
+
+
+async def research_phase() -> None:
+    """Phase 1: Research a topic and persist findings to Dakera.
+
+    The agent explicitly uses dakera_store to save each key finding.
+    These memories persist across process restarts.
+    """
+    async with app.run() as mcp_app:
+        agent = Agent(
+            name="researcher",
+            instruction="""You are a research assistant with persistent memory.
+
+When you discover important information, store it immediately using dakera_store
+with a clear, self-contained summary. Use dakera_session_start at the beginning
+of each session and dakera_session_end when done.
+
+Start by calling dakera_recall with query "prior research findings" to check
+what you already know before starting new research.""",
+            server_names=["dakera", "fetch"],
+        )
+
+        async with agent:
+            llm = await agent.attach_llm(AnthropicAugmentedLLM)
+            result = await llm.generate_str(
+                "Research the current state of multi-agent AI frameworks in 2025. "
+                "Find the top 3 frameworks by adoption and their key architectural differences. "
+                "Store each finding as a separate memory entry using dakera_store.",
+            )
+            print(f"[Phase 1 — Research complete]\n{result[:500]}...\n")
+
+
+async def recall_phase() -> None:
+    """Phase 2: A fresh agent recalls what Phase 1 stored.
+
+    This simulates a new process / container restart. The agent has no
+    in-process state from Phase 1 but can recall via Dakera.
+    """
+    async with app.run() as mcp_app:
+        agent = Agent(
+            name="analyst",
+            instruction="""You are an analyst with access to persistent memory.
+
+Always start by calling dakera_recall to retrieve relevant prior knowledge
+before answering. Your analysis should build on what was previously stored.""",
+            server_names=["dakera"],
+        )
+
+        async with agent:
+            llm = await agent.attach_llm(AnthropicAugmentedLLM)
+            result = await llm.generate_str(
+                "Based on prior research about multi-agent AI frameworks, "
+                "which framework would you recommend for a production enterprise deployment "
+                "and why? Use dakera_recall to check prior findings first.",
+            )
+            print(f"[Phase 2 — Recall + Analysis]\n{result}")
+
+
+async def main() -> None:
+    print("=== Phase 1: Research (storing to Dakera) ===\n")
+    await research_phase()
+
+    print("\n--- Simulating new agent session (process restart equivalent) ---\n")
+    print("=== Phase 2: Recall (reading from Dakera) ===\n")
+    await recall_phase()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/usecases/persistent_memory_agent/main.py
+++ b/examples/usecases/persistent_memory_agent/main.py
@@ -6,17 +6,17 @@ Demonstrates the three memory tiers discussed in issue #12:
   - Long-term:   Dakera dakera_recall (semantic search, decay-weighted)
 
 Prereq:
-    docker run -d -p 3000:3000 \\
+    docker run -d -p 3300:3300 \\
         -e DAKERA_API_KEY=demo \\
-        dakera/dakera:latest
+        ghcr.io/dakera-ai/dakera:latest
     npx @dakera-ai/dakera-mcp --help  # confirms the MCP server starts
 
 Usage:
     # First run: research and store
-    DAKERA_API_URL=http://localhost:3000 DAKERA_API_KEY=demo python main.py
+    DAKERA_API_URL=http://localhost:3300 DAKERA_API_KEY=demo python main.py
 
     # Second run: notice the agent recalls prior findings from Dakera
-    DAKERA_API_URL=http://localhost:3000 DAKERA_API_KEY=demo python main.py
+    DAKERA_API_URL=http://localhost:3300 DAKERA_API_KEY=demo python main.py
 """
 
 import asyncio

--- a/examples/usecases/persistent_memory_agent/mcp_agent.config.yaml
+++ b/examples/usecases/persistent_memory_agent/mcp_agent.config.yaml
@@ -1,0 +1,27 @@
+$schema: ../../../schema/mcp-agent.config.schema.json
+
+execution_engine: asyncio
+
+logger:
+  transports: [console, file]
+  level: info
+  path_settings:
+    path_pattern: "logs/memory-agent-{unique_id}.jsonl"
+    unique_id: "timestamp"
+    timestamp_format: "%Y%m%d_%H%M%S"
+
+mcp:
+  servers:
+    dakera:
+      transport: stdio
+      command: "uvx"
+      args: ["dakera-mcp"]
+      env:
+        DAKERA_API_URL: "${DAKERA_API_URL}"
+        DAKERA_API_KEY: "${DAKERA_API_KEY}"
+    fetch:
+      command: "uvx"
+      args: ["mcp-server-fetch"]
+
+anthropic:
+  default_model: claude-sonnet-4-5

--- a/examples/usecases/persistent_memory_agent/mcp_agent.config.yaml
+++ b/examples/usecases/persistent_memory_agent/mcp_agent.config.yaml
@@ -14,8 +14,8 @@ mcp:
   servers:
     dakera:
       transport: stdio
-      command: "uvx"
-      args: ["dakera-mcp"]
+      command: "npx"
+      args: ["-y", "@dakera-ai/dakera-mcp"]
       env:
         DAKERA_API_URL: "${DAKERA_API_URL}"
         DAKERA_API_KEY: "${DAKERA_API_KEY}"


### PR DESCRIPTION
## Summary

Adds `examples/usecases/persistent_memory_agent/` — a working example of the long-term memory feature requested in #12. It uses [Dakera](https://dakera.ai), a self-hosted, decay-weighted MCP memory server, to give mcp-agent applications true cross-session persistence.

Crucially, it models memory as a **project-continuity layer**, not a "store everything the agent said" transcript dump (per the design discussion in #713).

Closes #12

## The memory contract

The agent only **promotes** durable facts to long-term memory, and each record is tagged so it can be retrieved deliberately by scope later:

```text
type:<decision | convention | failed_path | bug_fix | open_question>
project:<scope>
status:<accepted | candidate | superseded>
```

`accepted` facts are stored at importance 0.8–0.9 so they survive decay.

## The three memory tiers (from #12)

| Tier | What it holds | Storage | Survives restart? |
|------|---------------|---------|-------------------|
| Working context | Current in-process state | mcp-agent `Context` | No |
| Session trace | What happened this run (auditable) | Dakera session | Yes |
| Project memory | Durable, promoted, typed facts | Dakera long-term index | Yes |

## Files

```
examples/usecases/persistent_memory_agent/
├── mcp_agent.config.yaml   # MCP config; Dakera stdio server via npx @dakera-ai/dakera-mcp
├── main.py                 # Three-phase demo (see below)
└── README.md               # Contract, tiers, setup, per-phase tool usage
```

## How it works

**Phase 1 — Research & promote.** The agent loads prior accepted facts, researches the gap, and stores only promotable, typed records under the contract.

**Phase 2 — Scope-filtered recall.** A fresh agent (simulating a restart) uses `dakera_batch_recall` filtered by `project:…` + `status:accepted`, so it pulls back only durable facts for this project — the scope-based retrieval from #12.

**Phase 3 — Entity / knowledge-graph memory.** `dakera_extract_entities` + `dakera_knowledge_graph` turn the stored prose into a queryable entity graph — the graph/entity tier from #12.

Re-run the script to see continuity: Phase 1 recalls what a prior run stored before adding anything new.

## Dakera MCP config

```yaml
mcp:
  servers:
    dakera:
      transport: stdio
      command: "npx"
      args: ["-y", "@dakera-ai/dakera-mcp"]
      env:
        DAKERA_API_URL: "${DAKERA_API_URL}"
        DAKERA_API_KEY: "${DAKERA_API_KEY}"
```

Self-host: `docker run -d -p 3300:3300 -e DAKERA_API_KEY=demo ghcr.io/dakera-ai/dakera:latest`

## Testing notes

- `python -m py_compile main.py` — clean.
- `ruff check` and `ruff format --check` — pass.
- Docstring coverage: 100% (module + all four functions).
- All referenced tools (`dakera_store`, `dakera_batch_recall`, `dakera_extract_entities`, `dakera_knowledge_graph`, session tools) are exposed by the `@dakera-ai/dakera-mcp` server.

## Checklist

- [x] New example is self-contained under `examples/usecases/`
- [x] README with prerequisites, run steps, and tool usage
- [x] Config uses the supported launcher (`npx @dakera-ai/dakera-mcp`) and correct image/port
- [x] Lint + format clean; 100% docstring coverage
- [x] Addresses the graph/entity + scope-based retrieval capabilities from #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Persistent Memory Agent” example demonstrating cross-session memory across separate runs.
  * Introduced a three-phase workflow (research, scope-filtered recall after restart, and knowledge graph exploration).
  * Added an MCP agent configuration to enable memory storage and recall, including timestamped logging.
* **Documentation**
  * Expanded the example README with prerequisites, environment variables, first/second run instructions, and a clear summary of the agent’s MCP tools and memory contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->