### PR TITLE
docs: clarify openai.base_url vs MCP_API_BASE_URL

### DIFF
--- a/docs/cloud/mcp-agent-cloud/manage-secrets.mdx
+++ b/docs/cloud/mcp-agent-cloud/manage-secrets.mdx
@@ -179,7 +179,7 @@ api_key = os.environ["OPENAI__API_KEY"]
 ## Non-interactive + CI/CD
 
 - **Reuse existing handles**: `mcp-agent deploy --non-interactive` reuses secrets stored in `mcp_agent.deployed.secrets.yaml` and fails if new values are required.
-- **Custom API URL/keys**: set `MCP_API_KEY` (or use `--api-key`) and `MCP_API_BASE_URL` for staging environments.
+- **Custom API URL/keys**: set `MCP_API_KEY` (or use `--api-key`) and `MCP_API_BASE_URL` for staging environments. These control access to the mcp-agent Cloud / CLI API — not LLM inference. For OpenAI-compatible model hosts, configure `openai.base_url` / `OPENAI_BASE_URL` instead (see [Configuration → OpenAI-compatible APIs](/reference/configuration#openai-compatible-apis)).
 - **Partial updates**: if you add a new entry to `mcp_agent.secrets.yaml`, the CLI prompts only for the new value.
 
 ## Advanced tips

--- a/docs/mcp-agent-sdk/core-components/configuring-your-application.mdx
+++ b/docs/mcp-agent-sdk/core-components/configuring-your-application.mdx
@@ -155,6 +155,10 @@ Configure your LLM provider. Many examples follow this layout—for instance, th
     openai:
       api_key: "sk-..."
     ```
+
+    <Tip>
+    For OpenAI-compatible hosts (LM Studio, Groq, hosted Chat Completions APIs), set `openai.base_url` to the LLM `/v1` root — not `/v1/chat/completions`, and not `MCP_API_BASE_URL`. See [Configuration → OpenAI-compatible APIs](/reference/configuration#openai-compatible-apis).
+    </Tip>
   </Tab>
 
   <Tab title="Anthropic">

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -266,6 +266,8 @@ authorization:
 
 ### OpenAI-compatible APIs
 
+Hosted Chat Completions endpoints and local OpenAI-compatible servers (LM Studio, Ollama, Groq, Together, and similar) all use the `openai:` settings block with `OpenAIAugmentedLLM`.
+
 ```yaml
 openai:
   default_model: gpt-4o-mini
@@ -274,7 +276,44 @@ openai:
   user: "research-team"
 ```
 
-- Override `base_url` to target OpenAI-compatible services such as Groq (`https://api.groq.com/openai/v1`), Together, or local Ollama (`http://localhost:11434/v1`). Provide a dummy `api_key` for services that do not check it.
+Three details are easy to get wrong when pointing this block at a non-OpenAI host:
+
+1. **`openai.base_url` / `OPENAI_BASE_URL` is the LLM `/v1` root**, not the chat-completions path. Use `https://host/v1` (or `http://localhost:1234/v1` for LM Studio). Do **not** set it to `/v1/chat/completions`.
+2. **Do not set `MCP_API_BASE_URL` to the LLM host.** That environment variable is for [mcp-agent Cloud / CLI API access](/cloud/mcp-agent-cloud/manage-secrets), not for OpenAI-compatible inference. LLM traffic belongs under `openai.base_url` (or `OPENAI_BASE_URL`).
+3. **`default_model` is the catalog id the host advertises.** LM Studio local models often use an `openai/` prefix (see [`examples/lm_studio`](https://github.com/lastmile-ai/mcp-agent/tree/main/examples/lm_studio)); a hosted catalog id usually must **not** include that prefix. Confirm with the host’s `GET {base_url}/models` listing.
+
+<Warning>
+`MCP_API_BASE_URL` and `openai.base_url` are different knobs. Mixing them up silently sends Cloud CLI traffic to an LLM host (or leaves the LLM client on the default OpenAI endpoint).
+</Warning>
+
+Example for a hosted OpenAI-compatible Chat Completions API (PZERO-shaped):
+
+```yaml
+# mcp_agent.config.yaml
+openai:
+  base_url: https://api.pzero.studio/v1
+  default_model: deepseek-v4-flash
+```
+
+```yaml
+# mcp_agent.secrets.yaml
+openai:
+  api_key: pzero_…
+```
+
+Optional remote MCP from the same vendor is a **separate** server slot. Do not reuse the MCP URL as `openai.base_url`:
+
+```yaml
+mcp:
+  servers:
+    pzero:
+      transport: streamable_http
+      url: https://mcp.pzero.studio/mcp
+      headers:
+        Authorization: "Bearer ${PZERO_API_KEY}"
+```
+
+- Override `base_url` for other OpenAI-compatible services such as Groq (`https://api.groq.com/openai/v1`), Together, or local Ollama (`http://localhost:11434/v1`). Provide a dummy `api_key` for services that do not check it.
 - Use `default_headers` to inject custom headers when talking to proxies or gateways.
 
 ### Anthropic

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -304,13 +304,21 @@ openai:
 Optional remote MCP from the same vendor is a **separate** server slot. Do not reuse the MCP URL as `openai.base_url`:
 
 ```yaml
+# mcp_agent.config.yaml
 mcp:
   servers:
     pzero:
       transport: streamable_http
       url: https://mcp.pzero.studio/mcp
+```
+
+```yaml
+# mcp_agent.secrets.yaml — headers are passed through as-is (no ${ENV} expansion)
+mcp:
+  servers:
+    pzero:
       headers:
-        Authorization: "Bearer ${PZERO_API_KEY}"
+        Authorization: "Bearer pzero_…"
 ```
 
 - Override `base_url` for other OpenAI-compatible services such as Groq (`https://api.groq.com/openai/v1`), Together, or local Ollama (`http://localhost:11434/v1`). Provide a dummy `api_key` for services that do not check it.


### PR DESCRIPTION
﻿## Summary
- Expand OpenAI-compatible provider docs with the three common `base_url` / `MCP_API_BASE_URL` / `default_model` gotchas from #748.
- Add a hosted Chat Completions config example (PZERO-shaped) and keep optional remote MCP on a separate server slot.
- Cross-link from Cloud secrets (`MCP_API_BASE_URL`) and the SDK configuring-your-application OpenAI tip.

Fixes #748

## Test plan
- [ ] Confirm `/reference/configuration#openai-compatible-apis` renders the new Warning + examples
- [ ] Confirm Cloud manage-secrets and configuring-your-application links resolve
- [ ] Spot-check that `MCP_API_BASE_URL` is described as Cloud/CLI-only, not LLM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that MCP API keys and base URLs control MCP Cloud and CLI access, not LLM inference.
  * Added guidance for configuring OpenAI-compatible providers with their `/v1` base URL.
  * Expanded examples for hosted and local providers, model names, secrets, and remote MCP connections.
  * Added warnings to prevent mixing LLM and MCP endpoints.
  * Clarified how remote MCP authentication headers are configured and passed through.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->