### PR TITLE
fix(logging): respect configured levels in Temporal workflows

### DIFF
--- a/src/mcp_agent/logging/events.py
+++ b/src/mcp_agent/logging/events.py
@@ -100,6 +100,7 @@ class EventFilter(BaseModel):
             level_map: Dict[EventType, int] = {
                 "debug": logging.DEBUG,
                 "info": logging.INFO,
+                "progress": logging.INFO,
                 "warning": logging.WARNING,
                 "error": logging.ERROR,
             }

--- a/src/mcp_agent/logging/logger.py
+++ b/src/mcp_agent/logging/logger.py
@@ -89,6 +89,11 @@ class Logger:
                 in_temporal_workflow = False
 
             if in_temporal_workflow:
+                forward_upstream = LoggingConfig.allows_upstream_event(event)
+                log_locally = LoggingConfig.allows_event(event)
+                if not forward_upstream and not log_locally:
+                    return
+
                 # Prefer forwarding via the upstream session proxy using a workflow task, if available.
                 try:
                     from mcp_agent.executor.temporal.temporal_context import (
@@ -110,7 +115,7 @@ class Logger:
                     # Construct payload
                     async def _forward_via_proxy():
                         # If we have an upstream session, use it first
-                        if upstream is not None:
+                        if forward_upstream and upstream is not None:
                             try:
                                 level_map = {
                                     "debug": "debug",
@@ -149,35 +154,37 @@ class Logger:
                                 pass
 
                         # Fallback: use activity gateway directly if execution_id is available
-                        try:
-                            exec_id = _get_exec_id()
-                            if exec_id:
-                                level = {
-                                    "debug": "debug",
-                                    "info": "info",
-                                    "warning": "warning",
-                                    "error": "error",
-                                    "progress": "info",
-                                }.get(event.type, "info")
-                                ns = event.namespace
-                                msg = event.message
-                                data = event.data or {}
-                                # Call by activity name to align with worker registration
-                                await _wf.execute_activity(
-                                    "mcp_forward_log",
-                                    exec_id,
-                                    level,
-                                    ns,
-                                    msg,
-                                    data,
-                                    schedule_to_close_timeout=timedelta(seconds=5),
-                                )
-                                return
-                        except Exception:
-                            pass
+                        if forward_upstream:
+                            try:
+                                exec_id = _get_exec_id()
+                                if exec_id:
+                                    level = {
+                                        "debug": "debug",
+                                        "info": "info",
+                                        "warning": "warning",
+                                        "error": "error",
+                                        "progress": "info",
+                                    }.get(event.type, "info")
+                                    ns = event.namespace
+                                    msg = event.message
+                                    data = event.data or {}
+                                    # Call by activity name to align with worker registration
+                                    await _wf.execute_activity(
+                                        "mcp_forward_log",
+                                        exec_id,
+                                        level,
+                                        ns,
+                                        msg,
+                                        data,
+                                        schedule_to_close_timeout=timedelta(seconds=5),
+                                    )
+                                    return
+                            except Exception:
+                                pass
 
                         # If all else fails, fall back to stderr transport
-                        self.event_bus.emit_with_stderr_transport(event)
+                        if log_locally:
+                            self.event_bus.emit_with_stderr_transport(event)
 
                     try:
                         _wf.create_task(_forward_via_proxy())
@@ -190,7 +197,8 @@ class Logger:
                     pass
 
                 # As a last resort, log to stdout/stderr as a fallback
-                self.event_bus.emit_with_stderr_transport(event)
+                if log_locally:
+                    self.event_bus.emit_with_stderr_transport(event)
             else:
                 try:
                     loop.run_until_complete(self.event_bus.emit(event))
@@ -393,6 +401,13 @@ class LoggingConfig:
     _event_filter_ref: EventFilter | None = None
     _upstream_event_filter_ref: EventFilter | None = None
     _session_min_levels: Dict[str, EventType] = {}
+    _LEVEL_ORDER: Final[Dict[EventType, int]] = {
+        "debug": 10,
+        "info": 20,
+        "progress": 20,
+        "warning": 30,
+        "error": 40,
+    }
     _LEVEL_MAPPING: Final[Dict[str, EventType]] = {
         "debug": "debug",
         "info": "info",
@@ -523,6 +538,34 @@ class LoggingConfig:
     @classmethod
     def get_event_filter(cls) -> EventFilter | None:
         return cls._event_filter_ref
+
+    @classmethod
+    def allows_event(cls, event: Event) -> bool:
+        """Return whether the configured local filter accepts an event."""
+        return (
+            cls._initialized
+            and cls._event_filter_ref is not None
+            and cls._event_filter_ref.matches(event)
+        )
+
+    @classmethod
+    def allows_upstream_event(cls, event: Event) -> bool:
+        """Return whether the upstream and session filters accept an event."""
+        if (
+            not cls._initialized
+            or cls._upstream_event_filter_ref is None
+            or not cls._upstream_event_filter_ref.matches(event)
+        ):
+            return False
+
+        session_id = event.context.session_id if event.context is not None else None
+        session_min_level = cls.get_session_min_level(session_id)
+        if session_min_level is None:
+            return True
+
+        return cls._LEVEL_ORDER.get(event.type, 0) >= cls._LEVEL_ORDER.get(
+            session_min_level, 0
+        )
 
     @classmethod
     def set_session_min_level(

--- a/tests/logging/test_temporal_workflow_logging.py
+++ b/tests/logging/test_temporal_workflow_logging.py
@@ -137,6 +137,21 @@ def test_temporal_workflow_applies_upstream_log_level(temporal_harness):
     ]
 
 
+def test_temporal_workflow_treats_progress_as_info(temporal_harness):
+    configure_logging(temporal_harness, "info")
+    upstream = RecordingUpstreamSession()
+    logger = Logger(
+        "tests.temporal", bound_context=SimpleNamespace(upstream_session=upstream)
+    )
+
+    logger.progress("visible progress event")
+    temporal_harness.drain()
+
+    assert [(call["level"], call["data"]["message"]) for call in upstream.calls] == [
+        ("info", "visible progress event")
+    ]
+
+
 def test_temporal_workflow_applies_activity_log_level(temporal_harness):
     configure_logging(temporal_harness, "error")
     temporal_harness.execution_id["value"] = "execution-1"

--- a/tests/logging/test_temporal_workflow_logging.py
+++ b/tests/logging/test_temporal_workflow_logging.py
@@ -1,0 +1,230 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from temporalio import workflow as temporal_workflow
+
+from mcp_agent.executor.temporal import temporal_context
+from mcp_agent.logging.events import EventFilter
+from mcp_agent.logging.logger import Logger, LoggingConfig
+from mcp_agent.logging.transport import AsyncEventBus
+
+
+class RecordingUpstreamSession:
+    def __init__(self):
+        self.calls = []
+
+    async def send_log_message(self, level, data, logger, related_request_id=None):
+        self.calls.append(
+            {
+                "level": level,
+                "data": data,
+                "logger": logger,
+                "related_request_id": related_request_id,
+            }
+        )
+
+
+@pytest.fixture
+def temporal_harness(monkeypatch):
+    AsyncEventBus.reset()
+    monkeypatch.setattr(LoggingConfig, "_initialized", False)
+    monkeypatch.setattr(LoggingConfig, "_event_filter_ref", None)
+    monkeypatch.setattr(LoggingConfig, "_upstream_event_filter_ref", None)
+    monkeypatch.setattr(LoggingConfig, "_session_min_levels", {})
+
+    try:
+        previous_event_loop = asyncio.get_event_loop()
+    except RuntimeError:
+        previous_event_loop = None
+
+    event_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(event_loop)
+    scheduled = []
+    activity_calls = []
+    execution_id = {"value": None}
+
+    monkeypatch.setattr(temporal_workflow, "in_workflow", lambda: True)
+    monkeypatch.setattr(
+        temporal_workflow,
+        "create_task",
+        lambda coroutine: scheduled.append(coroutine),
+        raising=False,
+    )
+
+    async def execute_activity(*args, **kwargs):
+        activity_calls.append((args, kwargs))
+
+    monkeypatch.setattr(temporal_workflow, "execute_activity", execute_activity)
+    monkeypatch.setattr(
+        temporal_context, "get_execution_id", lambda: execution_id["value"]
+    )
+
+    def drain():
+        while scheduled:
+            event_loop.run_until_complete(scheduled.pop(0))
+
+    harness = SimpleNamespace(
+        loop=event_loop,
+        drain=drain,
+        activity_calls=activity_calls,
+        execution_id=execution_id,
+    )
+
+    try:
+        yield harness
+    finally:
+        for coroutine in scheduled:
+            coroutine.close()
+        if LoggingConfig._initialized:
+            event_loop.run_until_complete(LoggingConfig.shutdown())
+        else:
+            event_loop.run_until_complete(AsyncEventBus.get().stop())
+        pending = [task for task in asyncio.all_tasks(event_loop) if not task.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            event_loop.run_until_complete(
+                asyncio.gather(*pending, return_exceptions=True)
+            )
+        AsyncEventBus.reset()
+        event_loop.close()
+        asyncio.set_event_loop(
+            previous_event_loop
+            if previous_event_loop and not previous_event_loop.is_closed()
+            else None
+        )
+
+
+def configure_logging(harness, min_level):
+    harness.loop.run_until_complete(
+        LoggingConfig.configure(
+            event_filter=EventFilter(min_level=min_level),
+            progress_display=False,
+        )
+    )
+
+
+def test_temporal_workflow_applies_local_log_level(temporal_harness, capsys):
+    configure_logging(temporal_harness, "error")
+    logger = Logger("tests.temporal")
+
+    logger.debug("hidden debug event")
+    temporal_harness.drain()
+
+    assert capsys.readouterr().err == ""
+
+    logger.error("visible error event")
+    temporal_harness.drain()
+
+    assert "visible error event" in capsys.readouterr().err
+
+
+def test_temporal_workflow_applies_upstream_log_level(temporal_harness):
+    configure_logging(temporal_harness, "error")
+    upstream = RecordingUpstreamSession()
+    logger = Logger(
+        "tests.temporal", bound_context=SimpleNamespace(upstream_session=upstream)
+    )
+
+    logger.debug("hidden debug event")
+    temporal_harness.drain()
+    logger.error("visible error event")
+    temporal_harness.drain()
+
+    assert [call["data"]["message"] for call in upstream.calls] == [
+        "visible error event"
+    ]
+
+
+def test_temporal_workflow_applies_activity_log_level(temporal_harness):
+    configure_logging(temporal_harness, "error")
+    temporal_harness.execution_id["value"] = "execution-1"
+    logger = Logger("tests.temporal")
+
+    logger.debug("hidden debug event")
+    temporal_harness.drain()
+    logger.error("visible error event")
+    temporal_harness.drain()
+
+    assert len(temporal_harness.activity_calls) == 1
+    assert temporal_harness.activity_calls[0][0][:6] == (
+        "mcp_forward_log",
+        "execution-1",
+        "error",
+        "tests.temporal",
+        "visible error event",
+        {},
+    )
+
+
+@pytest.mark.parametrize(
+    ("local_level", "upstream_level", "expected_upstream", "expected_stderr"),
+    [
+        ("debug", "error", [], "debug event"),
+        ("error", "debug", ["debug event"], ""),
+    ],
+)
+def test_temporal_workflow_keeps_local_and_upstream_filters_independent(
+    temporal_harness,
+    capsys,
+    local_level,
+    upstream_level,
+    expected_upstream,
+    expected_stderr,
+):
+    configure_logging(temporal_harness, local_level)
+    LoggingConfig.set_min_level(upstream_level)
+    upstream = RecordingUpstreamSession()
+    logger = Logger(
+        "tests.temporal", bound_context=SimpleNamespace(upstream_session=upstream)
+    )
+
+    logger.debug("debug event")
+    temporal_harness.drain()
+
+    assert [call["data"]["message"] for call in upstream.calls] == expected_upstream
+    stderr = capsys.readouterr().err
+    if expected_stderr:
+        assert expected_stderr in stderr
+    else:
+        assert stderr == ""
+
+
+def test_temporal_workflow_applies_session_upstream_log_level(temporal_harness, capsys):
+    configure_logging(temporal_harness, "debug")
+    LoggingConfig.set_session_min_level("session-1", "error")
+    upstream = RecordingUpstreamSession()
+    logger = Logger(
+        "tests.temporal",
+        session_id="session-1",
+        bound_context=SimpleNamespace(upstream_session=upstream),
+    )
+
+    logger.debug("local debug event")
+    temporal_harness.drain()
+    logger.error("upstream error event")
+    temporal_harness.drain()
+
+    assert [call["data"]["message"] for call in upstream.calls] == [
+        "upstream error event"
+    ]
+    assert "local debug event" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("route", ["upstream", "activity", "stderr"])
+def test_temporal_workflow_is_silent_before_logging_is_configured(
+    temporal_harness, capsys, route
+):
+    upstream = RecordingUpstreamSession() if route == "upstream" else None
+    if route == "activity":
+        temporal_harness.execution_id["value"] = "execution-1"
+    context = SimpleNamespace(upstream_session=upstream) if upstream else None
+    logger = Logger("tests.temporal", bound_context=context)
+
+    logger.error("unconfigured event")
+    temporal_harness.drain()
+
+    assert upstream is None or upstream.calls == []
+    assert temporal_harness.activity_calls == []
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
Fixes #382

Follow-up to #734 by @tonycoder-hub, which was closed without merging. This version also addresses the unresolved review point that logging must remain silent before `LoggingConfig.configure()` completes.

Temporal workflow logging bypasses `AsyncEventBus` and forwards directly to an upstream MCP session, the `mcp_forward_log` activity, or stderr. Because that route did not consult `LoggingConfig`, events below `LoggerSettings.level` could still be emitted.

This change applies the configured filters before selecting a destination:

- Local filtering controls the stderr fallback.
- Upstream filtering, including per-session overrides, controls the MCP session and activity routes.
- Local and upstream thresholds remain independent.
- Logging remains silent before configuration completes.

Verification:

- Added 9 regression cases covering stderr, upstream sessions, activities, independent thresholds, session overrides, and pre-configuration silence.
- Related logging and Temporal suite: 33 passed.
- Ruff lint, format, and Python compilation checks passed.
- Full Windows comparison added 9 passing tests without changing the baseline failure or error counts.

🤖 Assisted by OpenAI Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added log-level filtering for workflow events across local output, upstream sessions, and activity forwarding.
  * Upstream sessions can apply their own minimum log level.
  * Progress events now follow informational-level filtering.

* **Bug Fixes**
  * Prevented events from being forwarded or written locally when they do not meet configured filters.
  * Prevented logging output before logging is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->